### PR TITLE
docs(workbooks): fix control shape + grouped-table/conditional-aggregate recipes

### DIFF
--- a/sigma-workbooks/reference/specification/controls.md
+++ b/sigma-workbooks/reference/specification/controls.md
@@ -21,11 +21,15 @@ A `control` element has exactly these fields:
 | `controlId` | yes | Formula reference name (e.g., `RegionFilter`) — keep distinct from `id`. This is the human-meaningful handle used when referring to the control's value from formulas. |
 | `controlType` | yes | Any value the recipe above returns. Determines the widget and filter behavior. |
 | `filters` | — | Array of `{ source, columnId }` — connects the control to the column(s) it filters. `source` is `{ kind: table, elementId: ... }`. |
+| `source` | list/segmented | Where the widget's VALUE LIST comes from. Double-nested: `{ kind: source, source: { kind: table, elementId: ... }, columnId: ... }`. |
+| `mode` | list | `include` \| `exclude`. **Flat top-level field.** |
+| `selectionMode` | list | `single` \| `multiple`. **Flat top-level field.** |
+| `values` | list | Default selection (`[]` = all). **Flat top-level field.** |
 | `parameters` | — | Array, for binding the control to a data-model control (parameter). |
 | `name` | — | Display label. |
 | `style` | — | Presentation options for the widget. |
 
-There are **no** value/widget fields at the control top level. Things like the selected mode, current value, or range bounds live inside the value object that the control carries, not as flat sibling fields of `controlType`. The recipes below show the value-object shape per type; treat those nested shapes as the value detail, not as additional control-element properties.
+The value/widget fields (`mode`, `selectionMode`, `values`, range bounds, etc.) are **flat top-level siblings of `controlType`**, NOT nested in a separate "value object" — verified against a live workbook 2026-06-15. Different `controlType`s carry different value fields (the per-type recipes below show which), but they are always flat. Omitting them — or nesting them — yields the opaque `Invalid kind: control` rejection.
 
 `filters[]` items are `{ source: { kind: table, elementId: ... }, columnId: ... }`. The `columnId` is the column on the target element to filter.
 
@@ -37,18 +41,27 @@ A single- or multi-select list control over a column's values.
 
 ```yaml
 kind: control
-id: ctrl-region
-controlId: RegionFilter
+id: ctrl-region          # element id — distinct from controlId
+controlId: region        # formula handle
 name: Store region
 controlType: list
-filters:
+mode: include            # include | exclude   (TOP-LEVEL, not nested)
+selectionMode: multiple  # single | multiple   (TOP-LEVEL)
+values: []               # default selection, [] = all   (TOP-LEVEL)
+source:                  # where the control's VALUE LIST comes from (note the double nesting)
+  kind: source
+  source:
+    kind: table
+    elementId: sales-master
+  columnId: col-region
+filters:                 # the TARGETS it filters — one entry per element+column it controls
   - source:
       kind: table
-      elementId: sales-table
-    columnId: col-region
+      elementId: sales-by-region
+    columnId: scoped-col-region
 ```
 
-The value object carries the selection (`mode`: `include` | `exclude`; selection cardinality; selected values). `segmented` and `hierarchy` are the other list-style widget types — same wiring, different presentation. Inspect the spec's control value schema for the exact value-object field names rather than guessing.
+> **Verified working shape** (pulled from a live, successfully-POSTed workbook 2026-06-15). A list control carries `source` / `mode` / `selectionMode` / `values` as **flat top-level siblings** — NOT inside a nested "value object." The single most common mistake is omitting `source`/`mode`/`selectionMode`/`values` (or nesting them); Sigma then rejects the element with the opaque catch-all `Invalid kind: control`, which means **the inner fields are wrong, NOT that controls are unsupported** (see `reference/workflows/validate.md`). `segmented` and `hierarchy` are the other list-style widgets — same wiring (value-list `source` + `filters` targets).
 
 ## Date Range
 

--- a/sigma-workbooks/reference/specification/tables.md
+++ b/sigma-workbooks/reference/specification/tables.md
@@ -48,8 +48,17 @@ Pivot / aggregation views without changing element kind:
 groupings:
   - id: by-region
     groupBy: [col-region]
-    calculations: [col-total, col-profit]
+    calculations: [col-total, col-profit]   # MUST be aggregate columns (Sum/Count/…)
+    sort: [{ columnId: col-total, direction: descending }]   # optional
 ```
+
+> **A `table` with no `groupings` shows raw DETAIL rows.** This is the #1 migration bug for aggregated source vizzes: a Tableau worksheet with a dimension on Rows + `SUM(...)` is an *aggregated* query, so its Sigma `table` MUST carry a `groupings` entry. Without it the table renders every warehouse row (e.g. "9,676,896 rows"), the dimension repeats, and `Sum(If(...))` columns read `$0` per row. If a "summary" table renders the base row count, it's missing `groupings`. (Charts don't need this — they aggregate by their axis/`value` binding; only `table` does.)
+>
+> **`calculations` columns must be AGGREGATE expressions** (`Sum([Amt])`, `CountDistinct([Id])`, …). A conditional aggregate is a **row-level** column `If(cond, [val], 0)` wrapped in `Sum(...)` at the grouping — i.e. `Sum([Cur Amt])` where `Cur Amt = If(flag = "Cur", [Tcv], 0)`. Do **not** put a *passthrough of an already-aggregated* column in `calculations`; it re-aggregates to **"multiple values"** in every group cell. (Verified 2026-06-15.)
+>
+> **Multiple `groupings` on one element NEST hierarchically** (array order = levels: `[by-region, by-flag]` ⇒ region→flag, not two independent rollups). For two *independent* group-bys (e.g. one table by Region and another by Flag) give each its **own source element**, or let a chart aggregate the second one by axis. (Verified 2026-06-15.)
+>
+> **Exclude a NULL/unwanted bucket** with an element list filter on the dimension — this is how a Tableau view filter maps: `filters: [{ id: f, columnId: col-flag, kind: list, mode: include, values: ["Cur FYTD", "Prior FYTD"] }]`. (A grouped bar that includes the NULL bucket is the classic "giant first bar" artifact.)
 
 ### `filters` (top-N, element-level row filters)
 


### PR DESCRIPTION
Root-causes the EDNA-class Tableau-migration failures (ungrouped 9.6M-row tables, $10B NULL bucket, and the false "controls aren't supported" conclusion a customer was told).

## controls.md
The List example was incomplete and the doc wrongly claimed value fields live in a nested "value object." **Verified against a live, successfully-POSTed workbook (2026-06-15):** a list control carries `source` (double-nested value-list), `mode`, `selectionMode`, `values` as **flat top-level siblings**, plus `id` **and** `controlId` (distinct). Omitting/nesting these → the opaque `Invalid kind: control`, which means **wrong inner fields, NOT unsupported.**

## tables.md
Added the gotchas behind the ungrouped/`$0`/"multiple values" bugs:
1. an aggregated source viz **must** carry `groupings` or it renders raw detail rows;
2. `calculations` must be **aggregate** exprs — a conditional aggregate is a row-level `If(...)` wrapped in `Sum(...)`, not a passthrough of a pre-aggregated column (which reads *"multiple values"*);
3. multiple `groupings` on one element **nest** — independent group-bys need separate bases;
4. exclude a NULL bucket via an element **list filter** (how a Tableau view filter maps).

## Verification
Rebuilt the EDNA-style dashboard correctly end-to-end (grouped 4-row table with exact `$` values, 2-bar no-NULL chart, working list control, real grid layout) — every number matches warehouse ground truth. All converters defer to this reference, so the fix propagates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)