### PR TITLE
docs(workbooks): correct control value-field prose, donut value.id, holeValue optional

### DIFF
--- a/sigma-workbooks/reference/specification/controls.md
+++ b/sigma-workbooks/reference/specification/controls.md
@@ -4,7 +4,7 @@ Recipe book for the control element family and the patterns that wire them up. T
 
 Controls are interactive filter elements — lists, date pickers, text inputs, sliders, etc. They live in the page's `elements` array alongside tables and charts, **not** nested inside them. The wiring (which column a control filters, which downstream elements respond) is the part the OpenAPI doesn't teach — that's what this file is for.
 
-**Every `controlType` wires up the same way** (`controlId` + `filters`, below); they differ only in the widget and its value object. So treat the per-type sections below as illustrations of the *wiring*, **not a catalog of what's supported** — a `controlType` you don't see here works the same way. The set also grows over time, so get the current list from the spec rather than hardcoding it:
+**Every `controlType` wires up the same way** (`controlId` + `filters`, below); they differ only in the widget and its (flat top-level) value fields. So treat the per-type sections below as illustrations of the *wiring*, **not a catalog of what's supported** — a `controlType` you don't see here works the same way. The set also grows over time, so get the current list from the spec rather than hardcoding it:
 
 ```bash
 jq -r '[.. | objects | select(.properties?.controlType?.enum) | .properties.controlType.enum[0]] | unique[]' /tmp/sigma-api.json
@@ -65,7 +65,7 @@ filters:                 # the TARGETS it filters — one entry per element+colu
 
 ## Date Range
 
-A date-range control filters one or more date columns. The widget shape is determined by `mode`, and each mode takes different additional fields **inside the value object**. No `source` is needed — the column is defined by the `filters` binding.
+A date-range control filters one or more date columns. The widget shape is determined by `mode`, and each mode takes different additional fields — all of them **flat top-level siblings of `controlType`** (verified against a live workbook 2026-06-15; a nested `value:{mode,unit}` object is rejected with `Invalid kind: control`). No `source` is needed — the column is defined by the `filters` binding.
 
 ```yaml
 kind: control
@@ -80,7 +80,7 @@ filters:
     columnId: col-date
 ```
 
-The value object selects a mode and its parameters. `includeNulls`: `always` | `never` | `when-no-value-is-selected`.
+`mode` and its parameters are flat top-level fields. `includeNulls`: `always` | `never` | `when-no-value-is-selected`.
 
 ### Modes
 
@@ -107,9 +107,9 @@ value: 30
 
 `op`: `now-minus` or `now-plus`.
 
-### Value-object Examples
+### Mode Examples
 
-These show the date-range **value shape**, not flat control fields.
+These show the flat fields each `mode` carries — all top-level siblings of `controlType` (shown without the wrapping control element for brevity).
 
 **Last 70 days:**
 
@@ -166,7 +166,7 @@ filters:
     columnId: col-product-name
 ```
 
-The text value object carries the match `mode` and the search string. `mode` values include `equals`, `does-not-equal`, `contains`, `does-not-contain`, `starts-with`, `ends-with`, `like`, `matches-regexp`, and their negations.
+The text control carries the match `mode` and the search string as flat top-level fields. `mode` values include `equals`, `does-not-equal`, `contains`, `does-not-contain`, `starts-with`, `ends-with`, `like`, `matches-regexp`, and their negations.
 
 ## Number Range
 
@@ -183,11 +183,46 @@ filters:
     columnId: col-amount
 ```
 
-The number-range value object expresses the bounds with `low`, `high`, and an optional `step` — **not** a positional `values: [min, max]` array.
+The number-range control expresses the bounds with flat top-level `low`, `high`, and an optional `step` — **not** a positional `values: [min, max]` array and **not** a nested value object.
 
 ## Sliders
 
-`slider` and `range-slider` are both first-class `controlType` values — distinct from `number` and `number-range`. A `slider` is a single-handle widget; `range-slider` has two handles for a low/high band. Pick the `controlType` for the widget you want and supply the bounds in the value object (`low`/`high`/`step`).
+`slider` and `range-slider` are both first-class `controlType` values — distinct from `number` and `number-range`. A `slider` is a single-handle widget; `range-slider` has two handles for a low/high band. The bounds and value are **flat top-level fields** (verified against a live, UI-built workbook and a successful POST, 2026-06-15) — there is no value object.
+
+A **single-handle `slider`** carries the track bounds (`low`/`high`), a `mode` comparator describing which rows the handle keeps, and a **scalar** `value` for the handle position:
+
+```yaml
+kind: control
+id: ctrl-deal-size
+controlId: DealSize
+name: Deal size
+controlType: slider
+low: 0
+high: 100000
+mode: "<="          # comparator: <= | >= | = | < | > — rows kept relative to the handle
+value: 33755        # scalar handle position (FLAT — not a value object)
+includeNulls: when-no-value-is-selected
+filters:
+  - source:
+      kind: table
+      elementId: sales-table
+    columnId: col-amount
+```
+
+A **`range-slider`** drops the scalar `value`/`mode` and uses the two-handle `low`/`high` band:
+
+```yaml
+controlType: range-slider
+low: 0
+high: 100000        # flat low/high band; no scalar value
+filters:
+  - source:
+      kind: table
+      elementId: sales-table
+    columnId: col-amount
+```
+
+> A nested `value:{low,high}` object is rejected with `Invalid kind: control`. The most common slider mistake is omitting `mode` — without the comparator the element is rejected even though `low`/`high`/`value` are present.
 
 ## Single-value types
 
@@ -208,7 +243,7 @@ filters:
 
 ## Top-N
 
-`top-n` is a dedicated control type for "show the top N" interactions. Wire it like any other control via `filters`; the cap lives in its value object.
+`top-n` is a dedicated control type for "show the top N" interactions. Wire it like any other control via `filters`; the cap is a flat top-level field.
 
 ---
 

--- a/sigma-workbooks/reference/specification/example-full.yaml
+++ b/sigma-workbooks/reference/specification/example-full.yaml
@@ -190,7 +190,7 @@ pages:
             by: rMc1XEsnWx
             direction: descending
         value:
-          columnId: rMc1XEsnWx
+          id: rMc1XEsnWx
         name: Sales by product family
   - id: 3Ht0vQc7hD
     name: Data

--- a/sigma-workbooks/reference/specification/styling.md
+++ b/sigma-workbooks/reference/specification/styling.md
@@ -6,7 +6,7 @@
 
 Recipe library for moving a workbook from "default auto-arrange" to "looks designed." Every pattern below is built from fields that already exist in the workbook spec — no external CSS, no theme JSON, no UI editing required.
 
-The recipes were extracted from a 2026-05-29 design experiment that built 6 versions of the same dashboard (default → polished) and compared screenshots via the `/v2/workbooks/{id}/export` PNG endpoint. The findings caught two silent-failure bugs (see `charts.md` donut section) and 4 undocumented container `style` knobs (see `containers.md`).
+The recipes were extracted from a 2026-05-29 design experiment that built 6 versions of the same dashboard (default → polished) and compared screenshots via the `/v2/workbooks/{id}/export` PNG endpoint. The findings caught two silent-failure bugs (see `charts.md` donut section) and 4 undocumented container `style` knobs (see `layout.md`).
 
 ---
 
@@ -159,7 +159,7 @@ Between the high-level charts and the "drill down to raw rows" table, a horizont
 <LayoutElement elementId="divider-1" gridColumn="1 / 25" gridRow="26 / 27"/>
 ```
 
-A 1-row span. The `divider` element is a first-class kind, not a hack — see `others.md`.
+A 1-row span. The `divider` element is a first-class kind, not a hack — see `content-elements.md`.
 
 ---
 

--- a/sigma-workbooks/reference/workflows/validate.md
+++ b/sigma-workbooks/reference/workflows/validate.md
@@ -33,7 +33,7 @@ Also check for these rarer issues:
 
 - A column's `formula` references a name matching its own `name` field → circular reference.
 - A formula references a column name that doesn't exist on the source (re-confirm column names with the user).
-- Donut charts have a `holeValue` field (required).
+- Donut charts require `value.id` (the measure) and `color.id` (the slice dimension) — **not** `value.columnId`. `holeValue` is **optional**; if set it must reference a *different* column than `value.id` (see `reference/specification/charts.md`).
 - Layout XML: no `<LayoutElement type="grid">` with children — use `<GridContainer>` for nesting.
 
 ## 4. Post-create verification (do not skip)


### PR DESCRIPTION
Live-verified doc fixes (POST /v2/workbooks/spec, tj-wells-1989, 2026-06-15) for four inconsistencies that survived #4.

## controls.md
- The authoritative header already says control value fields are **flat top-level**, but the per-type **prose** still said "value object" (date-range / text / number-range / sliders / top-n), and one line even claimed the date-range examples were "**not** flat control fields" — the opposite of what the API accepts. A nested `value:{mode,unit}` is rejected with `Invalid kind: control`; flat `mode`/`unit` POSTs cleanly. All reworded to "flat top-level fields."
- **Sliders**: added the live-verified shapes. Single-handle `slider` = flat `low`/`high` + `mode` comparator + **scalar** `value` (handle position) — read back from a UI-built slider **and** confirmed via POST. `range-slider` = flat two-handle `low`/`high`. Flagged the common mistake (omitting `mode`).

## example-full.yaml
- Donut used `value.columnId` → **`value.id`** (donut/pie require `value.id` + `color.id`; `value.columnId` → `"value.id: Invalid string: undefined"`). `charts.md` was already correct.

## validate.md
- "Donut charts have a `holeValue` field (required)" was wrong on both counts → `holeValue` is **optional**; required fields are `value.id` + `color.id`.

## styling.md
- Fixed two stale cross-refs: `containers.md` → `layout.md`, `others.md` → `content-elements.md`.

`generated/` mirrors build from `SKILL.md` (clean) — no regeneration needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)