### PR TITLE
sigma-workbooks: 2026-06-18 spec release (theming, plugins, input-table validation)

### DIFF
--- a/sigma-workbooks/reference/specification/content-elements.md
+++ b/sigma-workbooks/reference/specification/content-elements.md
@@ -72,3 +72,26 @@ id: embed-report
 kind: embed
 url: https://example.com/report
 ```
+
+## plugin (2026-06-18 release)
+
+Embeds a **custom Sigma plugin** as a page element. Required `id`, `kind`, `pluginId`; optional `displayName`, `style`, and a plugin-defined `config`.
+
+```yaml
+id: my-histogram
+kind: plugin
+pluginId: 6cdf51c1-dda0-4f99-aa08-5c72804020bb   # the plugin's registered UUID
+displayName: Histogram                            # optional label
+style: { backgroundColor: "#101826" }             # optional element background (see notes)
+config:                                            # plugin-defined bindings + settings
+  source: { kind: element, elementId: master }     # bind an element as the data source
+  valueColumn: { kind: column, columnId: m-netprof, source: source }
+  chartType: Frequency
+  binMethod: "Auto (Sturges)"
+  binCount: "10"
+```
+
+- **Data bindings** inside `config`: `{ kind: element, elementId }` selects a source element; `{ kind: column, columnId, source }` selects one of its columns (`{ kind: column, columnIds: [...], source }` for several); `source: source` points at the `config.source` element. A plugin can also read a control's value — bind the control the same way the plugin's input expects.
+- **`config` is an opaque passthrough bag** — Sigma does not validate its keys; whatever you POST is handed to the plugin at render time. So a key round-tripping does **not** mean Sigma supports it — only the plugin's code interprets it. The exact `config` keys are per-plugin; harvest them from a working spec.
+- **Element background:** use element-level `style.backgroundColor` (same shape as a container `style`) — a plugin renders on its own white canvas otherwise, which looks wrong inside a dark theme. A bare top-level `background` key is stripped.
+- **There is no API to discover plugins.** A `pluginId` is a registered UUID; a **bogus one is not validated at POST** (it returns 200 and renders as a broken "missing plugin"). The only way to learn a real `pluginId` is to read a workbook spec that already uses the plugin — so the **caller must supply it**. See `twells89/sigma-workbook-spec-findings` for the harvested Plugin-ID catalog and finding #27.

--- a/sigma-workbooks/reference/specification/input-tables.md
+++ b/sigma-workbooks/reference/specification/input-tables.md
@@ -44,10 +44,24 @@ so after the first real rows land, **query the table** (don't just inspect
 versions linked tables were also dropped from `/spec` entirely; if inherited
 columns misbehave, suspect an older org/API first.
 
-UI-only remains UI-only: column-level **data validation** (single/multi-select
-dropdowns — "coming soon" in the spec), **column protection**, and
-**data-entry permissions** are configured in the UI and are not in the element
-spec.
+**Column validation is now spec-authorable (2026-06-18 release)** — see the
+"Editable data column" shapes in `tables.md`. Confirmed round-tripping live:
+- **Single-select** dropdown — a scalar column (`type: text|number|datetime`) plus
+  a fixed **`values: [ ... ]`** option list. (There is no `single-select` type
+  token — `type: single-select` 400s; the `values` list is what makes it a
+  dropdown.)
+- **Multi-select** — `type: multi-select` + `values: [ ... ]`. Variant-backed:
+  requires a connection whose warehouse supports variant columns (e.g. Snowflake).
+- **Range bounds** — `range: { min, max }` on a `number` or `datetime` column.
+- **File-upload columns** — `type: file` + optional `maxFileNum`, `maxFileSizeMb`,
+  `acceptedFileTypes: [ ... ]`. Variant-backed.
+
+Still UI-only (no round-tripping spec shape found as of 2026-06-18 — see
+`twells89/sigma-workbook-spec-findings` #28): **options sourced from a sibling
+element's column (`valuesFrom`)**, **pills display** (single-color / color-by-
+option), **column protection**, and **data-entry permissions**. Configure these
+in the UI; to author them from a spec, harvest the shape from a UI-built example
+once Sigma documents it.
 
 ## Reading an input table's data & structure
 

--- a/sigma-workbooks/reference/specification/styling.md
+++ b/sigma-workbooks/reference/specification/styling.md
@@ -10,6 +10,30 @@ The recipes were extracted from a 2026-05-29 design experiment that built 6 vers
 
 ---
 
+## Workbook theme (2026-06-18 release)
+
+A workbook now carries a **top-level theme**, alongside `pages` and `layout`:
+
+```yaml
+name: My Workbook
+schemaVersion: 1
+pages: [ ... ]
+layout: ...
+themeName: Dark          # built-in: Light | Dark | Surface  — OR an org theme UUID
+themeOverrides:          # optional — colors / fonts / layout style / table defaults
+  colors:
+    text: "#FFFFFF"
+    highlight: "#1E88E5"
+    surface: "#101826"
+```
+
+- `themeName` accepts a **built-in** name (`Light` / `Dark` / `Surface`) or an **org theme id** (a UUID). All four round-trip. A bogus value is a clean 400.
+- **There is no API to discover theme names.** Built-ins are the three above; an org theme id can only be learned by reading a workbook spec that already uses it (admin Branding Settings shows names, not ids). So the **caller must supply** the theme name/id — an agent cannot enumerate them. Ask the user which theme to apply.
+- `themeOverrides` round-trips (colors confirmed). Use it for one-off tweaks on top of a base theme.
+- Theme vs. the recipes below: a theme is the global skin (selected, org-managed). The recipes here style individual elements from spec fields and **stack on top of** whatever theme is set. For a migration, prefer the source dashboard's look; reach for a theme only when the user asks to apply one.
+
+---
+
 ## What "designed" looks like via spec
 
 You can ship a dashboard that looks legitimately professional from the spec by stacking five patterns:

--- a/sigma-workbooks/reference/specification/tables.md
+++ b/sigma-workbooks/reference/specification/tables.md
@@ -161,8 +161,16 @@ The `input-table` element is an editable table — users type values directly in
 
 - **System column** — `{ id }` where `id` ∈ `ID`, `CREATED_AT`, `CREATED_BY`, `UPDATED_AT`, `UPDATED_BY`. Protocol-managed; type is fixed.
 - **Key column** — `{ id, key }` binding to a source column on `source.from` (linked tables; `key` is immutable once created).
-- **Editable data column** — `{ id, type }` where `type` ∈ `text`, `number`, `datetime`, `checkbox`.
+- **Editable data column** — `{ id, type }` where `type` ∈ `text`, `number`, `datetime`, `checkbox`, `multi-select`, `file`.
 - **Formula column** — `{ id, formula }` for a computed column.
+
+**Column validation (2026-06-18 release; all verified round-tripping):**
+
+- **Single-select dropdown** — a scalar column + a fixed option list: `{ id, type: text, values: ["A", "B", "C"] }` (also `number`/`datetime`). There is **no** `single-select` type token — the `values` list is what makes it a dropdown.
+- **Multi-select** — `{ id, type: multi-select, values: [...] }`. **Variant-backed** — needs a variant-capable warehouse (e.g. Snowflake).
+- **Range bounds** — `{ id, type: number, range: { min, max } }` (also `datetime`, which normalizes to `…T00:00:00Z`).
+- **File upload** — `{ id, type: file, maxFileNum: 3, maxFileSizeMb: 10, acceptedFileTypes: ["image/png", "application/pdf"] }`. **Variant-backed.**
+- **Still UI-only:** options from a sibling element's column (`valuesFrom`) and pills display — no round-tripping spec shape yet.
 
 ```yaml
 id: feedback-input


### PR DESCRIPTION
Documents the 2026-06-18 workbook-spec release in the canonical `sigma-workbooks` skill. **All shapes live-verified** on tj-wells-1989 — see `twells89/sigma-workbook-spec-findings` #26–#29 (verifier `release-2026-06-18.rb`).

## Changes (4 reference docs)
- **styling.md** — new *Workbook theme* section: top-level `themeName` (built-in `Light`/`Dark`/`Surface` or org UUID) + `themeOverrides`. Flags that theme names are **not API-discoverable** → caller must supply.
- **content-elements.md** — new *plugin* section: `kind: plugin` + `pluginId` + `displayName` + `style.backgroundColor` + `config` bindings. Notes `config` is an opaque passthrough bag, a bogus `pluginId` isn't validated at POST, and pluginIds aren't API-discoverable.
- **tables.md** — input-table column validation: single-select (scalar `type` + `values`; **no** `single-select` token), `multi-select`, `range:{min,max}`, `file` columns.
- **input-tables.md** — replaced the now-stale "data validation is UI-only / coming soon" note with the shipped shapes; `valuesFrom` + pills remain UI-only.

Scope per decision: canonical skill only — the 8 migration converters inherit this by reference and were intentionally not wired to emit themes/plugins in this pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)