### PR TITLE
sigma-workbooks: fix duplicate KPI-card title (name:' ' not omit)

### DIFF
--- a/sigma-workbooks/reference/specification/kpis.md
+++ b/sigma-workbooks/reference/specification/kpis.md
@@ -30,6 +30,7 @@ value:
 - `columns` — define exactly one column (the value you want displayed). More columns are allowed but only the bound `value.columnId` is rendered.
 - `value.columnId` — REQUIRED. The column ID to show in the card.
 - `format` on the column controls the displayed format. See `formatting.md`.
+- **Hiding the title:** set `name: ' '` (a single space) to render the card with **no title** — e.g. when a Markdown label above the KPI already names it (see `styling.md` KPI-card recipe). Omitting `name` or setting `name: ''` does **not** work: an empty/absent name is stripped and the KPI re-derives its title from the value column, producing a duplicate. Only a single space persists.
 
 For a period-over-period delta (e.g. "vs. prior quarter"), compute it as a **formula column** — `[This Quarter] / [Last Quarter] - 1` against the source — and show it in its own column or a second KPI.
 

--- a/sigma-workbooks/reference/specification/styling.md
+++ b/sigma-workbooks/reference/specification/styling.md
@@ -123,7 +123,7 @@ elements:
       <span style="color: #3B82F6">**NET REVENUE**</span>
   - id: kpi-net
     kind: kpi-chart
-    # omit `name:` — the colored label above stands in for the title
+    name: ' '   # single space — suppresses the KPI's own title (see note below)
     source:
       elementId: master
       kind: table
@@ -148,7 +148,7 @@ elements:
 
 Repeat the container + label + KPI triple for each metric, switching the label color (green for growth, purple for averages, amber for trailing-indicator metrics). Three across at columns `1/9`, `9/17`, `17/25` is the standard layout.
 
-> **Omit `name:` on each KPI** if you're using a colored Markdown label above it. The element's `name` always renders as its own title; with the label, you get a duplicate. There's no `showTitle: false` field.
+> **Set `name: ' '` (a single space) on each KPI** when a colored Markdown label sits above it — otherwise you get a **duplicate title**: the card label (`NET REVENUE`) *and* the KPI's own title (`Net Revenue`) stacked in the same card. There's no `showTitle: false` field, and **omitting `name:` does NOT work** — an empty/absent `name` is stripped and the KPI **re-derives** its title from the value column. Only a single space persists as a blank title and suppresses it. (Verified live + rendered; this is the #1 KPI-card mistake.)
 
 ---
 


### PR DESCRIPTION
Fixes the recurring **double-title on KPI cards** (reported with a screenshot): every card showed both the colored Markdown label (`NET REVENUE`) and the KPI's own derived title (`Net Revenue`).

**Root cause:** the KPI-card recipe said to *omit* `name:`. But an absent/empty `name` is stripped and the KPI **re-derives** its title from the value column — so the title comes back. Verified live (round-trip: omit → `nil`, `''` → `nil`, `' '` → `' '`) and rendered (single label, no derived title).

**Fix:** use `name: ' '` (a single space) on KPIs that have a Markdown label above them.
- `styling.md` Recipe 2: example + rewritten note explaining why omit fails (no `showTitle` field).
- `kpis.md`: added the title-hiding rule to the shape reference.

🤖 Generated with [Claude Code](https://claude.com/claude-code)