### PR TITLE
workbooks/data-models: spec gotchas from a live dashboard migration

### DIFF
--- a/sigma-data-models/reference/sources.md
+++ b/sigma-data-models/reference/sources.md
@@ -28,6 +28,8 @@ Run a raw SQL query against a connection. Columns then reference `[Custom SQL/<C
 
 > **Column naming:** The formula prefix `[Custom SQL/...]` must match the **exact output column name** from the SQL query. For Snowflake (the most common warehouse), unquoted column names and aliases are returned in UPPERCASE — e.g., `SUM(price) AS revenue` becomes `[Custom SQL/REVENUE]`. Use double-quoted aliases (e.g., `AS "revenue"`) if you need mixed-case or lowercase column names.
 
+> **A `sql` source runs directly against the connection — so it skips the warehouse-table catalog sync.** A `warehouse-table` source resolves through Sigma's cached table catalog, so a **freshly created** warehouse table (just `CREATE`d / loaded) often fails to POST with `Source not found` until the connection is re-synced (and the conn role has `SELECT`). A `sql` source has no such dependency: Sigma executes the `statement` live, so a `sql` element referencing a brand-new table resolves immediately (the role still needs `SELECT`). Handy when landing new tables and building the model in the same pass — and for joins/aggregations you'd otherwise model as relationships, authored once as the SQL `statement`. (Live-verified 2026-06-26 building a data model over a just-loaded schema.)
+
 ## Join
 
 Combine two table elements using a join. Both source tables must be defined as separate elements on the same page and referenced by their element `id`.

--- a/sigma-workbooks/reference/specification/charts.md
+++ b/sigma-workbooks/reference/specification/charts.md
@@ -83,6 +83,8 @@ stacking: none
 
 ## Bar chart with custom category colors
 
+> **Channel exclusivity:** a column can sit on **only one channel**. Putting the same column on both `color` and an axis (`yAxis`/`xAxis`) is a 400 — `Column 'X' is referenced from both 'yAxis' and 'color'; a column can only be on one channel at a time` (live-verified 2026-06-26 on `scatter-chart`). To color a chart *by its measure*, either drop `color` or add a **second column with the same formula** and bind that to `color` (same pattern as the donut `value`/`holeValue` rule below). To color by category, point `color` at the dimension column, not the measure.
+
 `bar-chart` accepts an optional `color` channel with three variants:
 
 ```yaml

--- a/sigma-workbooks/reference/specification/controls.md
+++ b/sigma-workbooks/reference/specification/controls.md
@@ -63,6 +63,8 @@ filters:                 # the TARGETS it filters — one entry per element+colu
 
 > **Verified working shape** (pulled from a live, successfully-POSTed workbook 2026-06-15). A list control carries `source` / `mode` / `selectionMode` / `values` as **flat top-level siblings** — NOT inside a nested "value object." The single most common mistake is omitting `source`/`mode`/`selectionMode`/`values` (or nesting them); Sigma then rejects the element with the opaque catch-all `Invalid kind: control`, which means **the inner fields are wrong, NOT that controls are unsupported** (see `reference/workflows/validate.md`). `segmented` and `hierarchy` are the other list-style widgets — same wiring (value-list `source` + `filters` targets).
 
+> **A control cannot bind to a map element** (`point-map` / `region-map` / `geography-map`). Pointing a list control's `source` (value list) or a `filters[]` target at a map element fails the POST with `Dependency not found: '<mapElementId>'` (live-verified 2026-06-26). Back the control with a real `table` element (e.g. a small dimension/directory table on the same column) for both the value list and the filter target. To also scope the map, filter it indirectly (e.g. drive the map's source element off the same filtered table, or apply the predicate in the data model) rather than targeting the map element directly.
+
 ## Date Range
 
 A date-range control filters one or more date columns. The widget shape is determined by `mode`, and each mode takes different additional fields — all of them **flat top-level siblings of `controlType`** (verified against a live workbook 2026-06-15; a nested `value:{mode,unit}` object is rejected with `Invalid kind: control`). No `source` is needed — the column is defined by the `filters` binding.

--- a/sigma-workbooks/reference/specification/maps.md
+++ b/sigma-workbooks/reference/specification/maps.md
@@ -15,6 +15,8 @@ The distinctive binding per kind (the part worth knowing up front):
 
 **Shape gotcha:** `geography` / `latitude` / `longitude` / `size` / `region` are **single `{ id }` objects**, but `label` and `tooltip` are **arrays** of `{ id }`.
 
+**Channel-exclusivity gotcha:** a column can sit on only one channel. Binding the same column to both `size` and `color` is a 400 — `Column 'X' is referenced from both 'size' and 'color'` (live-verified 2026-06-26 on `point-map`). To size **and** color by the same measure, add a second column with the same formula and bind one to each — or drop `color`.
+
 ```yaml
 id: sales-by-state
 kind: region-map


### PR DESCRIPTION
## What

Four live-verified spec gotchas (2026-06-26) surfaced while hand-building a Cognos dashboard → Sigma (the Nebraska school-board sample: 5 pages, 6 KPIs + 15 viz). Each cost a failed POST to discover; documenting so the next build doesn't.

| File | Gotcha |
|---|---|
| `sigma-workbooks/.../charts.md` | **Channel exclusivity** — a column on `color` cannot also be on `yAxis`/`xAxis` (400: `referenced from both 'yAxis' and 'color'`). Use a duplicate column, or color by the dimension. (Generalizes the donut `value`/`holeValue` note already present.) |
| `sigma-workbooks/.../maps.md` | Same exclusivity for `size` + `color` on `point-map`. |
| `sigma-workbooks/.../controls.md` | A **control can't bind to a map element** (`Dependency not found`). Back the list control with a real `table` element. |
| `sigma-data-models/.../sources.md` | A `sql` source **runs live against the connection → skips the warehouse-table catalog sync**, so a freshly-created table resolves immediately (vs. `Source not found` for a `warehouse-table` source). |

Docs-only. Companion to twells89/sigma-migration-skills#183 (Cognos dashboard support), which is where the full migration recipe lives.

🤖 Generated with [Claude Code](https://claude.com/claude-code)