### PR TITLE
portability: shell-neutral token + de-/tmp + net/http (no curl/jq)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,7 @@
+__pycache__/
+*.pyc
+
+# get_token.py writes this — never commit (auth.json holds a live bearer token).
+auth.json
+
+.env

--- a/custom-sql-to-data-model/SKILL.md
+++ b/custom-sql-to-data-model/SKILL.md
@@ -32,14 +32,33 @@ catches.
 
 Required env vars: `SIGMA_BASE_URL`, `SIGMA_CLIENT_ID`, `SIGMA_CLIENT_SECRET`
 
-Always chain the token eval with `&&` so the token is live for all subsequent
-commands in the same block:
+**Default (shell-neutral, works in bash/zsh/PowerShell/cmd):** mint a token
+with the stdlib-only Python script and let `scripts/lib/sigma_rest.rb` pick
+it up automatically from `auth.json` — no `eval`, no shell-specific syntax:
+
+```bash
+python3 scripts/get_token.py --workdir /tmp/custom-sql-run
+```
+
+This writes `/tmp/custom-sql-run/auth.json` (mode 0600). Every Ruby script in
+this skill checks `$SIGMA_WORKDIR/auth.json` (or `./auth.json`) before
+falling back to a fresh client-credentials exchange, so point `SIGMA_WORKDIR`
+at the same directory (or run from inside it) and every subsequent `ruby
+scripts/*.rb` invocation authenticates without any shell-specific token
+plumbing:
+
+```bash
+export SIGMA_WORKDIR=/tmp/custom-sql-run
+ruby scripts/scan-workbooks.rb
+```
+
+**bash/zsh convenience (equivalent, but bash-only):**
 
 ```bash
 eval "$(bash scripts/get-token.sh)"
 ```
 
-> Tokens expire after ~1 hour. **The Ruby scripts in this skill now auto-refresh on 401** via `scripts/lib/sigma_rest.rb` — full-site scans on large orgs (hundreds of workbooks, sometimes >1 hour total) no longer fail mid-run. If you still see `Token missing or malformed` after a refresh, re-run `eval "$(bash scripts/get-token.sh)"` manually.
+> Tokens expire after ~1 hour. **The Ruby scripts in this skill now auto-refresh on 401** via `scripts/lib/sigma_rest.rb` — full-site scans on large orgs (hundreds of workbooks, sometimes >1 hour total) no longer fail mid-run. If you still see `Token missing or malformed` after a refresh, re-run `python3 scripts/get_token.py --workdir "$SIGMA_WORKDIR"` (or `eval "$(bash scripts/get-token.sh)"` in bash) manually.
 
 ---
 
@@ -50,7 +69,8 @@ eval "$(bash scripts/get-token.sh)" && ruby scripts/scan-workbooks.rb
 ```
 
 Reads every workbook spec in the org, finds all elements where
-`source.kind == "sql"`, and writes `/tmp/custom-sql-manifest.json`.
+`source.kind == "sql"`, and writes `custom-sql-manifest.json` to the system
+temp dir (Ruby's `Dir.tmpdir` — `/tmp` on macOS/Linux, `%TEMP%` on Windows).
 
 Each entry:
 
@@ -82,7 +102,7 @@ Review the findings and confirm with the user which workbooks to convert.
 eval "$(bash scripts/get-token.sh)" && ruby scripts/scan-data-models.rb
 ```
 
-Writes `/tmp/dm-sql-index.json`. The scanner emits one entry per existing DM
+Writes `dm-sql-index.json` to the system temp dir (`Dir.tmpdir`). The scanner emits one entry per existing DM
 element of either kind:
 
 - `kind: "sql"` — indexed by normalized SQL text
@@ -98,7 +118,7 @@ planner can prefer focused DMs over kitchen-sink ones.
 ruby scripts/plan-dedup.rb
 ```
 
-Writes `/tmp/swap-plan.json`. The planner:
+Writes `swap-plan.json` to the system temp dir (`Dir.tmpdir`). The planner:
 
 1. Groups manifest entries by normalized SQL (whitespace/case-collapsed, but
    no semantic reformatting — copy/paste duplicates collapse, semantically-
@@ -126,8 +146,8 @@ Summary: 3 unique SQL strings → 1 reuse, 2 build. 5 total swap actions.
 
 Confirm with the user before continuing — a `[REUSE]` decision is only as
 good as the picked candidate. If the heuristic picked the wrong DM, edit
-`/tmp/swap-plan.json` to point `target.dataModelId` / `target.elementId` at
-the preferred DM before Phase 5.
+`swap-plan.json` (in the system temp dir) to point `target.dataModelId` /
+`target.elementId` at the preferred DM before Phase 5.
 
 ---
 
@@ -313,11 +333,12 @@ new name. Then the swap auto-rewrites cleanly.
 
 ```ruby
 require 'json'
+require 'tmpdir'
 WB = '<workbookId>'
 raw = `curl -s -H "Authorization: Bearer $SIGMA_API_TOKEN" -H "Accept: application/json" "$SIGMA_BASE_URL/v2/workbooks/#{WB}/spec"`
 spec = JSON.parse(raw)
 
-manifest = JSON.parse(File.read('/tmp/custom-sql-manifest.json'))
+manifest = JSON.parse(File.read(File.join(Dir.tmpdir, 'custom-sql-manifest.json')))
 new_names = manifest
   .select { |m| m['workbook_id'] == WB }
   .to_h    { |m| [m['element_id'], m['element_name']] }
@@ -345,7 +366,7 @@ spec['pages'].each do |page|
 end
 
 %w[workbookId url ownerId createdBy updatedBy createdAt updatedAt latestDocumentVersion documentVersion].each { |k| spec.delete(k) }
-File.write('/tmp/wb-pre-swap.json', JSON.pretty_generate(spec))
+File.write(File.join(Dir.tmpdir, 'wb-pre-swap.json'), JSON.pretty_generate(spec))
 ```
 
 ```bash
@@ -548,14 +569,14 @@ for completeness.
 
 | Error / symptom | Cause | Fix |
 |---|---|---|
-| `Token missing or malformed` | Token expired between commands | Re-run `eval "$(bash scripts/get-token.sh)"` — chain with `&&` |
+| `Token missing or malformed` | Token expired between commands | Re-run `python3 scripts/get_token.py --workdir "$SIGMA_WORKDIR"` (shell-neutral), or `eval "$(bash scripts/get-token.sh)"` in bash — chain the latter with `&&` |
 | `:swapSources` returns HTTP 200 `{}` but nothing changed | `from.customSqlId` doesn't match a real element (typo or already swapped) | Re-list `/v2/workbooks/{id}/sources`; assert no `custom-sql` entries remain |
 | `Element X not found in data model` (400) on `:swapSources` | `to.elementId` doesn't exist in the DM | Use the server-assigned ID from Phase 3, not your authoring ID |
 | `bad substitution` on the curl URL | Shell expanded `$WB:swapSources` as a parameter modifier | Wrap in braces: `${WB}:swapSources` |
 | Child element formulas show `[Missing node/...]` after swap | Root SQL element was unnamed; the implicit "Custom SQL" prefix lost its referent | **Sticky** — must be fixed manually. Pre-swap: name the root element AND rewrite child formulas to use that name |
 | Query returns an error string inside a data cell, e.g. `Column "[OT Summary/OT_HOURS]" does not exist` | Auto-match silently missed a SNAKE_CASE column alias; formula points at a column ID the DM doesn't expose | Run `scripts/audit-formulas.rb --from-plan` (Phase 6). For repeat offenders, pass `columnMapping` in the swap call proactively |
 | `service_error` 500 on a swap whose `to.definition` contains SQL with single quotes | Heredoc / shell expansion mangled the SQL string | Use a JSON file with `-d @<file>` instead of inline `-d '...'`, or escape carefully |
-| Plan picked the wrong reuse target | The DM with the lowest `dmElementCount` and matching connection was not the most appropriate | Edit `/tmp/swap-plan.json` to point `target.dataModelId` / `target.elementId` at the preferred DM before Phase 5 |
+| Plan picked the wrong reuse target | The DM with the lowest `dmElementCount` and matching connection was not the most appropriate | Edit `swap-plan.json` (system temp dir) to point `target.dataModelId` / `target.elementId` at the preferred DM before Phase 5 |
 | `Invalid array: ...columns, got undefined` | Converter returned no columns (SELECT * case) | Fetch columns via `mcp__sigma-mcp-v2__describe` and add them manually |
 | `formula: Invalid string: undefined` | Column missing `formula` field | Every column needs `formula` — `[Custom SQL/SQL_ALIAS]` for sql, `[TABLE/COL]` for warehouse-table |
 | `Circular column reference` | Formula used the column's own display name with no prefix | Use `[Custom SQL/SQL_ALIAS]` — bare `[Display Name]` self-references |

--- a/custom-sql-to-data-model/scripts/audit-formulas.rb
+++ b/custom-sql-to-data-model/scripts/audit-formulas.rb
@@ -13,12 +13,13 @@
 #
 # Usage:
 #   ruby scripts/audit-formulas.rb <workbookId> [<workbookId> ...]
-# Or, drive from /tmp/swap-plan.json:
+# Or, drive from <Dir.tmpdir>/swap-plan.json (e.g. /tmp/swap-plan.json on macOS/Linux):
 #   ruby scripts/audit-formulas.rb --from-plan
 
 require 'net/http'
 require 'uri'
 require 'json'
+require 'tmpdir'
 
 BASE_URL = ENV.fetch('SIGMA_BASE_URL')
 $LOAD_PATH.unshift File.expand_path('lib', __dir__)
@@ -73,7 +74,7 @@ end
 
 ids =
   if ARGV.first == '--from-plan'
-    plan = JSON.parse(File.read('/tmp/swap-plan.json'))
+    plan = JSON.parse(File.read(File.join(Dir.tmpdir, 'swap-plan.json')))
     plan.flat_map { |e| (e['workbooks'] || []).map { |w| w['workbook_id'] } }.uniq
   else
     ARGV

--- a/custom-sql-to-data-model/scripts/get-token.sh
+++ b/custom-sql-to-data-model/scripts/get-token.sh
@@ -2,6 +2,11 @@
 # Exchange Sigma client credentials for a bearer token.
 # Usage:  eval "$(scripts/get-token.sh)"
 # Sets SIGMA_API_TOKEN in the calling shell.
+#
+# bash/zsh only — PowerShell and cmd.exe can't run `eval "$(...)"`. For a
+# shell-neutral path (any shell, any agent), use scripts/get_token.py instead:
+#   python3 scripts/get_token.py --workdir /tmp/my-run
+# which writes auth.json for scripts/lib/sigma_rest.rb to pick up automatically.
 
 set -euo pipefail
 

--- a/custom-sql-to-data-model/scripts/get_token.py
+++ b/custom-sql-to-data-model/scripts/get_token.py
@@ -1,0 +1,126 @@
+#!/usr/bin/env python3
+"""get_token.py — shell-neutral Sigma token minting (Python stdlib only).
+
+get-token.sh only works in bash/zsh (`eval "$(get-token.sh)"`) — that idiom
+doesn't run in PowerShell or cmd.exe. This script is the cross-shell twin:
+instead of printing an `export` line, it writes the token to
+<WORKDIR>/auth.json so every shell — bash, PowerShell, cmd, or an agent
+driving any of them — uses the exact same invocation:
+
+    python3 scripts/get_token.py --workdir <WORKDIR>   # writes <WORKDIR>/auth.json (0600)
+    python3 scripts/get_token.py --print-export         # bash: eval "$(...)" compatibility
+    python3 scripts/get_token.py --print-token          # bare token to stdout (for scripting)
+
+auth.json shape:  {"SIGMA_API_TOKEN": "...", "SIGMA_BASE_URL": "..."}
+It is read by scripts/lib/sigma_rest.rb (env vars still win) and MUST be
+kept out of version control — it holds a live bearer token.
+
+Credential resolution: SIGMA_BASE_URL / SIGMA_CLIENT_ID / SIGMA_CLIENT_SECRET
+must already be in the environment (see the repo README / .env.example).
+"""
+
+import argparse
+import base64
+import json
+import os
+import sys
+import urllib.error
+import urllib.request
+
+
+def _die(msg):
+    print(msg, file=sys.stderr)
+    sys.exit(1)
+
+
+def mint_token():
+    base = os.environ.get("SIGMA_BASE_URL")
+    cid = os.environ.get("SIGMA_CLIENT_ID")
+    secret = os.environ.get("SIGMA_CLIENT_SECRET")
+    if not base or not cid or not secret:
+        _die(
+            "FATAL: Sigma credentials not set.\n"
+            "  Set SIGMA_BASE_URL / SIGMA_CLIENT_ID / SIGMA_CLIENT_SECRET in the\n"
+            "  environment (see .env.example / README.md 'Auth' section)."
+        )
+
+    # The #1 hard blocker in practice: a settings file where
+    # SIGMA_CLIENT_SECRET is a COPY of SIGMA_CLIENT_ID. Sigma returns the
+    # opaque "client secret provided is invalid" and nothing else runs.
+    # Catch that obvious paste-error here with an actionable message.
+    if secret == cid:
+        _die(
+            "FATAL: SIGMA_CLIENT_SECRET is identical to SIGMA_CLIENT_ID — you pasted the\n"
+            "client ID into both fields. The secret is a SEPARATE, longer value shown only\n"
+            "once when the API key was created. Fix it and re-run."
+        )
+
+    creds = base64.b64encode(f"{cid}:{secret}".encode()).decode()
+    req = urllib.request.Request(
+        f"{base}/v2/auth/token",
+        data=b"grant_type=client_credentials",
+        headers={
+            "Authorization": f"Basic {creds}",
+            "Content-Type": "application/x-www-form-urlencoded",
+        },
+        method="POST",
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=30) as resp:
+            payload = json.load(resp)
+    except urllib.error.HTTPError as e:
+        _die(
+            "Token exchange failed — check SIGMA_BASE_URL, SIGMA_CLIENT_ID, SIGMA_CLIENT_SECRET\n"
+            f"  base : {base}\n"
+            f"  id   : {len(cid)} chars   secret: {len(secret)} chars\n"
+            "  (a valid Sigma secret is ~128 chars — if the secret is the same length as\n"
+            f"   the id, you likely pasted the id into both fields.)\n"
+            f"  server -> {e.code} {e.reason}"
+        )
+    except urllib.error.URLError as e:
+        _die(f"Token exchange failed — could not reach {base}: {e.reason}")
+
+    token = payload.get("access_token")
+    if not token:
+        _die("Token exchange failed — response did not contain access_token")
+    return base, token
+
+
+def main():
+    ap = argparse.ArgumentParser(description="Mint a Sigma bearer token (shell-neutral).")
+    ap.add_argument("--workdir", help="write <WORKDIR>/auth.json (mode 0600)")
+    ap.add_argument("--print-export", action="store_true",
+                    help="print `export SIGMA_API_TOKEN=...` (bash eval compatibility)")
+    ap.add_argument("--print-token", action="store_true",
+                    help="print the bare token to stdout")
+    args = ap.parse_args()
+
+    base, token = mint_token()
+
+    wrote = False
+    if args.workdir:
+        os.makedirs(args.workdir, exist_ok=True)
+        auth_path = os.path.join(args.workdir, "auth.json")
+        # Write 0600 atomically-ish: create with restrictive mode from the start.
+        fd = os.open(auth_path, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
+        with os.fdopen(fd, "w", encoding="utf-8") as fh:
+            json.dump({"SIGMA_API_TOKEN": token, "SIGMA_BASE_URL": base}, fh)
+        try:
+            os.chmod(auth_path, 0o600)  # no-op on Windows, harmless
+        except OSError:
+            pass
+        print(f"wrote {auth_path} (Sigma token; expires ~1h)", file=sys.stderr)
+        wrote = True
+
+    if args.print_export:
+        print(f"export SIGMA_API_TOKEN={token}")
+    elif args.print_token:
+        print(token)
+    elif not wrote:
+        # Default with no flags: behave like get-token.sh so `eval "$(...)"`
+        # keeps working in bash and nobody's muscle memory breaks.
+        print(f"export SIGMA_API_TOKEN={token}")
+
+
+if __name__ == "__main__":
+    main()

--- a/custom-sql-to-data-model/scripts/lib/sigma_rest.rb
+++ b/custom-sql-to-data-model/scripts/lib/sigma_rest.rb
@@ -24,6 +24,28 @@ require 'uri'
 require 'json'
 require 'base64'
 
+# File-based token handoff (shell-neutral, kills the `eval "$(get-token.sh)"`
+# bash idiom that PowerShell/cmd cannot run). scripts/get_token.py writes
+# <WORK>/auth.json = {"SIGMA_API_TOKEN": ..., "SIGMA_BASE_URL": ...}. Read it
+# here so any shell/agent can mint once (python) and every downstream Ruby
+# script picks the token up. Precedence: explicit env ALWAYS wins → auth.json →
+# (below) client-credential self-mint via refresh_token!. auth.json should be
+# kept out of version control — it holds a live bearer token, never print it.
+if ENV['SIGMA_API_TOKEN'].nil?
+  _auth_candidates = [ENV['SIGMA_WORKDIR'], Dir.pwd].compact
+                        .map { |d| File.join(d, 'auth.json') }
+  _auth_path = _auth_candidates.find { |p| File.exist?(p) }
+  if _auth_path
+    begin
+      _auth = JSON.parse(File.read(_auth_path, encoding: 'bom|utf-8'))
+      ENV['SIGMA_API_TOKEN'] ||= _auth['SIGMA_API_TOKEN'] if _auth['SIGMA_API_TOKEN']
+      ENV['SIGMA_BASE_URL']  ||= _auth['SIGMA_BASE_URL']  if _auth['SIGMA_BASE_URL']
+    rescue JSON::ParserError
+      # A corrupt auth.json must not wedge the run — fall through to self-mint.
+    end
+  end
+end
+
 module Sigma
   class Error < StandardError; end
   class AuthError < Error; end

--- a/custom-sql-to-data-model/scripts/plan-dedup.rb
+++ b/custom-sql-to-data-model/scripts/plan-dedup.rb
@@ -4,7 +4,8 @@
 #   - If a DM element already wraps it → reuse (status: "existing")
 #   - Otherwise → mark as needs-build (status: "to-build")
 #
-# Output: /tmp/swap-plan.json — an array of plan entries. Each entry has the
+# Output: <Dir.tmpdir>/swap-plan.json (e.g. /tmp/swap-plan.json on macOS/Linux)
+# — an array of plan entries. Each entry has the
 # normalized SQL, the list of workbook occurrences that share it, and either
 # an existing target {dataModelId, elementId} OR a `to_build: true` flag with
 # a representative sql/connection_id/folder_id the user can pass to Phase 2.
@@ -15,10 +16,11 @@
 #   ruby scripts/plan-dedup.rb
 
 require 'json'
+require 'tmpdir'
 
-MANIFEST = '/tmp/custom-sql-manifest.json'
-DM_INDEX = '/tmp/dm-sql-index.json'
-OUT      = '/tmp/swap-plan.json'
+MANIFEST = File.join(Dir.tmpdir, 'custom-sql-manifest.json')
+DM_INDEX = File.join(Dir.tmpdir, 'dm-sql-index.json')
+OUT      = File.join(Dir.tmpdir, 'swap-plan.json')
 
 unless File.exist?(MANIFEST)
   abort "missing #{MANIFEST} — run scan-workbooks.rb first"

--- a/custom-sql-to-data-model/scripts/scan-data-models.rb
+++ b/custom-sql-to-data-model/scripts/scan-data-models.rb
@@ -1,6 +1,7 @@
 #!/usr/bin/env ruby
 # Scan all data models for elements with source.kind == "sql".
-# Outputs a JSON index keyed by normalized SQL to /tmp/dm-sql-index.json,
+# Outputs a JSON index keyed by normalized SQL to <Dir.tmpdir>/dm-sql-index.json
+# (e.g. /tmp/dm-sql-index.json on macOS/Linux),
 # used by plan-dedup.rb to decide whether to reuse an existing DM element
 # or build a new one for a given custom-SQL fingerprint.
 #
@@ -13,6 +14,7 @@ require 'uri'
 require 'json'
 require 'yaml'
 require 'date'
+require 'tmpdir'
 
 BASE_URL = ENV.fetch('SIGMA_BASE_URL') { abort 'SIGMA_BASE_URL not set' }
 $LOAD_PATH.unshift File.expand_path('lib', __dir__)
@@ -117,6 +119,6 @@ end
 puts "\n#{'=' * 60}"
 puts "Unique SQL strings indexed across DMs: #{index.size}"
 
-out = '/tmp/dm-sql-index.json'
+out = File.join(Dir.tmpdir, 'dm-sql-index.json')
 File.write(out, JSON.pretty_generate(index))
 puts "Index written to #{out}"

--- a/custom-sql-to-data-model/scripts/scan-workbooks.rb
+++ b/custom-sql-to-data-model/scripts/scan-workbooks.rb
@@ -1,6 +1,7 @@
 #!/usr/bin/env ruby
 # Scan all workbooks for elements with source.kind == "sql".
-# Outputs a JSON manifest to /tmp/custom-sql-manifest.json
+# Outputs a JSON manifest to <Dir.tmpdir>/custom-sql-manifest.json
+# (e.g. /tmp/custom-sql-manifest.json on macOS/Linux)
 #
 # Usage:
 #   eval "$(bash scripts/get-token.sh)"
@@ -11,6 +12,7 @@ require 'uri'
 require 'json'
 require 'yaml'
 require 'date'
+require 'tmpdir'
 
 BASE_URL = ENV.fetch('SIGMA_BASE_URL') { abort 'SIGMA_BASE_URL not set — run: eval "$(bash scripts/get-token.sh)"' }
 $LOAD_PATH.unshift File.expand_path('lib', __dir__)
@@ -83,7 +85,7 @@ puts "Custom SQL elements found: #{findings.size}"
 if findings.empty?
   puts "No custom SQL elements found in any workbook."
 else
-  out = '/tmp/custom-sql-manifest.json'
+  out = File.join(Dir.tmpdir, 'custom-sql-manifest.json')
   File.write(out, JSON.pretty_generate(findings))
   puts "Manifest written to #{out}"
 end

--- a/sigma-workbooks/SKILL.md
+++ b/sigma-workbooks/SKILL.md
@@ -55,6 +55,16 @@ jq --arg k bar-chart 'first(.. | objects | select((.allOf? and any(.allOf[]?; .p
 
 `WebFetch` works for the JSON too. Either path is fine.
 
+No `curl`/`jq` on the machine (e.g. Windows without WSL)? `scripts/wb-rep.rb`
+ships a `capabilities` subcommand that does the same three queries with
+pure-Ruby `Net::HTTP` + `JSON.parse` — no external tools required:
+
+```bash
+ruby scripts/wb-rep.rb capabilities                          # list every kind
+ruby scripts/wb-rep.rb capabilities --kind bar-chart          # field list for one kind
+ruby scripts/wb-rep.rb capabilities --kind bar-chart --field source  # one field's shape
+```
+
 **Why bother:** the API ships new fields and viz configurations regularly, and this skill covers the common surface, not every field. If you want a capability and don't see it documented here, **assume it may exist and check the spec before concluding it doesn't** — the `kind` query above answers in seconds.
 
 ## Auth

--- a/sigma-workbooks/scripts/wb-rep.rb
+++ b/sigma-workbooks/scripts/wb-rep.rb
@@ -45,6 +45,7 @@ require 'net/http'
 require 'uri'
 require 'fileutils'
 require 'time'
+require 'tmpdir'
 
 RESPONSE_ONLY = %w[workbookId url documentVersion latestDocumentVersion ownerId
                    createdBy updatedBy createdAt updatedAt].freeze
@@ -400,21 +401,88 @@ def cmd_summarize(args)
   puts "  sources: #{sources.compact.uniq.join(', ')}" unless sources.compact.empty?
 end
 
-OPENAPI_CACHE = '/tmp/sigma-api.json'.freeze
+OPENAPI_CACHE = File.join(Dir.tmpdir, 'sigma-api.json').freeze
+OPENAPI_URL = 'https://help.sigmacomputing.com/openapi/sigma-computing-public-rest-api.json'.freeze
+
+# Depth-first walk mirroring jq's `.. | objects`: yields every Hash reachable
+# from `node` (including `node` itself), descending through both Hash values
+# and Array elements.
+def walk_objects(node, &blk)
+  return enum_for(:walk_objects, node) unless blk
+  case node
+  when Hash
+    blk.call(node)
+    node.each_value { |v| walk_objects(v, &blk) }
+  when Array
+    node.each { |v| walk_objects(v, &blk) }
+  end
+end
+
+# Mirrors the jq selector used throughout: a schema matches `kind` either via
+# an allOf branch's `properties.kind.enum` or its own.
+def kind_schema_match?(obj, kind)
+  all_of = obj['allOf']
+  allof_match = all_of.is_a?(Array) && all_of.any? { |s| s.is_a?(Hash) && s.dig('properties', 'kind', 'enum') == [kind] }
+  allof_match || obj.dig('properties', 'kind', 'enum') == [kind]
+end
+
+def find_kind_schema(doc, kind)
+  walk_objects(doc).find { |obj| kind_schema_match?(obj, kind) }
+end
+
+# Mirrors `[.allOf[]?.properties // .properties | keys[]] | unique[]`: merge
+# property keys across allOf branches, falling back to the schema's own
+# properties when there's no allOf (or none of its branches have properties).
+def merged_properties_keys(schema)
+  props_list = []
+  if schema['allOf'].is_a?(Array)
+    props_list = schema['allOf']
+                 .select { |s| s.is_a?(Hash) && s['properties'].is_a?(Hash) }
+                 .map { |s| s['properties'] }
+  end
+  props_list = [schema['properties']].compact if props_list.empty? && schema['properties'].is_a?(Hash)
+  props_list.flat_map(&:keys).uniq.sort
+end
+
+# Mirrors `.. | objects | select(.properties[field]) | .properties[field] | .[0]`:
+# first descendant schema (depth-first) that declares `field`, returning its
+# sub-schema.
+def find_field_schema(kind_schema, field)
+  walk_objects(kind_schema).each do |obj|
+    return obj['properties'][field] if obj['properties'].is_a?(Hash) && obj['properties'].key?(field)
+  end
+  nil
+end
+
 def cmd_capabilities(args)
   kind = field = nil
   if (i = args.index('--kind')) then kind = args[i + 1]; args.slice!(i, 2); end
   if (i = args.index('--field')) then field = args[i + 1]; args.slice!(i, 2); end
   unless File.exist?(OPENAPI_CACHE)
-    system('curl', '-sf', 'https://help.sigmacomputing.com/openapi/sigma-computing-public-rest-api.json', '-o', OPENAPI_CACHE) or die 'failed to fetch OpenAPI'
+    uri = URI(OPENAPI_URL)
+    res = Net::HTTP.get_response(uri)
+    die 'failed to fetch OpenAPI' unless res.is_a?(Net::HTTPSuccess)
+    File.write(OPENAPI_CACHE, res.body)
   end
-  sel = %q{first(.. | objects | select((.allOf? and any(.allOf[]?; .properties?.kind?.enum==[$k])) or .properties?.kind?.enum==[$k]))}
+  doc = JSON.parse(File.read(OPENAPI_CACHE))
+
   if kind.nil?
-    system('jq', '-r', '[.. | objects | select(.properties.kind.enum) | .properties.kind.enum[0]] | unique[]', OPENAPI_CACHE)
-  elsif field.nil?
-    system('jq', '-r', '--arg', 'k', kind, "#{sel} | [.allOf[]?.properties // .properties | keys[]] | unique[]", OPENAPI_CACHE)
+    kinds = walk_objects(doc).each_with_object([]) do |obj, acc|
+      enum = obj.dig('properties', 'kind', 'enum')
+      acc << enum.first if enum.is_a?(Array) && !enum.empty?
+    end
+    kinds.uniq.sort.each { |k| puts k }
+    return
+  end
+
+  schema = find_kind_schema(doc, kind)
+  die "no schema found for kind #{kind.inspect}" unless schema
+
+  if field.nil?
+    merged_properties_keys(schema).each { |k| puts k }
   else
-    system('jq', '--arg', 'k', kind, "[#{sel} | .. | objects | select(.properties[\"#{field}\"]) | .properties[\"#{field}\"]] | .[0]", OPENAPI_CACHE)
+    result = find_field_schema(schema, field)
+    puts result.nil? ? 'null' : JSON.pretty_generate(result)
   end
 end
 


### PR DESCRIPTION
## Summary

Cross-platform / Windows-safety pass on `custom-sql-to-data-model` and `sigma-workbooks` (bead `beads-sigma-xy5g`). The Ruby in this repo is already stdlib-only and portable; the blockers were bash idioms, curl/jq shell-outs, and hardcoded `/tmp` paths.

- **Shell-neutral token minting**: added `custom-sql-to-data-model/scripts/get_token.py` (stdlib-only Python), the cross-shell twin of `get-token.sh`. Instead of printing a bash `export SIGMA_API_TOKEN=...` line (which only bash/zsh's `eval "$(...)"` idiom can consume), it writes `<workdir>/auth.json` — readable by any shell or agent. `scripts/lib/sigma_rest.rb` now checks `$SIGMA_WORKDIR/auth.json` (or `./auth.json`) before self-minting via client-credentials; explicit env vars always win. `get-token.sh` is kept as a documented bash-only convenience; `get_token.py` is now the default path in `custom-sql-to-data-model/SKILL.md`'s Prerequisites and Troubleshooting sections.
- **De-hardcoded `/tmp`**: `scan-workbooks.rb`, `scan-data-models.rb`, `plan-dedup.rb`, `audit-formulas.rb`, and `wb-rep.rb`'s `OPENAPI_CACHE` now use `Dir.tmpdir` instead of a literal `/tmp/...` path. Writer/reader filenames are unchanged so the manifest → dm-index → swap-plan pipeline still coordinates correctly across scripts run in the same process tree. Updated the accompanying SKILL.md prose/snippets that referenced the old literal paths.
- **curl/jq → Net::HTTP/JSON.parse**: `wb-rep.rb`'s `capabilities` subcommand (`~line 403-419`) shelled out to `curl` to fetch the Sigma OpenAPI doc and to `jq` for four different queries against it (list all `kind`s, field list for a kind, full field-list with allOf merging, and single-field lookup). Replaced with `Net::HTTP.get_response` for the fetch and a small pure-Ruby recursive walker (`walk_objects`/`find_kind_schema`/`merged_properties_keys`/`find_field_schema`) that reproduces the same jq selectors without any external tool. Cross-linked this from `sigma-workbooks/SKILL.md`'s curl+jq OpenAPI-navigation section as the tool-free alternative.
- Added a `.gitignore` (none existed) covering `auth.json`, `__pycache__/`, `.env` — `auth.json` holds a live bearer token and must never be committed.

## Deferred (noted, not fixed)

- `sigma-workbooks/scripts/validate-spec.sh` and `verify-workbook.sh` remain bash-only: they require `jq`/`yq` and `verify-workbook.sh` uses a `< <(process substitution)` construct that fails under POSIX `sh`/`dash`. Porting these to Ruby is a larger, separable follow-up (both currently work fine under bash/zsh/git-bash, so this isn't a regression — just not yet cross-shell).

## Vendored-copy reconciliation note

`custom-sql-to-data-model` is vendored byte-identical into `sigma-migration-skills` (a different repo). That vendored copy needs the same fixes applied separately — there is no cross-repo sync tool to do it automatically, so this PR does not attempt it.

## Verification

- `ruby -c` on every changed `.rb` file: all Syntax OK.
- `python3 -m py_compile` on `get_token.py`: OK.
- Functional dry-runs (no live Sigma creds needed):
  - `sigma_rest.rb`'s new auth.json fallback: verified it picks up `SIGMA_API_TOKEN`/`SIGMA_BASE_URL` from a workdir `auth.json` when env vars are unset, and that explicit env vars still take precedence.
  - `wb-rep.rb capabilities` (list kinds / `--kind` / `--kind --field`) against a synthetic OpenAPI-shaped JSON fixture: output matched the equivalent jq queries' semantics (kind list, allOf-merged field list, single-field sub-schema lookup).
  - `get_token.py --help` and the "credentials not set" actionable-error path.
  - `plan-dedup.rb` run with no manifest present: aborts with a message pointing at the new `Dir.tmpdir`-based path.

Not merging — PR flow only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)