### PR TITLE
fix(sigma-data-models): correct window-fn calc-column claim (*Over vs native)

### DIFF
--- a/sigma-data-models/SKILL.md
+++ b/sigma-data-models/SKILL.md
@@ -66,7 +66,7 @@ Call out any of these before presenting the final spec:
 - Input tables, Python elements, and UI elements
 - Referencing Sigma elements in custom SQL
 - Partial updates — the create and update endpoints both require the full representation
-- `CountOver` / `SumOver` / `RowNumberOver` / other window functions inside DM element calculated columns — they silently error. See `reference/calc-columns.md` for workarounds.
+- The `*Over` window functions (`CountOver` / `SumOver` / `RowNumberOver` / `RankOver` / …) — invalid as a spec formula (a DM-spec POST 400s; workbook calc columns error `Unknown function`). The Sigma-**native** window family (`CumulativeSum` / `MovingAvg` / `Rank` / `RowNumber` / `Lag` / `Lead` / `PercentOfTotal`) DOES resolve in DM-element and workbook calc columns — use those. See `reference/calc-columns.md`.
 - `IsIn(...)` in any formula — Sigma's formula language has no such function. Use chained `or` conditions instead. (See the `sigma-workbooks` skill's `formulas.md` for the full function reference.)
 
 ## Cross-Skill References

--- a/sigma-data-models/generated/cline/sigma-data-models.md
+++ b/sigma-data-models/generated/cline/sigma-data-models.md
@@ -57,14 +57,14 @@ Call out any of these before presenting the final spec:
 - Input tables, Python elements, and UI elements
 - Referencing Sigma elements in custom SQL
 - Partial updates — the create and update endpoints both require the full representation
-- `CountOver` / `SumOver` / `RowNumberOver` / other window functions inside DM element calculated columns — they silently error. See `reference/calc-columns.md` for workarounds.
+- The `*Over` window functions (`CountOver` / `SumOver` / `RowNumberOver` / `RankOver` / …) — invalid as a spec formula (a DM-spec POST 400s; workbook calc columns error `Unknown function`). The Sigma-**native** window family (`CumulativeSum` / `MovingAvg` / `Rank` / `RowNumber` / `Lag` / `Lead` / `PercentOfTotal`) DOES resolve in DM-element and workbook calc columns — use those. See `reference/calc-columns.md`.
 - `IsIn(...)` in any formula — Sigma's formula language has no such function. Use chained `or` conditions instead. (See the `sigma-workbooks` skill's `formulas.md` for the full function reference.)
 
 ## Cross-Skill References
 
 - **Building a workbook on top of this model** → load the `sigma-workbooks` skill. Its `sources.md` documents the `{ "kind": "data-model", "dataModelId": "...", "elementId": "..." }` source shape.
 - **Repointing existing workbooks to a newly-created model** → see `sigma-workbooks/reference/workflows/crud.md` and the swap-sources endpoint.
-- **Auth, base URLs, regions, token refresh** → always defer to the `sigma-api` skill rather than restating.
+- **Auth, base URLs, regions, token refresh** → always defer to the `sigma-api` skill rather than restating. For automatic 401-retry-with-refresh in Ruby long-running scripts (DM-build loops that outlive the 1-hour token TTL), see `sigma-workbooks/SKILL.md` "401 Unauthorized" — same pattern applies here.
 
 ## Out of Scope (use a different tool)
 

--- a/sigma-data-models/generated/codex/AGENTS.md
+++ b/sigma-data-models/generated/codex/AGENTS.md
@@ -57,14 +57,14 @@ Call out any of these before presenting the final spec:
 - Input tables, Python elements, and UI elements
 - Referencing Sigma elements in custom SQL
 - Partial updates — the create and update endpoints both require the full representation
-- `CountOver` / `SumOver` / `RowNumberOver` / other window functions inside DM element calculated columns — they silently error. See `reference/calc-columns.md` for workarounds.
+- The `*Over` window functions (`CountOver` / `SumOver` / `RowNumberOver` / `RankOver` / …) — invalid as a spec formula (a DM-spec POST 400s; workbook calc columns error `Unknown function`). The Sigma-**native** window family (`CumulativeSum` / `MovingAvg` / `Rank` / `RowNumber` / `Lag` / `Lead` / `PercentOfTotal`) DOES resolve in DM-element and workbook calc columns — use those. See `reference/calc-columns.md`.
 - `IsIn(...)` in any formula — Sigma's formula language has no such function. Use chained `or` conditions instead. (See the `sigma-workbooks` skill's `formulas.md` for the full function reference.)
 
 ## Cross-Skill References
 
 - **Building a workbook on top of this model** → load the `sigma-workbooks` skill. Its `sources.md` documents the `{ "kind": "data-model", "dataModelId": "...", "elementId": "..." }` source shape.
 - **Repointing existing workbooks to a newly-created model** → see `sigma-workbooks/reference/workflows/crud.md` and the swap-sources endpoint.
-- **Auth, base URLs, regions, token refresh** → always defer to the `sigma-api` skill rather than restating.
+- **Auth, base URLs, regions, token refresh** → always defer to the `sigma-api` skill rather than restating. For automatic 401-retry-with-refresh in Ruby long-running scripts (DM-build loops that outlive the 1-hour token TTL), see `sigma-workbooks/SKILL.md` "401 Unauthorized" — same pattern applies here.
 
 ## Out of Scope (use a different tool)
 

--- a/sigma-data-models/generated/continue/sigma-data-models.md
+++ b/sigma-data-models/generated/continue/sigma-data-models.md
@@ -57,14 +57,14 @@ Call out any of these before presenting the final spec:
 - Input tables, Python elements, and UI elements
 - Referencing Sigma elements in custom SQL
 - Partial updates — the create and update endpoints both require the full representation
-- `CountOver` / `SumOver` / `RowNumberOver` / other window functions inside DM element calculated columns — they silently error. See `reference/calc-columns.md` for workarounds.
+- The `*Over` window functions (`CountOver` / `SumOver` / `RowNumberOver` / `RankOver` / …) — invalid as a spec formula (a DM-spec POST 400s; workbook calc columns error `Unknown function`). The Sigma-**native** window family (`CumulativeSum` / `MovingAvg` / `Rank` / `RowNumber` / `Lag` / `Lead` / `PercentOfTotal`) DOES resolve in DM-element and workbook calc columns — use those. See `reference/calc-columns.md`.
 - `IsIn(...)` in any formula — Sigma's formula language has no such function. Use chained `or` conditions instead. (See the `sigma-workbooks` skill's `formulas.md` for the full function reference.)
 
 ## Cross-Skill References
 
 - **Building a workbook on top of this model** → load the `sigma-workbooks` skill. Its `sources.md` documents the `{ "kind": "data-model", "dataModelId": "...", "elementId": "..." }` source shape.
 - **Repointing existing workbooks to a newly-created model** → see `sigma-workbooks/reference/workflows/crud.md` and the swap-sources endpoint.
-- **Auth, base URLs, regions, token refresh** → always defer to the `sigma-api` skill rather than restating.
+- **Auth, base URLs, regions, token refresh** → always defer to the `sigma-api` skill rather than restating. For automatic 401-retry-with-refresh in Ruby long-running scripts (DM-build loops that outlive the 1-hour token TTL), see `sigma-workbooks/SKILL.md` "401 Unauthorized" — same pattern applies here.
 
 ## Out of Scope (use a different tool)
 

--- a/sigma-data-models/generated/cursor/rules/sigma-data-models.mdc
+++ b/sigma-data-models/generated/cursor/rules/sigma-data-models.mdc
@@ -62,14 +62,14 @@ Call out any of these before presenting the final spec:
 - Input tables, Python elements, and UI elements
 - Referencing Sigma elements in custom SQL
 - Partial updates — the create and update endpoints both require the full representation
-- `CountOver` / `SumOver` / `RowNumberOver` / other window functions inside DM element calculated columns — they silently error. See `reference/calc-columns.md` for workarounds.
+- The `*Over` window functions (`CountOver` / `SumOver` / `RowNumberOver` / `RankOver` / …) — invalid as a spec formula (a DM-spec POST 400s; workbook calc columns error `Unknown function`). The Sigma-**native** window family (`CumulativeSum` / `MovingAvg` / `Rank` / `RowNumber` / `Lag` / `Lead` / `PercentOfTotal`) DOES resolve in DM-element and workbook calc columns — use those. See `reference/calc-columns.md`.
 - `IsIn(...)` in any formula — Sigma's formula language has no such function. Use chained `or` conditions instead. (See the `sigma-workbooks` skill's `formulas.md` for the full function reference.)
 
 ## Cross-Skill References
 
 - **Building a workbook on top of this model** → load the `sigma-workbooks` skill. Its `sources.md` documents the `{ "kind": "data-model", "dataModelId": "...", "elementId": "..." }` source shape.
 - **Repointing existing workbooks to a newly-created model** → see `sigma-workbooks/reference/workflows/crud.md` and the swap-sources endpoint.
-- **Auth, base URLs, regions, token refresh** → always defer to the `sigma-api` skill rather than restating.
+- **Auth, base URLs, regions, token refresh** → always defer to the `sigma-api` skill rather than restating. For automatic 401-retry-with-refresh in Ruby long-running scripts (DM-build loops that outlive the 1-hour token TTL), see `sigma-workbooks/SKILL.md` "401 Unauthorized" — same pattern applies here.
 
 ## Out of Scope (use a different tool)
 

--- a/sigma-data-models/reference/calc-columns.md
+++ b/sigma-data-models/reference/calc-columns.md
@@ -22,19 +22,19 @@ A calc column has no warehouse-column ID prefix — its `id` is a generated shor
 
 A calc column **cannot reference itself**, even transitively — the server rejects circular references.
 
-## Window functions don't work in DM element calc columns
+## The `*Over` window functions don't work — but the native family does
 
-`CountOver`, `SumOver`, `RowNumberOver`, `RankOver`, and other window-style functions silently fail when used as a formula on a calculated column **inside a data model element**. The column's `error` flag flips on without a clear UI signal, and any downstream chart that references the column blanks out.
+The `*Over` family — `CountOver`, `SumOver`, `RowNumberOver`, `RankOver`, `MaxOver`, `MinOver` — is **not a valid spec formula**. In a data-model element calc column a DM-spec POST **hard-rejects** them (400 Bad Request); in a workbook calc column they resolve to `Unknown function` at query time. Never emit the `*Over` names from a spec.
 
-This is independent of the underlying SQL — the same formula works fine in a workbook calc column on most element types, but **not** on a workbook master table that's sourced from a data model (the workbook table inherits the DM-side restriction).
+The Sigma-**native** window family — `CumulativeSum` / `CumulativeAvg` / `CumulativeMax` / `CumulativeMin` / `CumulativeCount`, `MovingSum` / `MovingAvg` / `MovingMax` / `MovingMin` / `MovingStdDev`, `Rank` / `RankDense` / `RankPercentile`, `RowNumber`, `Lag`, `Lead`, `PercentOfTotal` — **does** work. Live-verified 2026-07-15: each compiles to real warehouse `OVER(...)` in a DM-element calc column, in a grouped workbook table, and in an ungrouped workbook "master" table sourced from a data model. There is **no** inherited DM-side restriction on DM-sourced workbook tables. Prefer these over the `*Over` names.
 
-### Workarounds
+### Workarounds (only when there is no native equivalent)
 
 | If you need… | Do this |
 |---|---|
-| A running total or rank by group on warehouse data | Push the calculation to a `sql` source — write the window function in SQL once, expose the result as a regular warehouse column. |
-| A row-number-by-group at view time | Move the calc to a workbook-level table that's **not** sourced from the DM (i.e., sources directly from warehouse-table). Window functions are allowed in those contexts. |
-| A simple cumulative metric | Express it as a metric on the model with `Sum / Count / etc.` — metrics aggregate across rows, which gets you most of what `SumOver` would. |
+| A running total, moving window, rank, or row number | Use the native form (`CumulativeSum` / `MovingAvg` / `Rank` / `RowNumber` / `Lag` / `Lead` / `PercentOfTotal`) — it works directly in a DM-element or workbook calc column. |
+| An `*Over`-only construct with no native equivalent | Push it to a `sql` source — write the window function in SQL once, expose the result as a regular warehouse column. |
+| A simple cumulative metric | `CumulativeSum(...)` in a calc column, or a model metric with `Sum / Count / etc.` |
 
 ### Side effect to know about
 
@@ -43,7 +43,7 @@ When a calc column on a DM element is set to an unsupported formula and the mode
 ## Common errors
 
 - **"Invalid column reference"** — bare `[col]` where a prefix was needed, or a misspelling. Re-check column names against the source via `discover.md`.
-- **Column shows `error` icon, formula looks fine** — likely a window function. Try a simpler aggregation; if that works, the window function is the issue.
+- **Column shows `error` icon, formula looks fine** — likely an `*Over` function (`SumOver`/`CountOver`/…). Switch to the native window function (`CumulativeSum`/`MovingAvg`/`Rank`/`Lag`/…), which resolves in calc columns.
 - **Chart that references this column blanks out** — the calc column is in error state. Fix the formula; the chart will recover on the next render.
 
 See `formulas.md` (in the `sigma-workbooks` skill) for the full formula language reference, including the function list. The data-model side uses the same formula syntax with the constraints noted here.


### PR DESCRIPTION
## What & why

The `sigma-data-models` reference stated window functions "don't work in DM element calc columns" and that DM-sourced workbook master tables inherit that restriction. That over-generalized the **`*Over`-family** limitation onto the **whole** window family.

Live-verified 2026-07-15 (via `probe-window-contexts.rb` in the tableau converter, 9 fns × 3 contexts):

- **Native family** (`Cumulative*`/`Moving*`/`Rank`/`RankDense`/`RowNumber`/`Lag`/`Lead`/`PercentOfTotal`) → compiles to real warehouse `OVER(...)` in a **DM-element calc column**, a **grouped** workbook table, and an **ungrouped "master"** workbook table. No inherited restriction.
- **`*Over` family** (`SumOver`/`CountOver`/`RowNumberOver`/`RankOver`/…) → invalid: a DM-spec POST **400s**, workbook calc columns error `Unknown function`.

## Changes
- `reference/calc-columns.md` — rewrote the window section as an `*Over`-vs-native distinction; fixed the "common errors" line
- `SKILL.md` — fixed the gotcha bullet
- regenerated `generated/{codex,cursor,cline,continue}` via `scripts/sync-targets.rb`

## Downstream
Mirrored in `twells89/sigma-migration-skills` (PR #380): the converters (pbi/qlik/quicksight) + the vendored copy of this skill. A full re-vendor of this repo into the marketplace is separate housekeeping.

🤖 Generated with [Claude Code](https://claude.com/claude-code)