### PR TITLE
sigma-workbooks: document native element.trellis (rowsBy/columnsBy) shapes

### DIFF
--- a/sigma-workbooks/docs/sigma-trellis-chart-support.md
+++ b/sigma-workbooks/docs/sigma-trellis-chart-support.md
@@ -1,0 +1,135 @@
+# Sigma native `trellis` — chart-kind support matrix
+
+Which Sigma viz kinds support the **native trellis** element property — the
+spec-authorable small-multiples facet — and how each orientation behaves.
+
+The native trellis binds a **categorical column** to a facet shelf on a single
+viz element:
+
+```jsonc
+{
+  "kind": "bar-chart",
+  "columns": [ { "id": "col-cat", "formula": "[Master/Category]" }, ... ],
+  "trellis": {
+    "rowsBy":    [ { "columnId": "col-cat" } ],   // vertical  — one facet per member, stacked in rows
+    "columnsBy": [ { "columnId": "col-cat" } ]     // horizontal — one facet per member, side by side
+  }
+}
+```
+
+- `rowsBy` alone → vertical small-multiples.
+- `columnsBy` alone → horizontal small-multiples.
+- both, referencing **two different** columns → a 2-D grid (rows × columns).
+- The facet reference key is **`columnId`** (a `columns[]` id on the element).
+  Note this differs from the `pivot-table` element's *own* `rowsBy`/`columnsBy`
+  cross-tab shelves, which key on `id` and are a separate mechanism (see below).
+
+> This is distinct from the legacy `trellis: { column, row, share?, tileSize? }`
+> *styling* object, which only styles a UI-configured trellis and whose facet
+> binding is silently stripped. The `rowsBy`/`columnsBy` form **does** bind the
+> facet from spec on the supported kinds.
+
+## How this was verified
+
+For each chart kind a minimal two-page workbook was POSTed live to
+`POST /v2/workbooks/spec` (Data page: a source table with a few-member category
+dimension + an x dimension + a numeric measure; content page: one element of the
+kind with `trellis` referencing the category column). Then
+`GET /v2/workbooks/{id}/spec` was read back and the `trellis` key compared to
+what was sent, and representative cases were rendered to PNG via the export API.
+
+**Primary signal = does the readback preserve the `trellis` key.** A kind that
+supports it round-trips the key byte-for-byte; a kind that does not returns
+`200` on POST but **silently drops** the key on readback (and renders a single,
+un-faceted chart). Render was used as confirmation on the positive cases (facets
+appear) and on a stripped case (pie renders flat).
+
+## Coverage matrix
+
+| Chart kind        | `rowsBy` (POST / readback / render) | `columnsBy` | 2-D grid | Notes |
+|-------------------|-------------------------------------|-------------|----------|-------|
+| **bar-chart**     | 200 / **preserved** / facets render | preserved (200) | preserved (200) | Full support. `stacking: stacked` and `stacking: normalized` variants both preserve trellis (200 / preserved). |
+| **line-chart**    | 200 / **preserved** / facets render | preserved (200) | preserved (200) | Full support. |
+| **area-chart**    | 200 / **preserved**                 | (cartesian — same as bar/line) | (same) | Full support; shares the cartesian shape. |
+| **combo-chart**   | 200 / **preserved**                 | (cartesian) | (same) | Full support; shares the cartesian shape. |
+| **scatter-chart** | 200 / **preserved**                 | (cartesian) | (same) | Key round-trips. Caveat: a scatter must bind to a grouping to render correctly (unrelated to trellis) — validate the render separately. |
+| **donut-chart**   | 200 / **preserved** / facets render | (circular — same as rowsBy) | (same) | **Supported** — one donut per facet member renders. |
+| **pie-chart**     | 200 / **STRIPPED** / renders flat   | **STRIPPED** (200) | **STRIPPED** (200) | **NOT supported.** POST succeeds, key is dropped on readback, render is a single un-faceted pie. Use `donut-chart` if a trellis is required. |
+| **kpi-chart**     | 200 / **STRIPPED**                  | —           | —        | **NOT supported.** Key dropped on readback. |
+| **pivot-table**   | 200 / **STRIPPED**                  | —           | —        | **NOT supported** as a `trellis` key. The pivot's *own* element-level `rowsBy`/`columnsBy` shelves (keyed on `id`) are the native cross-tab faceting — use those instead. |
+| **table**         | 200 / **STRIPPED**                  | —           | —        | **NOT supported.** Key dropped on readback. |
+
+Invalid element kinds (rejected `400 "Invalid kind"` — not part of the workbook
+spec API in this org): `box`, `heatmap`, `gauge`, `funnel`, `waterfall`,
+`single-value`, `geography`, `map`. There is no trellis story for these because
+the kinds themselves don't exist in the spec.
+
+### Key surprises
+
+1. **`pie-chart` does NOT support trellis, but `donut-chart` does** — despite
+   both being circular (`value` + `color`) charts. The trellis key is silently
+   stripped from a pie on readback and the render is a single flat pie; a donut
+   with the identical trellis renders one donut per facet member. If a source
+   tool has a faceted pie, emit a **donut** in Sigma (or route to post-publish).
+2. **Stripping is silent** — every non-supporting kind still returns `200` on
+   POST. POST success is **not** proof of trellis support; the readback is. Any
+   converter that emits native trellis must re-read the spec and confirm the
+   `trellis` key survived.
+3. **`pivot-table` / `table`** never trellis via the `trellis` key. For a pivot,
+   the element's own `rowsBy`/`columnsBy` cross-tab shelves already provide the
+   equivalent small-multiples layout.
+
+## Converter guidance
+
+**Emit native `trellis` (`rowsBy` / `columnsBy` / both) for these kinds only:**
+
+- `bar-chart` (including `stacking: stacked` / `normalized`)
+- `line-chart`
+- `area-chart`
+- `combo-chart`
+- `scatter-chart` (trellis round-trips; verify the grouping/render separately)
+- `donut-chart`
+
+For those, translate a source-tool small-multiples / trellis / "by" facet to a
+**single** viz element with the facet dimension added as a column and
+`trellis.rowsBy` (vertical) or `trellis.columnsBy` (horizontal), using
+`{ "columnId": "<facet-col-id>" }`. A 2-D facet maps to both keys pointing at
+two distinct columns.
+
+**Do NOT emit `trellis` for these — it is accepted but silently dropped:**
+
+| Kind | What to do instead |
+|------|--------------------|
+| `pie-chart` | Prefer emitting a **`donut-chart`** when the source is a faceted pie (donut trellises natively). If a pie is mandatory, **keep it flat** and route the faceting to a **post-publish** step (build the small-multiples in the editor), or replicate one element per member in layout. |
+| `kpi-chart` | Keep flat. For "one KPI per category," fan out to **N sibling KPI elements** (one per member) in the layout instead of a single trellised KPI — there is no native KPI trellis. |
+| `pivot-table` | Use the pivot's **own** `rowsBy`/`columnsBy` cross-tab shelves (keyed on `id`) — that is the native equivalent; do not add a separate `trellis` key. |
+| `table` | Keep flat, or model the facet as an extra grouping/row dimension. No native table trellis. |
+
+**Always confirm the round-trip.** Because unsupported kinds return `200` and
+drop the key, the emit path should GET the spec back after create and assert the
+`trellis` key is present on the element before treating the native trellis as
+applied; if it was stripped, fall back to the post-publish route above.
+
+## Neutral reference example
+
+Source table `Master` with `Category` (3 members: Region A / B / C), `Sub-Region`
+(x-axis dimension) and `Revenue` (measure). A vertically trellised bar chart:
+
+```jsonc
+{
+  "id": "el-revenue-by-subregion",
+  "kind": "bar-chart",
+  "source": { "elementId": "master", "kind": "table" },
+  "columns": [
+    { "id": "c-cat", "formula": "[Master/Category]",   "name": "Category" },
+    { "id": "c-x",   "formula": "[Master/Sub-Region]", "name": "Sub-Region" },
+    { "id": "c-y",   "formula": "Sum([Master/Revenue])", "name": "Revenue" }
+  ],
+  "xAxis": { "columnId": "c-x" },
+  "yAxis": { "columnIds": ["c-y"] },
+  "trellis": { "rowsBy": [ { "columnId": "c-cat" } ] }
+}
+```
+
+Swap `rowsBy` → `columnsBy` for horizontal small-multiples, or supply both
+(pointing at two different columns) for a 2-D grid.

--- a/sigma-workbooks/reference/specification/charts.md
+++ b/sigma-workbooks/reference/specification/charts.md
@@ -281,7 +281,7 @@ Chart-wide fallbacks `barStyle`, `lineAreaStyle`, `pointStyle`, and `gap` also e
 Each of these is a top-level key on cartesian charts; one-liner here, full sub-fields via the kind recipe at the top of this file.
 
 - `orientation: horizontal` on `bar-chart` — horizontal bars. Omit for the default vertical bars.
-- `trellis: { column, row, share?, tileSize? }` — **styles a UI-configured trellis only.** `tileSize` and the `column`/`row` guide styling (`labels`, `border`, `title`) round-trip, but the facet *column binding* cannot be set via spec — `columnId`/`id` inside `column`/`row` are silently stripped (live-verified 2026-06-11). Configure the facets in the editor; the spec can then style them.
+- `trellis: { rowsBy | columnsBy: [{ columnId }] }` — **native small multiples / faceting, authorable from spec** (see the "Trellis / small multiples" section below). This is the `rowsBy`/`columnsBy` form. Do NOT confuse it with the legacy `trellis: { column, row, share?, tileSize? }` *styling* object, which only styles a UI-configured trellis and whose facet `columnId`/`id` binding is silently stripped — use `rowsBy`/`columnsBy` to bind the facet from spec.
 - `legend: { visibility, position, ... }` — legend placement and styling.
 - `tooltip: { columnNames?, multiSeries?, valueFormat? }` — hover-tooltip content. Support is config-dependent (live-verified 2026-06-11): `columnNames` round-trips broadly; `multiSeries` round-trips on line charts but is silently stripped on bar-with-color; `valueFormat` is rejected or stripped in most configurations. Verify the readback after setting anything beyond `columnNames`.
 
@@ -324,6 +324,63 @@ The correct shape binds the scatter to a **grouping**: source a table element th
 ```
 
 `color` always takes the `{ by: single|category|scale, column, ... }` form (see "Bar chart with custom category colors") — a bare `{ id }` / `{ columnId }` is rejected. **Validate a scatter by querying it for >1 distinct x**, not by POST status alone.
+
+## Trellis / small multiples
+
+A **trellis** (small multiples) repeats the same viz once per member of a categorical dimension. Sigma authors this natively from spec with the element-level `trellis` property — **ONE viz element**, the facet dimension added as a `columns[]` entry, and `rowsBy` / `columnsBy` pointing at that column by `columnId`. Do **not** clone one element per member.
+
+```jsonc
+{
+  "id": "el-revenue-by-subregion",
+  "kind": "bar-chart",
+  "source": { "kind": "table", "elementId": "master" },
+  "columns": [
+    { "id": "c-cat", "name": "Region",     "formula": "[Master/Region]" },
+    { "id": "c-x",   "name": "Sub-Region", "formula": "[Master/Sub-Region]" },
+    { "id": "c-y",   "name": "Revenue",    "formula": "Sum([Master/Revenue])" }
+  ],
+  "xAxis": { "columnId": "c-x" },
+  "yAxis": { "columnIds": ["c-y"] },
+  "trellis": { "rowsBy": [ { "columnId": "c-cat" } ] }
+}
+```
+
+With a 3-member `Region` (Region A / Region B / Region C), this renders one bar panel per region, stacked in rows.
+
+- `rowsBy` alone → **vertical** small multiples (panels stacked in rows).
+- `columnsBy` alone → **horizontal** small multiples (panels side by side).
+- **both**, pointing at **two different** columns → a **2-D grid** (rows × columns).
+- The facet reference key is **`columnId`** (a `columns[]` id on the element). This is a different mechanism from the `pivot-table`'s own `rowsBy`/`columnsBy` cross-tab shelves, which key on `id`.
+
+### Supported chart kinds (emit `trellis` for these only)
+
+The native `trellis` key round-trips (survives readback and renders faceted) on exactly these kinds:
+
+| Kind | Trellis |
+|------|---------|
+| `bar-chart` (incl. `stacking: stacked` / `normalized`) | ✅ supported |
+| `line-chart` | ✅ supported |
+| `area-chart` | ✅ supported |
+| `combo-chart` | ✅ supported |
+| `scatter-chart` | ✅ key round-trips (validate the grouping/render separately — see the Scatter section) |
+| `donut-chart` | ✅ supported (one donut per member) |
+| `pie-chart` | ❌ **stripped** → emit a `donut-chart` instead |
+| `kpi-chart` | ❌ stripped → fan out to N sibling KPI elements |
+| `pivot-table` | ❌ stripped → use the pivot's own `rowsBy`/`columnsBy` shelves |
+| `table` | ❌ stripped → keep flat / model the facet as a grouping |
+
+The empirical coverage matrix (how each kind was verified live, POST + readback + render) is the source of truth: **`docs/sigma-trellis-chart-support.md`**.
+
+### Fallbacks for the unsupported kinds
+
+- **`pie-chart` → `donut-chart`.** Pie and donut are both circular (`value` + `color`), but only donut trellises. If the intent is a faceted pie, emit a `donut-chart` with the same `trellis`.
+- **`kpi-chart` → N sibling KPIs.** There is no native KPI trellis. For "one KPI per category," lay out N separate `kpi-chart` elements, one filtered to each member.
+- **`pivot-table` → its own shelves.** The pivot's element-level `rowsBy`/`columnsBy` cross-tab shelves (keyed on `id`) already are the native faceting — do not add a separate `trellis` key.
+- **`table` → keep flat** or add the facet as an extra grouping/row dimension.
+
+### ⚠️ Silent-stripping caveat — ALWAYS re-read and verify
+
+Sigma returns **`200` on POST even for the unsupported kinds**, then **silently drops the `trellis` key** on readback and renders a single un-faceted chart — no error. **POST success is NOT proof the trellis applied.** Any spec that emits a native `trellis` must GET the workbook spec back after create and assert the element still carries its `trellis` key (with the same axis) before treating the trellis as applied; if it was stripped, fall back to the routes above. (Converters do this with a round-trip survival guard.)
 
 ## Other chart kinds
 


### PR DESCRIPTION
## What & why

The native single-element **trellis** recipe (`trellis: { rowsBy | columnsBy: [{ columnId }] }`) had landed only in the **migration marketplace's vendored copy** of this skill (`twells89/sigma-migration-skills` #460/#462/#463 + the `shared/lib/trellis_emit.rb` emitter), **not here in the canonical repo**. Since `sigma-authoring/SYNC.md` re-vendors from *this* repo, a re-vendor would **clobber** the marketplace recipe with this repo's stale "trellis binding is UI-only" text. This back-ports the shapes so the source of truth is correct and they survive any re-vendor.

Verified byte-identical to the marketplace's version.

## Changes
- `sigma-workbooks/reference/specification/charts.md`
  - Replace the stale `trellis: { column, row, … }` "styles a UI-configured trellis only / binding can't be set via spec" bullet with the native `trellis: { rowsBy | columnsBy: [{ columnId }] }` form.
  - Add a **"Trellis / small multiples"** section: recipe (one element, facet as a `columns[]` entry, `rowsBy`/`columnsBy` by `columnId`), supported-kinds matrix (bar/line/area/combo/scatter/donut ✅; pie/kpi/pivot/table ❌ + fallbacks), and the **silent-stripping round-trip survival guard** (POST 200 ≠ applied).
- `sigma-workbooks/docs/sigma-trellis-chart-support.md` (new) — the empirical per-kind coverage matrix (how each kind was verified live: POST + readback + render).

## Notes
- Docs-only; no SKILL.md change, so the generated agent variants stay in sync.
- Follow-up in the marketplace: re-vendor `sigma-authoring/sigma-workbooks` from this repo once merged (so the vendored copy is backed by the SoT again).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
