### PR TITLE
scrub: genericize test-org identifiers in examples (public-repo hygiene)

### DIFF
--- a/custom-sql-to-data-model/SKILL.md
+++ b/custom-sql-to-data-model/SKILL.md
@@ -78,11 +78,11 @@ Each entry:
 {
   "workbook_id":   "25e21c63-...",
   "workbook_name": "Custom Sql Test",
-  "folder_id":     "57e59735-...",
+  "folder_id":     "fe98dc76-...",
   "element_id":    "6YSI-SjSmz",
   "element_name":  "Customer Dim SQL",
-  "connection_id": "cb2f5180-...",
-  "sql":           "select * from CSA.TJ.CUSTOMER_DIM",
+  "connection_id": "ab12cd34-...",
+  "sql":           "select * from DEMO_DB.DEMO.CUSTOMER_DIM",
   "column_count":  18
 }
 ```
@@ -130,7 +130,7 @@ Writes `swap-plan.json` to the system temp dir (`Dir.tmpdir`). The planner:
 
 ```
 [REUSE] group 1: 3 occurrence(s)
-  SQL: select * from csa.tj.customer_dim
+  SQL: select * from demo_db.demo.customer_dim
     - Custom Sql Test / Custom Sql Test SQL (6YSI-SjSmz)
     - Dedup Test Alpha / Customer Source  (el-customers)
     - Dedup Test Beta  / Customer Source  (el-customers-dup)
@@ -139,7 +139,7 @@ Writes `swap-plan.json` to the system temp dir (`Dir.tmpdir`). The planner:
 [BUILD] group 2: 1 occurrence(s)
   SQL: with monthly as ( select employee_id, date_trunc('month', date) as month, …
     - Dedup Test Alpha / OT Summary (el-ot-summary)
-  -> needs new DM (connection cb2f5180-..., folder 57e59735-...)
+  -> needs new DM (connection ab12cd34-..., folder fe98dc76-...)
 
 Summary: 3 unique SQL strings → 1 reuse, 2 build. 5 total swap actions.
 ```

--- a/custom-sql-to-data-model/generated/cline/custom-sql-to-data-model.md
+++ b/custom-sql-to-data-model/generated/cline/custom-sql-to-data-model.md
@@ -55,11 +55,11 @@ Each entry:
 {
   "workbook_id":   "25e21c63-...",
   "workbook_name": "Custom Sql Test",
-  "folder_id":     "57e59735-...",
+  "folder_id":     "fe98dc76-...",
   "element_id":    "6YSI-SjSmz",
   "element_name":  "Customer Dim SQL",
-  "connection_id": "cb2f5180-...",
-  "sql":           "select * from CSA.TJ.CUSTOMER_DIM",
+  "connection_id": "ab12cd34-...",
+  "sql":           "select * from DEMO_DB.DEMO.CUSTOMER_DIM",
   "column_count":  18
 }
 ```
@@ -107,7 +107,7 @@ Writes `/tmp/swap-plan.json`. The planner:
 
 ```
 [REUSE] group 1: 3 occurrence(s)
-  SQL: select * from csa.tj.customer_dim
+  SQL: select * from demo_db.demo.customer_dim
     - Custom Sql Test / Custom Sql Test SQL (6YSI-SjSmz)
     - Dedup Test Alpha / Customer Source  (el-customers)
     - Dedup Test Beta  / Customer Source  (el-customers-dup)
@@ -116,7 +116,7 @@ Writes `/tmp/swap-plan.json`. The planner:
 [BUILD] group 2: 1 occurrence(s)
   SQL: with monthly as ( select employee_id, date_trunc('month', date) as month, …
     - Dedup Test Alpha / OT Summary (el-ot-summary)
-  -> needs new DM (connection cb2f5180-..., folder 57e59735-...)
+  -> needs new DM (connection ab12cd34-..., folder fe98dc76-...)
 
 Summary: 3 unique SQL strings → 1 reuse, 2 build. 5 total swap actions.
 ```

--- a/custom-sql-to-data-model/generated/codex/AGENTS.md
+++ b/custom-sql-to-data-model/generated/codex/AGENTS.md
@@ -55,11 +55,11 @@ Each entry:
 {
   "workbook_id":   "25e21c63-...",
   "workbook_name": "Custom Sql Test",
-  "folder_id":     "57e59735-...",
+  "folder_id":     "fe98dc76-...",
   "element_id":    "6YSI-SjSmz",
   "element_name":  "Customer Dim SQL",
-  "connection_id": "cb2f5180-...",
-  "sql":           "select * from CSA.TJ.CUSTOMER_DIM",
+  "connection_id": "ab12cd34-...",
+  "sql":           "select * from DEMO_DB.DEMO.CUSTOMER_DIM",
   "column_count":  18
 }
 ```
@@ -107,7 +107,7 @@ Writes `/tmp/swap-plan.json`. The planner:
 
 ```
 [REUSE] group 1: 3 occurrence(s)
-  SQL: select * from csa.tj.customer_dim
+  SQL: select * from demo_db.demo.customer_dim
     - Custom Sql Test / Custom Sql Test SQL (6YSI-SjSmz)
     - Dedup Test Alpha / Customer Source  (el-customers)
     - Dedup Test Beta  / Customer Source  (el-customers-dup)
@@ -116,7 +116,7 @@ Writes `/tmp/swap-plan.json`. The planner:
 [BUILD] group 2: 1 occurrence(s)
   SQL: with monthly as ( select employee_id, date_trunc('month', date) as month, …
     - Dedup Test Alpha / OT Summary (el-ot-summary)
-  -> needs new DM (connection cb2f5180-..., folder 57e59735-...)
+  -> needs new DM (connection ab12cd34-..., folder fe98dc76-...)
 
 Summary: 3 unique SQL strings → 1 reuse, 2 build. 5 total swap actions.
 ```

--- a/custom-sql-to-data-model/generated/continue/custom-sql-to-data-model.md
+++ b/custom-sql-to-data-model/generated/continue/custom-sql-to-data-model.md
@@ -55,11 +55,11 @@ Each entry:
 {
   "workbook_id":   "25e21c63-...",
   "workbook_name": "Custom Sql Test",
-  "folder_id":     "57e59735-...",
+  "folder_id":     "fe98dc76-...",
   "element_id":    "6YSI-SjSmz",
   "element_name":  "Customer Dim SQL",
-  "connection_id": "cb2f5180-...",
-  "sql":           "select * from CSA.TJ.CUSTOMER_DIM",
+  "connection_id": "ab12cd34-...",
+  "sql":           "select * from DEMO_DB.DEMO.CUSTOMER_DIM",
   "column_count":  18
 }
 ```
@@ -107,7 +107,7 @@ Writes `/tmp/swap-plan.json`. The planner:
 
 ```
 [REUSE] group 1: 3 occurrence(s)
-  SQL: select * from csa.tj.customer_dim
+  SQL: select * from demo_db.demo.customer_dim
     - Custom Sql Test / Custom Sql Test SQL (6YSI-SjSmz)
     - Dedup Test Alpha / Customer Source  (el-customers)
     - Dedup Test Beta  / Customer Source  (el-customers-dup)
@@ -116,7 +116,7 @@ Writes `/tmp/swap-plan.json`. The planner:
 [BUILD] group 2: 1 occurrence(s)
   SQL: with monthly as ( select employee_id, date_trunc('month', date) as month, …
     - Dedup Test Alpha / OT Summary (el-ot-summary)
-  -> needs new DM (connection cb2f5180-..., folder 57e59735-...)
+  -> needs new DM (connection ab12cd34-..., folder fe98dc76-...)
 
 Summary: 3 unique SQL strings → 1 reuse, 2 build. 5 total swap actions.
 ```

--- a/custom-sql-to-data-model/generated/cursor/rules/custom-sql-to-data-model.mdc
+++ b/custom-sql-to-data-model/generated/cursor/rules/custom-sql-to-data-model.mdc
@@ -60,11 +60,11 @@ Each entry:
 {
   "workbook_id":   "25e21c63-...",
   "workbook_name": "Custom Sql Test",
-  "folder_id":     "57e59735-...",
+  "folder_id":     "fe98dc76-...",
   "element_id":    "6YSI-SjSmz",
   "element_name":  "Customer Dim SQL",
-  "connection_id": "cb2f5180-...",
-  "sql":           "select * from CSA.TJ.CUSTOMER_DIM",
+  "connection_id": "ab12cd34-...",
+  "sql":           "select * from DEMO_DB.DEMO.CUSTOMER_DIM",
   "column_count":  18
 }
 ```
@@ -112,7 +112,7 @@ Writes `/tmp/swap-plan.json`. The planner:
 
 ```
 [REUSE] group 1: 3 occurrence(s)
-  SQL: select * from csa.tj.customer_dim
+  SQL: select * from demo_db.demo.customer_dim
     - Custom Sql Test / Custom Sql Test SQL (6YSI-SjSmz)
     - Dedup Test Alpha / Customer Source  (el-customers)
     - Dedup Test Beta  / Customer Source  (el-customers-dup)
@@ -121,7 +121,7 @@ Writes `/tmp/swap-plan.json`. The planner:
 [BUILD] group 2: 1 occurrence(s)
   SQL: with monthly as ( select employee_id, date_trunc('month', date) as month, …
     - Dedup Test Alpha / OT Summary (el-ot-summary)
-  -> needs new DM (connection cb2f5180-..., folder 57e59735-...)
+  -> needs new DM (connection ab12cd34-..., folder fe98dc76-...)
 
 Summary: 3 unique SQL strings → 1 reuse, 2 build. 5 total swap actions.
 ```

--- a/sigma-workbooks/reference/workflows/from-image.md
+++ b/sigma-workbooks/reference/workflows/from-image.md
@@ -43,7 +43,7 @@ Example: image shows "Gross Margin by Customer Value Tier (Bronze / Silver / Gol
 
 ### Step 0d.1 — Verify each dimension picked is the *right shape*
 
-A common failure: the agent sees "Ship Speed Category" in the target image (four bars labeled Economy / Express / Slow / Standard), grabs the first categorical-looking column in the available data (e.g. `product_brand` with hundreds of values), and ends up with a bar chart that has 200 unreadable rotated labels.
+A common failure: the agent sees "Delivery Speed Tier" in the target image (four bars labeled Economy / Express / Slow / Standard), grabs the first categorical-looking column in the available data (e.g. `product_brand` with hundreds of values), and ends up with a bar chart that has 200 unreadable rotated labels.
 
 Before drafting, for each dimension you picked, sanity-check two things:
 


### PR DESCRIPTION
Replaces the tj-wells-1989 CSA demo org's identifiers in examples with generic placeholders — so the public repo doesn't expose org-specific IDs and the migration marketplace can re-vendor these skills cleanly through its hygiene gate. custom-sql-to-data-model (SKILL.md + 4 generated variants): `CSA.TJ.CUSTOMER_DIM`→`DEMO_DB.DEMO.CUSTOMER_DIM`, connection `cb2f5180…`→`ab12cd34…`, folder `57e59735…`→`fe98dc76…`. from-image.md: "Ship Speed Category"→"Delivery Speed Tier". Placeholders match the marketplace's existing scrub. Docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)