### PR TITLE
docs(sigma-workbooks): comparative KPI cards as the house default

### DIFF
--- a/sigma-workbooks/SKILL.md
+++ b/sigma-workbooks/SKILL.md
@@ -223,7 +223,7 @@ The reference is feature-sliced — don't read every file up-front. The index ha
 | `reference/specification/tables.md` | Table element, tabular data, data grid, spreadsheet-style list. Also element-level filters (top N, limit, rank), groupings (pivot, group by), the `pivot-table` and editable `input-table` element kinds, and `conditionalFormats` (threshold-based cell coloring, on pivot/input tables). |
 | `reference/specification/charts.md` | Chart, graph, visualization, line / bar / column / stacked / grouped / combo / donut / pie / scatter / share-of / breakdown. Cartesian axes, color channel, trellis, trendlines, reference marks. |
 | `reference/specification/maps.md` | Map visualizations — `geography-map` (GeoJSON shapes), `point-map` (lat/long bubbles), `region-map` (states / counties / countries). |
-| `reference/specification/kpis.md` | KPI, stat, big number, single value, metric card — including layout / value styling, the period-over-period formula recipe, and the spec limits of the comparison / trend-sparkline blocks (UI-bound). |
+| `reference/specification/kpis.md` | KPI, stat, big number, single value, metric card — including layout / value styling, the comparison Δ badge (`comparisonColumn` + `comparison:{display:"delta"}` — spec-authorable and readback-stable; the house default), and the trend/sparkline block (still UI-bound). |
 | `reference/specification/controls.md` | Filter, dropdown, picker, multi-select, date range, date picker, text filter, number range, slider, segmented, hierarchy. |
 | `reference/specification/content-elements.md` | The non-data elements — `text` (Markdown + inline styling), `image`, `divider`, `embed` (external URLs). Titles, callouts, logos, rules, embedded content. |
 | `reference/specification/input-tables.md` | Operational supplement for `input-table` (spec shape lives in `tables.md`): write-connection requirement, the publish gate, reading data back via warehouse views, element endpoints for auditing, and migration patterns (Excel/planning models). |
@@ -245,6 +245,7 @@ The reference is feature-sliced — don't read every file up-front. The index ha
 | `reference/specification/formatting.md` | Format, currency, percentage, date format, decimals — column formatting. |
 | `reference/specification/layout.md` | **Always load for multi-element workbooks.** Layout XML, GridContainer/LayoutElement, container elements, page visibility / background, auto-arrange fallback rules, when to write explicit layout vs. omit. |
 | `reference/specification/example-full.yaml` | A real multi-page reference spec (KPIs, charts, joins, controls, layout) — copy shapes from when in doubt. |
+| `reference/specification/comparative-kpi-card.yaml` | Minimal clone-able comparative KPI card — `value` + `comparisonColumn` + `comparison:{display:"delta"}`, the house-default comparative shape (see `kpis.md`). |
 
 ### Workflows
 

--- a/sigma-workbooks/generated/cline/sigma-workbooks.md
+++ b/sigma-workbooks/generated/cline/sigma-workbooks.md
@@ -48,6 +48,16 @@ jq --arg k bar-chart 'first(.. | objects | select((.allOf? and any(.allOf[]?; .p
 
 `WebFetch` works for the JSON too. Either path is fine.
 
+No `curl`/`jq` on the machine (e.g. Windows without WSL)? `scripts/wb-rep.rb`
+ships a `capabilities` subcommand that does the same three queries with
+pure-Ruby `Net::HTTP` + `JSON.parse` — no external tools required:
+
+```bash
+ruby scripts/wb-rep.rb capabilities                          # list every kind
+ruby scripts/wb-rep.rb capabilities --kind bar-chart          # field list for one kind
+ruby scripts/wb-rep.rb capabilities --kind bar-chart --field source  # one field's shape
+```
+
 **Why bother:** the API ships new fields and viz configurations regularly, and this skill covers the common surface, not every field. If you want a capability and don't see it documented here, **assume it may exist and check the spec before concluding it doesn't** — the `kind` query above answers in seconds.
 
 ## Auth
@@ -164,6 +174,8 @@ If any element reports `[FAIL]`, fix the column formulas in the spec (most often
 
 After initial creation, use `PUT /v2/workbooks/<id>/spec` to add pages or refine the workbook.
 
+**For anything beyond ~1 page / ~10 elements, switch to the element rep** (`reference/workflows/element-rep.md`): `scripts/wb-rep.rb pull <id> <dir>` explodes the spec into one file per element so each edit touches a ~½KB file instead of the whole spec, `push` handles drift-check + validation + PUT, and `render` exports page PNGs you can actually look at. The raw GET/PUT flow below remains fine for small workbooks and one-off tweaks.
+
 > **IDs are preserved on CREATE.** The `id` values you POST (pages, elements, columns) are kept verbatim, and `layout` `elementId` references stay valid — so you can edit your saved spec and `PUT` it back directly. `GET` the current spec first only if you don't have your latest copy. See `reference/workflows/crud.md`.
 
 ```bash
@@ -204,7 +216,7 @@ The reference is feature-sliced — don't read every file up-front. The index ha
 | `reference/specification/tables.md` | Table element, tabular data, data grid, spreadsheet-style list. Also element-level filters (top N, limit, rank), groupings (pivot, group by), the `pivot-table` and editable `input-table` element kinds, and `conditionalFormats` (threshold-based cell coloring, on pivot/input tables). |
 | `reference/specification/charts.md` | Chart, graph, visualization, line / bar / column / stacked / grouped / combo / donut / pie / scatter / share-of / breakdown. Cartesian axes, color channel, trellis, trendlines, reference marks. |
 | `reference/specification/maps.md` | Map visualizations — `geography-map` (GeoJSON shapes), `point-map` (lat/long bubbles), `region-map` (states / counties / countries). |
-| `reference/specification/kpis.md` | KPI, stat, big number, single value, metric card — including layout / value styling, the period-over-period formula recipe, and the spec limits of the comparison / trend-sparkline blocks (UI-bound). |
+| `reference/specification/kpis.md` | KPI, stat, big number, single value, metric card — including layout / value styling, the comparison Δ badge (`comparisonColumn` + `comparison:{display:"delta"}` — spec-authorable and readback-stable; the house default), and the trend/sparkline block (still UI-bound). |
 | `reference/specification/controls.md` | Filter, dropdown, picker, multi-select, date range, date picker, text filter, number range, slider, segmented, hierarchy. |
 | `reference/specification/content-elements.md` | The non-data elements — `text` (Markdown + inline styling), `image`, `divider`, `embed` (external URLs). Titles, callouts, logos, rules, embedded content. |
 | `reference/specification/input-tables.md` | Operational supplement for `input-table` (spec shape lives in `tables.md`): write-connection requirement, the publish gate, reading data back via warehouse views, element endpoints for auditing, and migration patterns (Excel/planning models). |
@@ -226,6 +238,7 @@ The reference is feature-sliced — don't read every file up-front. The index ha
 | `reference/specification/formatting.md` | Format, currency, percentage, date format, decimals — column formatting. |
 | `reference/specification/layout.md` | **Always load for multi-element workbooks.** Layout XML, GridContainer/LayoutElement, container elements, page visibility / background, auto-arrange fallback rules, when to write explicit layout vs. omit. |
 | `reference/specification/example-full.yaml` | A real multi-page reference spec (KPIs, charts, joins, controls, layout) — copy shapes from when in doubt. |
+| `reference/specification/comparative-kpi-card.yaml` | Minimal clone-able comparative KPI card — `value` + `comparisonColumn` + `comparison:{display:"delta"}`, the house-default comparative shape (see `kpis.md`). |
 
 ### Workflows
 
@@ -236,6 +249,7 @@ The reference is feature-sliced — don't read every file up-front. The index ha
 | `reference/workflows/crud.md` | POST / GET / PUT against the workbook spec endpoints. Load when creating, retrieving, or updating a workbook. |
 | `reference/workflows/validate.md` | Pre-submit + post-create validation. Load before any POST or PUT. |
 | `reference/workflows/from-image.md` | The user supplied a target image (screenshot, mockup, BI-tool export) to reproduce. Load *before* discovery — it adds explicit observation and validation steps. |
+| `reference/workflows/element-rep.md` | **Large or multi-page workbooks, parallel element work, or iterative refinement.** `scripts/wb-rep.rb` explodes the spec into one small file per element (pull/status/push/render) so edits never drag the whole spec through context — element-level semantics over the whole-spec API, plus PNG renders to inspect what you built. |
 
 ## Quick Formula Rules
 

--- a/sigma-workbooks/generated/codex/AGENTS.md
+++ b/sigma-workbooks/generated/codex/AGENTS.md
@@ -48,6 +48,16 @@ jq --arg k bar-chart 'first(.. | objects | select((.allOf? and any(.allOf[]?; .p
 
 `WebFetch` works for the JSON too. Either path is fine.
 
+No `curl`/`jq` on the machine (e.g. Windows without WSL)? `scripts/wb-rep.rb`
+ships a `capabilities` subcommand that does the same three queries with
+pure-Ruby `Net::HTTP` + `JSON.parse` — no external tools required:
+
+```bash
+ruby scripts/wb-rep.rb capabilities                          # list every kind
+ruby scripts/wb-rep.rb capabilities --kind bar-chart          # field list for one kind
+ruby scripts/wb-rep.rb capabilities --kind bar-chart --field source  # one field's shape
+```
+
 **Why bother:** the API ships new fields and viz configurations regularly, and this skill covers the common surface, not every field. If you want a capability and don't see it documented here, **assume it may exist and check the spec before concluding it doesn't** — the `kind` query above answers in seconds.
 
 ## Auth
@@ -164,6 +174,8 @@ If any element reports `[FAIL]`, fix the column formulas in the spec (most often
 
 After initial creation, use `PUT /v2/workbooks/<id>/spec` to add pages or refine the workbook.
 
+**For anything beyond ~1 page / ~10 elements, switch to the element rep** (`reference/workflows/element-rep.md`): `scripts/wb-rep.rb pull <id> <dir>` explodes the spec into one file per element so each edit touches a ~½KB file instead of the whole spec, `push` handles drift-check + validation + PUT, and `render` exports page PNGs you can actually look at. The raw GET/PUT flow below remains fine for small workbooks and one-off tweaks.
+
 > **IDs are preserved on CREATE.** The `id` values you POST (pages, elements, columns) are kept verbatim, and `layout` `elementId` references stay valid — so you can edit your saved spec and `PUT` it back directly. `GET` the current spec first only if you don't have your latest copy. See `reference/workflows/crud.md`.
 
 ```bash
@@ -204,7 +216,7 @@ The reference is feature-sliced — don't read every file up-front. The index ha
 | `reference/specification/tables.md` | Table element, tabular data, data grid, spreadsheet-style list. Also element-level filters (top N, limit, rank), groupings (pivot, group by), the `pivot-table` and editable `input-table` element kinds, and `conditionalFormats` (threshold-based cell coloring, on pivot/input tables). |
 | `reference/specification/charts.md` | Chart, graph, visualization, line / bar / column / stacked / grouped / combo / donut / pie / scatter / share-of / breakdown. Cartesian axes, color channel, trellis, trendlines, reference marks. |
 | `reference/specification/maps.md` | Map visualizations — `geography-map` (GeoJSON shapes), `point-map` (lat/long bubbles), `region-map` (states / counties / countries). |
-| `reference/specification/kpis.md` | KPI, stat, big number, single value, metric card — including layout / value styling, the period-over-period formula recipe, and the spec limits of the comparison / trend-sparkline blocks (UI-bound). |
+| `reference/specification/kpis.md` | KPI, stat, big number, single value, metric card — including layout / value styling, the comparison Δ badge (`comparisonColumn` + `comparison:{display:"delta"}` — spec-authorable and readback-stable; the house default), and the trend/sparkline block (still UI-bound). |
 | `reference/specification/controls.md` | Filter, dropdown, picker, multi-select, date range, date picker, text filter, number range, slider, segmented, hierarchy. |
 | `reference/specification/content-elements.md` | The non-data elements — `text` (Markdown + inline styling), `image`, `divider`, `embed` (external URLs). Titles, callouts, logos, rules, embedded content. |
 | `reference/specification/input-tables.md` | Operational supplement for `input-table` (spec shape lives in `tables.md`): write-connection requirement, the publish gate, reading data back via warehouse views, element endpoints for auditing, and migration patterns (Excel/planning models). |
@@ -226,6 +238,7 @@ The reference is feature-sliced — don't read every file up-front. The index ha
 | `reference/specification/formatting.md` | Format, currency, percentage, date format, decimals — column formatting. |
 | `reference/specification/layout.md` | **Always load for multi-element workbooks.** Layout XML, GridContainer/LayoutElement, container elements, page visibility / background, auto-arrange fallback rules, when to write explicit layout vs. omit. |
 | `reference/specification/example-full.yaml` | A real multi-page reference spec (KPIs, charts, joins, controls, layout) — copy shapes from when in doubt. |
+| `reference/specification/comparative-kpi-card.yaml` | Minimal clone-able comparative KPI card — `value` + `comparisonColumn` + `comparison:{display:"delta"}`, the house-default comparative shape (see `kpis.md`). |
 
 ### Workflows
 
@@ -236,6 +249,7 @@ The reference is feature-sliced — don't read every file up-front. The index ha
 | `reference/workflows/crud.md` | POST / GET / PUT against the workbook spec endpoints. Load when creating, retrieving, or updating a workbook. |
 | `reference/workflows/validate.md` | Pre-submit + post-create validation. Load before any POST or PUT. |
 | `reference/workflows/from-image.md` | The user supplied a target image (screenshot, mockup, BI-tool export) to reproduce. Load *before* discovery — it adds explicit observation and validation steps. |
+| `reference/workflows/element-rep.md` | **Large or multi-page workbooks, parallel element work, or iterative refinement.** `scripts/wb-rep.rb` explodes the spec into one small file per element (pull/status/push/render) so edits never drag the whole spec through context — element-level semantics over the whole-spec API, plus PNG renders to inspect what you built. |
 
 ## Quick Formula Rules
 

--- a/sigma-workbooks/generated/continue/sigma-workbooks.md
+++ b/sigma-workbooks/generated/continue/sigma-workbooks.md
@@ -48,6 +48,16 @@ jq --arg k bar-chart 'first(.. | objects | select((.allOf? and any(.allOf[]?; .p
 
 `WebFetch` works for the JSON too. Either path is fine.
 
+No `curl`/`jq` on the machine (e.g. Windows without WSL)? `scripts/wb-rep.rb`
+ships a `capabilities` subcommand that does the same three queries with
+pure-Ruby `Net::HTTP` + `JSON.parse` — no external tools required:
+
+```bash
+ruby scripts/wb-rep.rb capabilities                          # list every kind
+ruby scripts/wb-rep.rb capabilities --kind bar-chart          # field list for one kind
+ruby scripts/wb-rep.rb capabilities --kind bar-chart --field source  # one field's shape
+```
+
 **Why bother:** the API ships new fields and viz configurations regularly, and this skill covers the common surface, not every field. If you want a capability and don't see it documented here, **assume it may exist and check the spec before concluding it doesn't** — the `kind` query above answers in seconds.
 
 ## Auth
@@ -164,6 +174,8 @@ If any element reports `[FAIL]`, fix the column formulas in the spec (most often
 
 After initial creation, use `PUT /v2/workbooks/<id>/spec` to add pages or refine the workbook.
 
+**For anything beyond ~1 page / ~10 elements, switch to the element rep** (`reference/workflows/element-rep.md`): `scripts/wb-rep.rb pull <id> <dir>` explodes the spec into one file per element so each edit touches a ~½KB file instead of the whole spec, `push` handles drift-check + validation + PUT, and `render` exports page PNGs you can actually look at. The raw GET/PUT flow below remains fine for small workbooks and one-off tweaks.
+
 > **IDs are preserved on CREATE.** The `id` values you POST (pages, elements, columns) are kept verbatim, and `layout` `elementId` references stay valid — so you can edit your saved spec and `PUT` it back directly. `GET` the current spec first only if you don't have your latest copy. See `reference/workflows/crud.md`.
 
 ```bash
@@ -204,7 +216,7 @@ The reference is feature-sliced — don't read every file up-front. The index ha
 | `reference/specification/tables.md` | Table element, tabular data, data grid, spreadsheet-style list. Also element-level filters (top N, limit, rank), groupings (pivot, group by), the `pivot-table` and editable `input-table` element kinds, and `conditionalFormats` (threshold-based cell coloring, on pivot/input tables). |
 | `reference/specification/charts.md` | Chart, graph, visualization, line / bar / column / stacked / grouped / combo / donut / pie / scatter / share-of / breakdown. Cartesian axes, color channel, trellis, trendlines, reference marks. |
 | `reference/specification/maps.md` | Map visualizations — `geography-map` (GeoJSON shapes), `point-map` (lat/long bubbles), `region-map` (states / counties / countries). |
-| `reference/specification/kpis.md` | KPI, stat, big number, single value, metric card — including layout / value styling, the period-over-period formula recipe, and the spec limits of the comparison / trend-sparkline blocks (UI-bound). |
+| `reference/specification/kpis.md` | KPI, stat, big number, single value, metric card — including layout / value styling, the comparison Δ badge (`comparisonColumn` + `comparison:{display:"delta"}` — spec-authorable and readback-stable; the house default), and the trend/sparkline block (still UI-bound). |
 | `reference/specification/controls.md` | Filter, dropdown, picker, multi-select, date range, date picker, text filter, number range, slider, segmented, hierarchy. |
 | `reference/specification/content-elements.md` | The non-data elements — `text` (Markdown + inline styling), `image`, `divider`, `embed` (external URLs). Titles, callouts, logos, rules, embedded content. |
 | `reference/specification/input-tables.md` | Operational supplement for `input-table` (spec shape lives in `tables.md`): write-connection requirement, the publish gate, reading data back via warehouse views, element endpoints for auditing, and migration patterns (Excel/planning models). |
@@ -226,6 +238,7 @@ The reference is feature-sliced — don't read every file up-front. The index ha
 | `reference/specification/formatting.md` | Format, currency, percentage, date format, decimals — column formatting. |
 | `reference/specification/layout.md` | **Always load for multi-element workbooks.** Layout XML, GridContainer/LayoutElement, container elements, page visibility / background, auto-arrange fallback rules, when to write explicit layout vs. omit. |
 | `reference/specification/example-full.yaml` | A real multi-page reference spec (KPIs, charts, joins, controls, layout) — copy shapes from when in doubt. |
+| `reference/specification/comparative-kpi-card.yaml` | Minimal clone-able comparative KPI card — `value` + `comparisonColumn` + `comparison:{display:"delta"}`, the house-default comparative shape (see `kpis.md`). |
 
 ### Workflows
 
@@ -236,6 +249,7 @@ The reference is feature-sliced — don't read every file up-front. The index ha
 | `reference/workflows/crud.md` | POST / GET / PUT against the workbook spec endpoints. Load when creating, retrieving, or updating a workbook. |
 | `reference/workflows/validate.md` | Pre-submit + post-create validation. Load before any POST or PUT. |
 | `reference/workflows/from-image.md` | The user supplied a target image (screenshot, mockup, BI-tool export) to reproduce. Load *before* discovery — it adds explicit observation and validation steps. |
+| `reference/workflows/element-rep.md` | **Large or multi-page workbooks, parallel element work, or iterative refinement.** `scripts/wb-rep.rb` explodes the spec into one small file per element (pull/status/push/render) so edits never drag the whole spec through context — element-level semantics over the whole-spec API, plus PNG renders to inspect what you built. |
 
 ## Quick Formula Rules
 

--- a/sigma-workbooks/generated/cursor/rules/sigma-workbooks.mdc
+++ b/sigma-workbooks/generated/cursor/rules/sigma-workbooks.mdc
@@ -53,6 +53,16 @@ jq --arg k bar-chart 'first(.. | objects | select((.allOf? and any(.allOf[]?; .p
 
 `WebFetch` works for the JSON too. Either path is fine.
 
+No `curl`/`jq` on the machine (e.g. Windows without WSL)? `scripts/wb-rep.rb`
+ships a `capabilities` subcommand that does the same three queries with
+pure-Ruby `Net::HTTP` + `JSON.parse` — no external tools required:
+
+```bash
+ruby scripts/wb-rep.rb capabilities                          # list every kind
+ruby scripts/wb-rep.rb capabilities --kind bar-chart          # field list for one kind
+ruby scripts/wb-rep.rb capabilities --kind bar-chart --field source  # one field's shape
+```
+
 **Why bother:** the API ships new fields and viz configurations regularly, and this skill covers the common surface, not every field. If you want a capability and don't see it documented here, **assume it may exist and check the spec before concluding it doesn't** — the `kind` query above answers in seconds.
 
 ## Auth
@@ -169,6 +179,8 @@ If any element reports `[FAIL]`, fix the column formulas in the spec (most often
 
 After initial creation, use `PUT /v2/workbooks/<id>/spec` to add pages or refine the workbook.
 
+**For anything beyond ~1 page / ~10 elements, switch to the element rep** (`reference/workflows/element-rep.md`): `scripts/wb-rep.rb pull <id> <dir>` explodes the spec into one file per element so each edit touches a ~½KB file instead of the whole spec, `push` handles drift-check + validation + PUT, and `render` exports page PNGs you can actually look at. The raw GET/PUT flow below remains fine for small workbooks and one-off tweaks.
+
 > **IDs are preserved on CREATE.** The `id` values you POST (pages, elements, columns) are kept verbatim, and `layout` `elementId` references stay valid — so you can edit your saved spec and `PUT` it back directly. `GET` the current spec first only if you don't have your latest copy. See `reference/workflows/crud.md`.
 
 ```bash
@@ -209,7 +221,7 @@ The reference is feature-sliced — don't read every file up-front. The index ha
 | `reference/specification/tables.md` | Table element, tabular data, data grid, spreadsheet-style list. Also element-level filters (top N, limit, rank), groupings (pivot, group by), the `pivot-table` and editable `input-table` element kinds, and `conditionalFormats` (threshold-based cell coloring, on pivot/input tables). |
 | `reference/specification/charts.md` | Chart, graph, visualization, line / bar / column / stacked / grouped / combo / donut / pie / scatter / share-of / breakdown. Cartesian axes, color channel, trellis, trendlines, reference marks. |
 | `reference/specification/maps.md` | Map visualizations — `geography-map` (GeoJSON shapes), `point-map` (lat/long bubbles), `region-map` (states / counties / countries). |
-| `reference/specification/kpis.md` | KPI, stat, big number, single value, metric card — including layout / value styling, the period-over-period formula recipe, and the spec limits of the comparison / trend-sparkline blocks (UI-bound). |
+| `reference/specification/kpis.md` | KPI, stat, big number, single value, metric card — including layout / value styling, the comparison Δ badge (`comparisonColumn` + `comparison:{display:"delta"}` — spec-authorable and readback-stable; the house default), and the trend/sparkline block (still UI-bound). |
 | `reference/specification/controls.md` | Filter, dropdown, picker, multi-select, date range, date picker, text filter, number range, slider, segmented, hierarchy. |
 | `reference/specification/content-elements.md` | The non-data elements — `text` (Markdown + inline styling), `image`, `divider`, `embed` (external URLs). Titles, callouts, logos, rules, embedded content. |
 | `reference/specification/input-tables.md` | Operational supplement for `input-table` (spec shape lives in `tables.md`): write-connection requirement, the publish gate, reading data back via warehouse views, element endpoints for auditing, and migration patterns (Excel/planning models). |
@@ -231,6 +243,7 @@ The reference is feature-sliced — don't read every file up-front. The index ha
 | `reference/specification/formatting.md` | Format, currency, percentage, date format, decimals — column formatting. |
 | `reference/specification/layout.md` | **Always load for multi-element workbooks.** Layout XML, GridContainer/LayoutElement, container elements, page visibility / background, auto-arrange fallback rules, when to write explicit layout vs. omit. |
 | `reference/specification/example-full.yaml` | A real multi-page reference spec (KPIs, charts, joins, controls, layout) — copy shapes from when in doubt. |
+| `reference/specification/comparative-kpi-card.yaml` | Minimal clone-able comparative KPI card — `value` + `comparisonColumn` + `comparison:{display:"delta"}`, the house-default comparative shape (see `kpis.md`). |
 
 ### Workflows
 
@@ -241,6 +254,7 @@ The reference is feature-sliced — don't read every file up-front. The index ha
 | `reference/workflows/crud.md` | POST / GET / PUT against the workbook spec endpoints. Load when creating, retrieving, or updating a workbook. |
 | `reference/workflows/validate.md` | Pre-submit + post-create validation. Load before any POST or PUT. |
 | `reference/workflows/from-image.md` | The user supplied a target image (screenshot, mockup, BI-tool export) to reproduce. Load *before* discovery — it adds explicit observation and validation steps. |
+| `reference/workflows/element-rep.md` | **Large or multi-page workbooks, parallel element work, or iterative refinement.** `scripts/wb-rep.rb` explodes the spec into one small file per element (pull/status/push/render) so edits never drag the whole spec through context — element-level semantics over the whole-spec API, plus PNG renders to inspect what you built. |
 
 ## Quick Formula Rules
 

--- a/sigma-workbooks/reference/specification/comparative-kpi-card.yaml
+++ b/sigma-workbooks/reference/specification/comparative-kpi-card.yaml
@@ -1,0 +1,78 @@
+# Comparative KPI card — clone-able exemplar.
+#
+# A minimal two-element spec: a source table exposing a current-period and a
+# prior-period numeric column, and a `kpi-chart` bound to both via `value` +
+# `comparisonColumn` + `comparison:{display:"delta"}` — the verified,
+# readback-stable shape (live-verified 2026-07-27; see kpis.md's `layout`,
+# `comparison`, and `trend` blocks section for the full write-up and
+# gotchas). This is the house default for any headline number on a
+# dashboard — reach for a second column/second KPI only when the two
+# numbers being compared don't share the same underlying scope (e.g.
+# genuinely different sources) and can't be expressed as one value + one
+# comparison column.
+#
+# Required top-level fields for POST /v2/workbooks/spec are name, folderId,
+# schemaVersion, pages (see reference/workflows/crud.md). Swap `folderId`
+# and the source's `connectionId` / `path` for your own before posting —
+# the element shapes below can be cloned as-is.
+
+name: Comparative KPI card example
+folderId: <your-folder-id>
+schemaVersion: 1
+pages:
+  - id: page-kpi-example
+    name: KPI example
+    elements:
+      - id: kpi-source
+        kind: table
+        source:
+          kind: warehouse-table
+          connectionId: <your-connection-id>
+          path:
+            - YOUR_DB
+            - YOUR_SCHEMA
+            - REVENUE_BY_PERIOD
+        columns:
+          - id: rev_current
+            formula: '[Current Revenue]'
+            name: Current Revenue
+            format:
+              kind: number
+              formatString: '$.3~s'
+          - id: rev_prior
+            formula: '[Prior Revenue]'
+            name: Prior Revenue
+            format:
+              kind: number
+              formatString: '$.3~s'
+        name: KPI Source
+      - id: kpi-revenue
+        kind: kpi-chart
+        name: Revenue
+        source:
+          kind: table
+          elementId: kpi-source
+        columns:
+          - id: rev_current
+            formula: '[KPI Source/Current Revenue]'
+            name: Current Revenue
+            format:
+              kind: number
+              formatString: '$.3~s'
+          - id: rev_prior
+            formula: '[KPI Source/Prior Revenue]'
+            name: Prior Revenue
+        value:
+          columnId: rev_current      # value.columnId, NOT value.id
+        comparisonColumn:
+          columnId: rev_prior
+        comparison:
+          display: delta
+          colorGood: '#1a7f37'
+          colorBad: '#cf222e'
+layout: |
+  <?xml version="1.0" encoding="utf-8"?>
+  <Page type="grid" gridTemplateColumns="repeat(24, 1fr)" gridTemplateRows="auto" id="page-kpi-example">
+    <LayoutElement elementId="kpi-revenue" gridColumn="1 / 9" gridRow="1 / 8"/>
+    <LayoutElement elementId="kpi-source" gridColumn="1 / 25" gridRow="8 / 20"/>
+  </Page>

--- a/sigma-workbooks/reference/specification/kpis.md
+++ b/sigma-workbooks/reference/specification/kpis.md
@@ -46,15 +46,21 @@ Run `./scripts/validate-spec.sh <spec.yaml>` before publishing to catch it.
 
 ## `layout`, `comparison`, and `trend` blocks
 
-The OpenAPI exposes three more kpi-chart objects; their spec-authoring support differs (live-verified 2026-06-11, re-verified 2026-06-24):
+The OpenAPI exposes three more kpi-chart objects; their spec-authoring support differs:
 
-- `layout` — **round-trips.** `{ anchor: start|middle|end, titleOrient: top|bottom, ... }` positions the card contents. Default values are omitted on readback.
-- `value` styling — **round-trips.** `fontSize` (number or `"auto"`), `color`; `fontWeight: bold` reads back omitted (it appears to be the default).
-- `comparison` and `trend` (sparkline) — **did not render from spec in this org / the current public API (verified 2026-06-24); treat as UI-bound here, possibly org/version-dependent.** The public OpenAPI exposes only their *formatting* fields (shape, colors, interpolation, label) — **neither block carries the date/series binding** that drives the sparkline or the period delta, and `kpi-chart` has no `groupings` or dimension field to supply one. In this org that binding is **UI-only state, and `GET /v2/workbooks/{id}/spec` does not surface it.** Safe path: build the KPI via spec, then bind the trend (date) and comparison in the editor; the spec carries formatting overrides on top. For a guaranteed spec-only period-over-period *figure*, use the formula-column recipe above.
+- `layout` — **round-trips.** `{ anchor: start|middle|end, titleOrient: top|bottom, ... }` positions the card contents. Default values are omitted on readback. (live-verified 2026-06-11, re-verified 2026-06-24)
+- `value` styling — **round-trips.** `fontSize` (number or `"auto"`), `color`; `fontWeight: bold` reads back omitted (it appears to be the default). (live-verified 2026-06-11, re-verified 2026-06-24)
+- `comparison` (the Δ badge) via `comparisonColumn: {columnId}` + `comparison: {display: "delta", colorGood, colorBad}` — **spec-authorable and readback-stable.** Verified 2026-07-27 against live staging: POST → export the source table → GET readback, with `comparisonColumn.columnId` intact and correct and `comparison.display`/colors unmodified. **KPIs are comparative by default — this is the house pattern, not an edge case.** See `comparative-kpi-card.yaml` beside this file for a full worked example. This supersedes the "did not render from spec / UI-only / stripped on readback" claim this doc carried through 2026-06-24 — for *this exact shape only* (see below for what's still unproven).
 
-  Behavior on POST/readback differs by block (verified 2026-06-24):
+  **Don't over-extend this finding — two adjacent things remain unverified:**
+  - The UI's **period-comparison MODE** (a date-driven picker like "vs. prior quarter" that derives the comparison value from a date dimension at render time) is a **different mechanism** from `comparisonColumn`. No public-API field exposes that date/series binding, and it remains **UI-bound** here. `comparisonColumn` compares two columns *you* compute (e.g. a `Current` column and a `Prior` column produced by your own formulas/source) — it is not an automatic "vs. last N periods" toggle.
+  - `trend` (sparkline) is **still UI-bound** — unchanged by the 2026-07-27 finding, which tested only `comparisonColumn`/`comparison`, not `trend`. See the reproduction notes below.
+  - An earlier version of this doc claimed `comparison` itself was "best-effort — survives on some KPIs, stripped on others." That blanket claim does **not** hold for the `comparisonColumn` + `comparison:{display:"delta"}` shape (verified 2026-07-27, reproduced twice). If you hit stripping with some *other* `comparison` configuration, treat that configuration as unverified and confirm with a live readback before relying on it — don't assume the whole block is unreliable.
+
+  Behavior on POST/readback (verified 2026-06-24 for `trend`; 2026-07-27 for `comparison`/`comparisonColumn`):
+  - `comparisonColumn` + `comparison:{display:"delta"}` — **accepted and persists** on readback, populated correctly.
   - `trend` — **accepted and persists** on readback, but **inert without a UI binding** — it renders nothing on its own here.
-  - `comparison` and a column-level `columns[].sparkline` — **stripped** on readback. (A second team independently reports `comparison` is "best-effort — survives on some KPIs, stripped on others; finish in the UI if it drops" — i.e. don't rely on it round-tripping.)
+  - A column-level `columns[].sparkline` — **stripped** on readback.
 
   > ⚠️ **The widely-shared sparkline recipe did not reproduce here.** `trend: {shape: line}` + a `DateTrunc("month")` column + a date-range filter on it rendered **no** sparkline — tested ~8 ways on 2026-06-24, including the full documented recipe (a pre-grouped month time-series source, the month column in the KPI, **and both `mode: between` and the relative `mode: last … unit: month`**), column-level `sparkline`, and an exact copy of a *working* UI-bound KPI's columns. Every one rendered the value alone (the **grand total** — no date column ever created the series). Notably, the documented shape that filters a KPI on a `DateTrunc` month column **living on the source** (not in the KPI's own `columns`) is **rejected outright** by this API (`Dependency not found`). A KPI render that shows a live spark in the UI returns **no** `trend`/`sparkline` in its spec — only leftover `DateTrunc`/raw-date columns the editor added.
   >


### PR DESCRIPTION
## Summary

- `kpis.md` documented the KPI comparison badge (`comparisonColumn` + `comparison:{display:"delta"}`) as UI-only / stripped on readback. That claim is superseded: a live-staging POST → export → GET readback (2026-07-27, reproduced twice) showed the shape **is spec-authorable and survives readback intact**, with `comparisonColumn.columnId` and `comparison.display`/colors unmodified. A multi-row live run confirmed the delta aggregates as `Sum(current) − Sum(prior)`.
- Updated the `## layout, comparison, and trend blocks` section to reflect this — **KPIs are comparative by default is now the house pattern**, not an edge case. Nothing else in that section changed.
- **Precision kept intact:** the UI's period-comparison *mode* (date-driven "vs. prior quarter" picker) and the `trend`/sparkline date-binding remain **UI-bound and unproven** — those caveats are preserved verbatim, not weakened.
- Added `sigma-workbooks/reference/specification/comparative-kpi-card.yaml` — a minimal, clone-able exemplar — beside the existing `example-full.yaml`, following this repo's existing exemplar convention (flat `reference/specification/`, no `examples/` subdir). Referenced it from `SKILL.md`'s Reference Index. Uses generic placeholder data, no customer names.
- Also corrected the same stale "UI-bound" framing in `SKILL.md`'s Reference Index row for `kpis.md`, so the navigation table doesn't contradict the corrected reference file.
- Regenerated the non-Claude agent variants (`generated/{codex,cursor,cline,continue}`) via `scripts/sync-targets.rb sigma-workbooks`, since `SKILL.md` changed.

This mirrors the equivalent, already-verified change made in the `sigma-migration-skills` plugin's `sigma-authoring/sigma-workbooks` copy (a separate repo) — content mirrored, not file layout, to match this repo's flat convention.

## Test plan

- [x] `./sigma-workbooks/scripts/validate-spec.sh sigma-workbooks/reference/specification/comparative-kpi-card.yaml` → `OK: no obvious formula qualification errors.`
- [x] `ruby scripts/sync-targets.rb sigma-workbooks` → regenerated all 4 non-Claude variants; spot-checked they contain the new `kpis.md` blurb and the new exemplar's index row.
- [x] Confirmed the pre-existing uncommitted local edit to `sigma-workbooks/reference/specification/layout.md` on `main` was untouched (this work was done on a fresh worktree off `origin/main`).
- [ ] No live API/`verify-workbook.sh` run against this branch (that script needs `SIGMA_API_TOKEN`); the comparative-KPI shape itself was already verified live in the source repo on 2026-07-27.

🤖 Generated with [Claude Code](https://claude.com/claude-code)