### PR TITLE
feat: add sigma-plugin-authoring skill (recreate a non-native viz as a Sigma custom plugin)

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ See [Installation](#installation) below for the install helper.
 |-------|---------|
 | [`sigma-data-models`](sigma-data-models/) | Author Sigma data models from existing warehouse tables — sources, columns, metrics, relationships, filters, calc columns, CLS. Covers spec shape, discovery, CRUD, validation, and authoring judgment calls. **Out of scope: converting from another BI tool's format** (use the converter MCP / browser tool). |
 | [`sigma-workbooks`](sigma-workbooks/) | Build, edit, and iterate on Sigma workbook specs — pages, layout, controls, charts (line/bar/area/combo/donut), KPIs, tables, pivot tables, formulas, sources. Canonical reference for the workbook spec; other skills cross-link here for spec shape. |
+| [`sigma-plugin-authoring`](sigma-plugin-authoring/) | Recreate a source viz that has no native Sigma equivalent — a radial gauge, custom heatmap, sankey — as a bespoke `@sigmacomputing/plugin`: build, register, host, embed, bind, verify. Includes a worked gauge example. |
 | [`custom-sql-to-data-model`](custom-sql-to-data-model/) | Scan Sigma workbooks for custom SQL elements, dedupe across workbooks, build or reuse data models, then repoint via the v3alpha `:swapSources` endpoint. Handles many workbooks pointing at one shared model. |
 
 > **Looking for `tableau-to-sigma` or `tableau-vds-to-snowflake`?** Those skills are still iterating and live in the private [`twells89/sigma-skills-staging`](https://github.com/twells89/sigma-skills-staging) repo. They graduate here once they're stable across multiple real conversions.

--- a/sigma-plugin-authoring/SKILL.md
+++ b/sigma-plugin-authoring/SKILL.md
@@ -1,0 +1,188 @@
+---
+name: sigma-plugin-authoring
+description: >-
+  Build, register, host, embed, and data-bind a bespoke Sigma custom plugin
+  (@sigmacomputing/plugin) to recreate a source visualization for which
+  Sigma has no native chart/KPI/table equivalent — a radial gauge, a custom
+  heatmap, a sankey, or any bespoke viz kind outside Sigma's native element
+  set. **Use when a source viz has no native Sigma equivalent and should be
+  recreated as a bespoke plugin** — not when a native Sigma chart, KPI, or
+  table kind already covers it (that's the `sigma-workbooks` skill). Covers
+  the full lifecycle: writing the single-file plugin, registering it via
+  `POST /v2/plugins`, hosting it, embedding it in a workbook spec bound to
+  real data, and verifying value parity. Ships a worked example (a radial
+  gauge / "value vs. target" plugin) and the `plugin_embed` emitter. Requires
+  an SIGMA_API_TOKEN — obtain via the sigma-api skill first.
+---
+
+# Sigma Plugin Authoring (Recreate-as-Plugin)
+
+Sigma's native element kinds (`bar-chart`, `kpi-chart`, `table`, `pivot-table`,
+`point-map`, …) cover most dashboards. Some source vizzes don't map to any of
+them — a radial/semicircle gauge, a calendar heatmap, a sankey, a custom
+ring/dial. For those, recreate the viz as a **Sigma custom plugin**
+(`@sigmacomputing/plugin`): a single-file web app Sigma hosts inside a
+workbook element, wired to real workbook data through an editor-panel
+contract you define.
+
+## Scope
+
+The **plugin lifecycle**: build → register → host → embed → bind → verify.
+Building the rest of the workbook around the plugin (the data table it reads
+from, KPIs/controls alongside it, page layout, the hidden data page) is the
+`sigma-workbooks` skill's job — this skill only covers the plugin-specific
+pieces. Authoring the underlying data model is `sigma-data-models`.
+
+## Decision: does this viz need a plugin at all?
+
+Before reaching for this skill, confirm there's genuinely no native fit:
+check the `sigma-workbooks` skill's chart/KPI/table reference and, if still
+unsure, query the OpenAPI's `kind` enum (see that skill's "Consulting the
+OpenAPI" section). Only recreate as a plugin when the native surface is a
+confirmed miss — plugins carry real lifecycle cost (hosting, registration,
+re-registration on URL change) that a native chart doesn't.
+
+## The recipe
+
+### 1. Build the plugin
+
+Single HTML file, vanilla JS, the SDK loaded via
+`<script src="https://unpkg.com/@sigmacomputing/plugin">`. Declare the data
+contract with `client.config.configureEditorPanel([...])` — one entry per
+variable your embed will bind (an `element` source, one or more `column`
+bindings sourced from it, optional `text`/`number` config). Subscribe to the
+data, render, and:
+
+- Attach a **`ResizeObserver`** to the render container that fully
+  recomputes and redraws on every resize (not CSS-only scaling) — see
+  `reference/plugin-lifecycle.md` §5 for why this is non-negotiable.
+- Include a **synthetic fallback** so the file renders sensible demo data
+  when opened standalone (no Sigma `client`, or incomplete bound data) — see
+  §6.
+
+Use `plugins/gauge/index.html` (+ `plugins/gauge/README.md`) as the worked
+example — a radial gauge with `source`/`value`/`target`/`format` editor-panel
+vars. Copy its structure for a new archetype rather than starting from
+scratch.
+
+A plugin doesn't have to be display-only, either: it can be **interactive**
+— write back to a control or trigger a workbook action from a click, a
+selection, or an edit inside the plugin itself. See `reference/patterns.md`
+for the writeback (variable + action-trigger) pattern and
+`reference/sdk-api.md` for the full editor-panel config vocabulary and
+client/hook API behind it.
+
+### 2. Host it
+
+This is the customer's call, not this skill's — any **persistent** public
+static host they already use or prefer (their own S3/CDN, GitHub Pages,
+Netlify, Vercel, Cloudflare Pages, …) works identically for registration and
+embedding. `localhost` is fine for local dev/preview but is never a shared or
+headlessly-rendered result; an ephemeral tunnel (free-tier ngrok, etc.) is
+not a substitute for persistence either. **Handoff is the default path** —
+hand the user the plugin file and the exact hosting + registration steps for
+*their* chosen host; a turnkey automated static deploy is a fast-follow, not
+built into this skill yet. Localhost is sufficient to build, preview, and
+data-parity-verify the plugin; it is **not** sufficient for Sigma's
+server-side rendering (headless screenshots, scheduled exports) — see
+`reference/plugin-lifecycle.md` §2 before promising a screenshot.
+
+### 3. Register it
+
+```bash
+ruby scripts/register-plugin.rb "<plugin name>" "<hosted URL>" "<description>"
+# -> prints the pluginId on success
+```
+
+This calls `PluginRegister.register_or_get`, which is idempotent (safe to
+re-run) and already handles the two registration gotchas that will otherwise
+cost you a debugging session — a masked HTTP 404 that can accompany a
+*successful* register, and a 403 that means registration is org-admin-gated
+in this org (fall back to handoff, don't retry blindly). Full detail in
+`reference/plugin-lifecycle.md` §1.
+
+### 4. Embed it, bound to data
+
+Emit the workbook-spec plugin element with the shared emitter — **don't
+hand-write this JSON**:
+
+`PluginEmbed.build(id:, plugin_id:, source_element_id:, bindings:, extra_config: {})` (`scripts/plugin_embed.rb`)
+
+`bindings` maps each editor-panel column var to a `columnId` (e.g.
+`{"value" => "actual", "target" => "target"}`); `extra_config` is any other
+non-binding config (e.g. `{"format" => ".0%"}`). The emitter coerces every
+value to a bare string and emits the correct `config.source` shape — see
+`examples/gauge-embed.json` for a full output and
+`reference/plugin-lifecycle.md` §3 for *why* string-coercion matters (the
+failure mode is a silent, misleadingly generic error).
+
+Put the plugin's `source` data element on its own **hidden page** if it
+shouldn't be user-visible — `visibleAsSource:false` alone does not hide it
+(§4). Then hand the finished element off to the `sigma-workbooks` skill's
+normal create/update flow (`POST`/`PUT /v2/workbooks/spec`).
+
+### 5. Verify
+
+- **Data parity (hard gate).** Export the plugin's bound element
+  (`source.elementId`) via the standard workbook export flow and assert the
+  values match the source/warehouse. Works regardless of hosting.
+- **Visual (best-effort).** Screenshot the workbook only when the plugin is
+  publicly hosted — on localhost, skip this honestly rather than faking a
+  render.
+
+## Reference Index
+
+| File | When to load |
+|------|--------------|
+| `reference/plugin-lifecycle.md` | **Always, before registering or embedding.** The full verified-gotcha reference: masked-404/403 registration, `url` set-once, hosting/localhost boundary, bare-string config shape, hidden backing page, `ResizeObserver`, synthetic fallback. |
+| `reference/sdk-api.md` | **Before writing a plugin's editor-panel config or its data/variable/action wiring.** The authoring-surface lookup: every editor-panel config type (`element`, `column`, `text`, `variable`, `action-trigger`, …), the config-value-by-type table, the vanilla-client-vs-React-hook side-by-side, the column-oriented element data shape, and defensive date parsing. |
+| `reference/patterns.md` | **When the plugin needs to do more than display** — JSON settings, edit-mode gating, the variable + action-trigger writeback pattern, dynamic editor-panel reconfiguration, variable-value unwrapping, action-effects, and multi-column roles. Includes a worked (not yet live-verified) click-to-filter writeback recipe. |
+| `plugins/gauge/index.html` + `plugins/gauge/README.md` | The worked example plugin (radial gauge, value vs. target) — copy/adapt its structure for a new archetype. |
+| `examples/gauge-embed.json` | A `PluginEmbed.build` output exemplar — the exact embed shape to match. |
+
+## Framework choice
+
+This skill's worked example (`plugins/gauge/`) is a dependency-free single
+HTML file — the SDK loaded via a CDN `<script>` tag, no build step. That's
+the right default for a focused recreate-as-plugin: fast to iterate,
+nothing to bundle, easy to hand off for hosting. For a larger, more
+interactive plugin (several writeback fields, a real component tree, a
+bespoke settings UI), a bundled React+TypeScript scaffold is a reasonable
+alternative starting point instead of hand-rolling one — for example
+[neil-oliver/sigma-plugin-template](https://github.com/neil-oliver/sigma-plugin-template),
+a community scaffold. That's a pointer, not an endorsement or a
+vendored dependency — this skill doesn't ship or maintain it.
+
+## Cross-Skill References
+
+- **The rest of the workbook** (the data table the plugin reads from, KPIs
+  and controls alongside it, page layout, hidden pages, create/update/PUT
+  mechanics) → `sigma-workbooks` skill.
+- **The underlying data model** the bound element sources from →
+  `sigma-data-models` skill.
+- **Auth, base URL, token refresh** → defer to the `sigma-api` skill.
+
+## Troubleshooting
+
+**`Invalid kind:"plugin"` on workbook create/update.** This is Sigma's masked
+error for a malformed plugin element — almost always a `config` value that
+isn't a bare string (an object/column-ref shape slipped in somewhere other
+than `source`). Re-emit via `PluginEmbed.build` rather than hand-editing. See
+`reference/plugin-lifecycle.md` §3.
+
+**Registration seems to fail but the plugin exists.** Don't trust a non-2xx
+`POST /v2/plugins` response alone — confirm via `GET /v2/plugins` by name (or
+just use `register-plugin.rb`, which already does this). See §1.
+
+**403 registering the plugin.** Org-admin-gated in this org. Hand off the
+built bundle + exact steps to someone with admin credentials; don't drop the
+viz or fabricate a `pluginId`.
+
+**Plugin looks fine at first load, then clips/garbles on resize.** Missing or
+incomplete `ResizeObserver` handling — it must fully recompute geometry from
+the container's current box, not rely on CSS/viewBox scaling alone. See §5.
+
+**Need a screenshot but only have `localhost`.** Sigma's server-side render
+can't reach it. Report the gate as skipped (not passed) and note a public
+host is needed for that check specifically — data-parity is unaffected. See
+§2.

--- a/sigma-plugin-authoring/examples/gauge-embed.json
+++ b/sigma-plugin-authoring/examples/gauge-embed.json
@@ -1,0 +1,14 @@
+{
+  "config": {
+    "format": ".0%",
+    "source": {
+      "elementId": "tbl-gauge-data",
+      "kind": "element"
+    },
+    "target": "target",
+    "value": "actual"
+  },
+  "id": "gauge-el",
+  "kind": "plugin",
+  "pluginId": "00000000-0000-4000-8000-000000000000"
+}

--- a/sigma-plugin-authoring/generated/cline/sigma-plugin-authoring.md
+++ b/sigma-plugin-authoring/generated/cline/sigma-plugin-authoring.md
@@ -1,0 +1,178 @@
+<!--
+Auto-generated from SKILL.md by ~/sigma-skills/scripts/sync-targets.rb.
+Do not edit by hand — edit SKILL.md and re-run the script.
+-->
+
+> Build, register, host, embed, and data-bind a bespoke Sigma custom plugin (@sigmacomputing/plugin) to recreate a source visualization for which Sigma has no native chart/KPI/table equivalent — a radial gauge, a custom heatmap, a sankey, or any bespoke viz kind outside Sigma's native element set. **Use when a source viz has no native Sigma equivalent and should be recreated as a bespoke plugin** — not when a native Sigma chart, KPI, or table kind already covers it (that's the `sigma-workbooks` skill). Covers the full lifecycle: writing the single-file plugin, registering it via `POST /v2/plugins`, hosting it, embedding it in a workbook spec bound to real data, and verifying value parity. Ships a worked example (a radial gauge / "value vs. target" plugin) and the `plugin_embed` emitter. Requires an SIGMA_API_TOKEN — obtain via the sigma-api skill first.
+
+# Sigma Plugin Authoring (Recreate-as-Plugin)
+
+Sigma's native element kinds (`bar-chart`, `kpi-chart`, `table`, `pivot-table`,
+`point-map`, …) cover most dashboards. Some source vizzes don't map to any of
+them — a radial/semicircle gauge, a calendar heatmap, a sankey, a custom
+ring/dial. For those, recreate the viz as a **Sigma custom plugin**
+(`@sigmacomputing/plugin`): a single-file web app Sigma hosts inside a
+workbook element, wired to real workbook data through an editor-panel
+contract you define.
+
+## Scope
+
+The **plugin lifecycle**: build → register → host → embed → bind → verify.
+Building the rest of the workbook around the plugin (the data table it reads
+from, KPIs/controls alongside it, page layout, the hidden data page) is the
+`sigma-workbooks` skill's job — this skill only covers the plugin-specific
+pieces. Authoring the underlying data model is `sigma-data-models`.
+
+## Decision: does this viz need a plugin at all?
+
+Before reaching for this skill, confirm there's genuinely no native fit:
+check the `sigma-workbooks` skill's chart/KPI/table reference and, if still
+unsure, query the OpenAPI's `kind` enum (see that skill's "Consulting the
+OpenAPI" section). Only recreate as a plugin when the native surface is a
+confirmed miss — plugins carry real lifecycle cost (hosting, registration,
+re-registration on URL change) that a native chart doesn't.
+
+## The recipe
+
+### 1. Build the plugin
+
+Single HTML file, vanilla JS, the SDK loaded via
+`<script src="https://unpkg.com/@sigmacomputing/plugin">`. Declare the data
+contract with `client.config.configureEditorPanel([...])` — one entry per
+variable your embed will bind (an `element` source, one or more `column`
+bindings sourced from it, optional `text`/`number` config). Subscribe to the
+data, render, and:
+
+- Attach a **`ResizeObserver`** to the render container that fully
+  recomputes and redraws on every resize (not CSS-only scaling) — see
+  `reference/plugin-lifecycle.md` §5 for why this is non-negotiable.
+- Include a **synthetic fallback** so the file renders sensible demo data
+  when opened standalone (no Sigma `client`, or incomplete bound data) — see
+  §6.
+
+Use `plugins/gauge/index.html` (+ `plugins/gauge/README.md`) as the worked
+example — a radial gauge with `source`/`value`/`target`/`format` editor-panel
+vars. Copy its structure for a new archetype rather than starting from
+scratch.
+
+A plugin doesn't have to be display-only, either: it can be **interactive**
+— write back to a control or trigger a workbook action from a click, a
+selection, or an edit inside the plugin itself. See `reference/patterns.md`
+for the writeback (variable + action-trigger) pattern and
+`reference/sdk-api.md` for the full editor-panel config vocabulary and
+client/hook API behind it.
+
+### 2. Host it
+
+This is the customer's call, not this skill's — any **persistent** public
+static host they already use or prefer (their own S3/CDN, GitHub Pages,
+Netlify, Vercel, Cloudflare Pages, …) works identically for registration and
+embedding. `localhost` is fine for local dev/preview but is never a shared or
+headlessly-rendered result; an ephemeral tunnel (free-tier ngrok, etc.) is
+not a substitute for persistence either. **Handoff is the default path** —
+hand the user the plugin file and the exact hosting + registration steps for
+*their* chosen host; a turnkey automated static deploy is a fast-follow, not
+built into this skill yet. Localhost is sufficient to build, preview, and
+data-parity-verify the plugin; it is **not** sufficient for Sigma's
+server-side rendering (headless screenshots, scheduled exports) — see
+`reference/plugin-lifecycle.md` §2 before promising a screenshot.
+
+### 3. Register it
+
+```bash
+ruby scripts/register-plugin.rb "<plugin name>" "<hosted URL>" "<description>"
+# -> prints the pluginId on success
+```
+
+This calls `PluginRegister.register_or_get`, which is idempotent (safe to
+re-run) and already handles the two registration gotchas that will otherwise
+cost you a debugging session — a masked HTTP 404 that can accompany a
+*successful* register, and a 403 that means registration is org-admin-gated
+in this org (fall back to handoff, don't retry blindly). Full detail in
+`reference/plugin-lifecycle.md` §1.
+
+### 4. Embed it, bound to data
+
+Emit the workbook-spec plugin element with the shared emitter — **don't
+hand-write this JSON**:
+
+`PluginEmbed.build(id:, plugin_id:, source_element_id:, bindings:, extra_config: {})` (`scripts/plugin_embed.rb`)
+
+`bindings` maps each editor-panel column var to a `columnId` (e.g.
+`{"value" => "actual", "target" => "target"}`); `extra_config` is any other
+non-binding config (e.g. `{"format" => ".0%"}`). The emitter coerces every
+value to a bare string and emits the correct `config.source` shape — see
+`examples/gauge-embed.json` for a full output and
+`reference/plugin-lifecycle.md` §3 for *why* string-coercion matters (the
+failure mode is a silent, misleadingly generic error).
+
+Put the plugin's `source` data element on its own **hidden page** if it
+shouldn't be user-visible — `visibleAsSource:false` alone does not hide it
+(§4). Then hand the finished element off to the `sigma-workbooks` skill's
+normal create/update flow (`POST`/`PUT /v2/workbooks/spec`).
+
+### 5. Verify
+
+- **Data parity (hard gate).** Export the plugin's bound element
+  (`source.elementId`) via the standard workbook export flow and assert the
+  values match the source/warehouse. Works regardless of hosting.
+- **Visual (best-effort).** Screenshot the workbook only when the plugin is
+  publicly hosted — on localhost, skip this honestly rather than faking a
+  render.
+
+## Reference Index
+
+| File | When to load |
+|------|--------------|
+| `reference/plugin-lifecycle.md` | **Always, before registering or embedding.** The full verified-gotcha reference: masked-404/403 registration, `url` set-once, hosting/localhost boundary, bare-string config shape, hidden backing page, `ResizeObserver`, synthetic fallback. |
+| `reference/sdk-api.md` | **Before writing a plugin's editor-panel config or its data/variable/action wiring.** The authoring-surface lookup: every editor-panel config type (`element`, `column`, `text`, `variable`, `action-trigger`, …), the config-value-by-type table, the vanilla-client-vs-React-hook side-by-side, the column-oriented element data shape, and defensive date parsing. |
+| `reference/patterns.md` | **When the plugin needs to do more than display** — JSON settings, edit-mode gating, the variable + action-trigger writeback pattern, dynamic editor-panel reconfiguration, variable-value unwrapping, action-effects, and multi-column roles. Includes a worked (not yet live-verified) click-to-filter writeback recipe. |
+| `plugins/gauge/index.html` + `plugins/gauge/README.md` | The worked example plugin (radial gauge, value vs. target) — copy/adapt its structure for a new archetype. |
+| `examples/gauge-embed.json` | A `PluginEmbed.build` output exemplar — the exact embed shape to match. |
+
+## Framework choice
+
+This skill's worked example (`plugins/gauge/`) is a dependency-free single
+HTML file — the SDK loaded via a CDN `<script>` tag, no build step. That's
+the right default for a focused recreate-as-plugin: fast to iterate,
+nothing to bundle, easy to hand off for hosting. For a larger, more
+interactive plugin (several writeback fields, a real component tree, a
+bespoke settings UI), a bundled React+TypeScript scaffold is a reasonable
+alternative starting point instead of hand-rolling one — for example
+[neil-oliver/sigma-plugin-template](https://github.com/neil-oliver/sigma-plugin-template),
+a community scaffold. That's a pointer, not an endorsement or a
+vendored dependency — this skill doesn't ship or maintain it.
+
+## Cross-Skill References
+
+- **The rest of the workbook** (the data table the plugin reads from, KPIs
+  and controls alongside it, page layout, hidden pages, create/update/PUT
+  mechanics) → `sigma-workbooks` skill.
+- **The underlying data model** the bound element sources from →
+  `sigma-data-models` skill.
+- **Auth, base URL, token refresh** → defer to the `sigma-api` skill.
+
+## Troubleshooting
+
+**`Invalid kind:"plugin"` on workbook create/update.** This is Sigma's masked
+error for a malformed plugin element — almost always a `config` value that
+isn't a bare string (an object/column-ref shape slipped in somewhere other
+than `source`). Re-emit via `PluginEmbed.build` rather than hand-editing. See
+`reference/plugin-lifecycle.md` §3.
+
+**Registration seems to fail but the plugin exists.** Don't trust a non-2xx
+`POST /v2/plugins` response alone — confirm via `GET /v2/plugins` by name (or
+just use `register-plugin.rb`, which already does this). See §1.
+
+**403 registering the plugin.** Org-admin-gated in this org. Hand off the
+built bundle + exact steps to someone with admin credentials; don't drop the
+viz or fabricate a `pluginId`.
+
+**Plugin looks fine at first load, then clips/garbles on resize.** Missing or
+incomplete `ResizeObserver` handling — it must fully recompute geometry from
+the container's current box, not rely on CSS/viewBox scaling alone. See §5.
+
+**Need a screenshot but only have `localhost`.** Sigma's server-side render
+can't reach it. Report the gate as skipped (not passed) and note a public
+host is needed for that check specifically — data-parity is unaffected. See
+§2.

--- a/sigma-plugin-authoring/generated/codex/AGENTS.md
+++ b/sigma-plugin-authoring/generated/codex/AGENTS.md
@@ -1,0 +1,178 @@
+<!--
+Auto-generated from SKILL.md by ~/sigma-skills/scripts/sync-targets.rb.
+Do not edit by hand — edit SKILL.md and re-run the script.
+-->
+
+> Build, register, host, embed, and data-bind a bespoke Sigma custom plugin (@sigmacomputing/plugin) to recreate a source visualization for which Sigma has no native chart/KPI/table equivalent — a radial gauge, a custom heatmap, a sankey, or any bespoke viz kind outside Sigma's native element set. **Use when a source viz has no native Sigma equivalent and should be recreated as a bespoke plugin** — not when a native Sigma chart, KPI, or table kind already covers it (that's the `sigma-workbooks` skill). Covers the full lifecycle: writing the single-file plugin, registering it via `POST /v2/plugins`, hosting it, embedding it in a workbook spec bound to real data, and verifying value parity. Ships a worked example (a radial gauge / "value vs. target" plugin) and the `plugin_embed` emitter. Requires an SIGMA_API_TOKEN — obtain via the sigma-api skill first.
+
+# Sigma Plugin Authoring (Recreate-as-Plugin)
+
+Sigma's native element kinds (`bar-chart`, `kpi-chart`, `table`, `pivot-table`,
+`point-map`, …) cover most dashboards. Some source vizzes don't map to any of
+them — a radial/semicircle gauge, a calendar heatmap, a sankey, a custom
+ring/dial. For those, recreate the viz as a **Sigma custom plugin**
+(`@sigmacomputing/plugin`): a single-file web app Sigma hosts inside a
+workbook element, wired to real workbook data through an editor-panel
+contract you define.
+
+## Scope
+
+The **plugin lifecycle**: build → register → host → embed → bind → verify.
+Building the rest of the workbook around the plugin (the data table it reads
+from, KPIs/controls alongside it, page layout, the hidden data page) is the
+`sigma-workbooks` skill's job — this skill only covers the plugin-specific
+pieces. Authoring the underlying data model is `sigma-data-models`.
+
+## Decision: does this viz need a plugin at all?
+
+Before reaching for this skill, confirm there's genuinely no native fit:
+check the `sigma-workbooks` skill's chart/KPI/table reference and, if still
+unsure, query the OpenAPI's `kind` enum (see that skill's "Consulting the
+OpenAPI" section). Only recreate as a plugin when the native surface is a
+confirmed miss — plugins carry real lifecycle cost (hosting, registration,
+re-registration on URL change) that a native chart doesn't.
+
+## The recipe
+
+### 1. Build the plugin
+
+Single HTML file, vanilla JS, the SDK loaded via
+`<script src="https://unpkg.com/@sigmacomputing/plugin">`. Declare the data
+contract with `client.config.configureEditorPanel([...])` — one entry per
+variable your embed will bind (an `element` source, one or more `column`
+bindings sourced from it, optional `text`/`number` config). Subscribe to the
+data, render, and:
+
+- Attach a **`ResizeObserver`** to the render container that fully
+  recomputes and redraws on every resize (not CSS-only scaling) — see
+  `reference/plugin-lifecycle.md` §5 for why this is non-negotiable.
+- Include a **synthetic fallback** so the file renders sensible demo data
+  when opened standalone (no Sigma `client`, or incomplete bound data) — see
+  §6.
+
+Use `plugins/gauge/index.html` (+ `plugins/gauge/README.md`) as the worked
+example — a radial gauge with `source`/`value`/`target`/`format` editor-panel
+vars. Copy its structure for a new archetype rather than starting from
+scratch.
+
+A plugin doesn't have to be display-only, either: it can be **interactive**
+— write back to a control or trigger a workbook action from a click, a
+selection, or an edit inside the plugin itself. See `reference/patterns.md`
+for the writeback (variable + action-trigger) pattern and
+`reference/sdk-api.md` for the full editor-panel config vocabulary and
+client/hook API behind it.
+
+### 2. Host it
+
+This is the customer's call, not this skill's — any **persistent** public
+static host they already use or prefer (their own S3/CDN, GitHub Pages,
+Netlify, Vercel, Cloudflare Pages, …) works identically for registration and
+embedding. `localhost` is fine for local dev/preview but is never a shared or
+headlessly-rendered result; an ephemeral tunnel (free-tier ngrok, etc.) is
+not a substitute for persistence either. **Handoff is the default path** —
+hand the user the plugin file and the exact hosting + registration steps for
+*their* chosen host; a turnkey automated static deploy is a fast-follow, not
+built into this skill yet. Localhost is sufficient to build, preview, and
+data-parity-verify the plugin; it is **not** sufficient for Sigma's
+server-side rendering (headless screenshots, scheduled exports) — see
+`reference/plugin-lifecycle.md` §2 before promising a screenshot.
+
+### 3. Register it
+
+```bash
+ruby scripts/register-plugin.rb "<plugin name>" "<hosted URL>" "<description>"
+# -> prints the pluginId on success
+```
+
+This calls `PluginRegister.register_or_get`, which is idempotent (safe to
+re-run) and already handles the two registration gotchas that will otherwise
+cost you a debugging session — a masked HTTP 404 that can accompany a
+*successful* register, and a 403 that means registration is org-admin-gated
+in this org (fall back to handoff, don't retry blindly). Full detail in
+`reference/plugin-lifecycle.md` §1.
+
+### 4. Embed it, bound to data
+
+Emit the workbook-spec plugin element with the shared emitter — **don't
+hand-write this JSON**:
+
+`PluginEmbed.build(id:, plugin_id:, source_element_id:, bindings:, extra_config: {})` (`scripts/plugin_embed.rb`)
+
+`bindings` maps each editor-panel column var to a `columnId` (e.g.
+`{"value" => "actual", "target" => "target"}`); `extra_config` is any other
+non-binding config (e.g. `{"format" => ".0%"}`). The emitter coerces every
+value to a bare string and emits the correct `config.source` shape — see
+`examples/gauge-embed.json` for a full output and
+`reference/plugin-lifecycle.md` §3 for *why* string-coercion matters (the
+failure mode is a silent, misleadingly generic error).
+
+Put the plugin's `source` data element on its own **hidden page** if it
+shouldn't be user-visible — `visibleAsSource:false` alone does not hide it
+(§4). Then hand the finished element off to the `sigma-workbooks` skill's
+normal create/update flow (`POST`/`PUT /v2/workbooks/spec`).
+
+### 5. Verify
+
+- **Data parity (hard gate).** Export the plugin's bound element
+  (`source.elementId`) via the standard workbook export flow and assert the
+  values match the source/warehouse. Works regardless of hosting.
+- **Visual (best-effort).** Screenshot the workbook only when the plugin is
+  publicly hosted — on localhost, skip this honestly rather than faking a
+  render.
+
+## Reference Index
+
+| File | When to load |
+|------|--------------|
+| `reference/plugin-lifecycle.md` | **Always, before registering or embedding.** The full verified-gotcha reference: masked-404/403 registration, `url` set-once, hosting/localhost boundary, bare-string config shape, hidden backing page, `ResizeObserver`, synthetic fallback. |
+| `reference/sdk-api.md` | **Before writing a plugin's editor-panel config or its data/variable/action wiring.** The authoring-surface lookup: every editor-panel config type (`element`, `column`, `text`, `variable`, `action-trigger`, …), the config-value-by-type table, the vanilla-client-vs-React-hook side-by-side, the column-oriented element data shape, and defensive date parsing. |
+| `reference/patterns.md` | **When the plugin needs to do more than display** — JSON settings, edit-mode gating, the variable + action-trigger writeback pattern, dynamic editor-panel reconfiguration, variable-value unwrapping, action-effects, and multi-column roles. Includes a worked (not yet live-verified) click-to-filter writeback recipe. |
+| `plugins/gauge/index.html` + `plugins/gauge/README.md` | The worked example plugin (radial gauge, value vs. target) — copy/adapt its structure for a new archetype. |
+| `examples/gauge-embed.json` | A `PluginEmbed.build` output exemplar — the exact embed shape to match. |
+
+## Framework choice
+
+This skill's worked example (`plugins/gauge/`) is a dependency-free single
+HTML file — the SDK loaded via a CDN `<script>` tag, no build step. That's
+the right default for a focused recreate-as-plugin: fast to iterate,
+nothing to bundle, easy to hand off for hosting. For a larger, more
+interactive plugin (several writeback fields, a real component tree, a
+bespoke settings UI), a bundled React+TypeScript scaffold is a reasonable
+alternative starting point instead of hand-rolling one — for example
+[neil-oliver/sigma-plugin-template](https://github.com/neil-oliver/sigma-plugin-template),
+a community scaffold. That's a pointer, not an endorsement or a
+vendored dependency — this skill doesn't ship or maintain it.
+
+## Cross-Skill References
+
+- **The rest of the workbook** (the data table the plugin reads from, KPIs
+  and controls alongside it, page layout, hidden pages, create/update/PUT
+  mechanics) → `sigma-workbooks` skill.
+- **The underlying data model** the bound element sources from →
+  `sigma-data-models` skill.
+- **Auth, base URL, token refresh** → defer to the `sigma-api` skill.
+
+## Troubleshooting
+
+**`Invalid kind:"plugin"` on workbook create/update.** This is Sigma's masked
+error for a malformed plugin element — almost always a `config` value that
+isn't a bare string (an object/column-ref shape slipped in somewhere other
+than `source`). Re-emit via `PluginEmbed.build` rather than hand-editing. See
+`reference/plugin-lifecycle.md` §3.
+
+**Registration seems to fail but the plugin exists.** Don't trust a non-2xx
+`POST /v2/plugins` response alone — confirm via `GET /v2/plugins` by name (or
+just use `register-plugin.rb`, which already does this). See §1.
+
+**403 registering the plugin.** Org-admin-gated in this org. Hand off the
+built bundle + exact steps to someone with admin credentials; don't drop the
+viz or fabricate a `pluginId`.
+
+**Plugin looks fine at first load, then clips/garbles on resize.** Missing or
+incomplete `ResizeObserver` handling — it must fully recompute geometry from
+the container's current box, not rely on CSS/viewBox scaling alone. See §5.
+
+**Need a screenshot but only have `localhost`.** Sigma's server-side render
+can't reach it. Report the gate as skipped (not passed) and note a public
+host is needed for that check specifically — data-parity is unaffected. See
+§2.

--- a/sigma-plugin-authoring/generated/continue/sigma-plugin-authoring.md
+++ b/sigma-plugin-authoring/generated/continue/sigma-plugin-authoring.md
@@ -1,0 +1,178 @@
+<!--
+Auto-generated from SKILL.md by ~/sigma-skills/scripts/sync-targets.rb.
+Do not edit by hand — edit SKILL.md and re-run the script.
+-->
+
+> Build, register, host, embed, and data-bind a bespoke Sigma custom plugin (@sigmacomputing/plugin) to recreate a source visualization for which Sigma has no native chart/KPI/table equivalent — a radial gauge, a custom heatmap, a sankey, or any bespoke viz kind outside Sigma's native element set. **Use when a source viz has no native Sigma equivalent and should be recreated as a bespoke plugin** — not when a native Sigma chart, KPI, or table kind already covers it (that's the `sigma-workbooks` skill). Covers the full lifecycle: writing the single-file plugin, registering it via `POST /v2/plugins`, hosting it, embedding it in a workbook spec bound to real data, and verifying value parity. Ships a worked example (a radial gauge / "value vs. target" plugin) and the `plugin_embed` emitter. Requires an SIGMA_API_TOKEN — obtain via the sigma-api skill first.
+
+# Sigma Plugin Authoring (Recreate-as-Plugin)
+
+Sigma's native element kinds (`bar-chart`, `kpi-chart`, `table`, `pivot-table`,
+`point-map`, …) cover most dashboards. Some source vizzes don't map to any of
+them — a radial/semicircle gauge, a calendar heatmap, a sankey, a custom
+ring/dial. For those, recreate the viz as a **Sigma custom plugin**
+(`@sigmacomputing/plugin`): a single-file web app Sigma hosts inside a
+workbook element, wired to real workbook data through an editor-panel
+contract you define.
+
+## Scope
+
+The **plugin lifecycle**: build → register → host → embed → bind → verify.
+Building the rest of the workbook around the plugin (the data table it reads
+from, KPIs/controls alongside it, page layout, the hidden data page) is the
+`sigma-workbooks` skill's job — this skill only covers the plugin-specific
+pieces. Authoring the underlying data model is `sigma-data-models`.
+
+## Decision: does this viz need a plugin at all?
+
+Before reaching for this skill, confirm there's genuinely no native fit:
+check the `sigma-workbooks` skill's chart/KPI/table reference and, if still
+unsure, query the OpenAPI's `kind` enum (see that skill's "Consulting the
+OpenAPI" section). Only recreate as a plugin when the native surface is a
+confirmed miss — plugins carry real lifecycle cost (hosting, registration,
+re-registration on URL change) that a native chart doesn't.
+
+## The recipe
+
+### 1. Build the plugin
+
+Single HTML file, vanilla JS, the SDK loaded via
+`<script src="https://unpkg.com/@sigmacomputing/plugin">`. Declare the data
+contract with `client.config.configureEditorPanel([...])` — one entry per
+variable your embed will bind (an `element` source, one or more `column`
+bindings sourced from it, optional `text`/`number` config). Subscribe to the
+data, render, and:
+
+- Attach a **`ResizeObserver`** to the render container that fully
+  recomputes and redraws on every resize (not CSS-only scaling) — see
+  `reference/plugin-lifecycle.md` §5 for why this is non-negotiable.
+- Include a **synthetic fallback** so the file renders sensible demo data
+  when opened standalone (no Sigma `client`, or incomplete bound data) — see
+  §6.
+
+Use `plugins/gauge/index.html` (+ `plugins/gauge/README.md`) as the worked
+example — a radial gauge with `source`/`value`/`target`/`format` editor-panel
+vars. Copy its structure for a new archetype rather than starting from
+scratch.
+
+A plugin doesn't have to be display-only, either: it can be **interactive**
+— write back to a control or trigger a workbook action from a click, a
+selection, or an edit inside the plugin itself. See `reference/patterns.md`
+for the writeback (variable + action-trigger) pattern and
+`reference/sdk-api.md` for the full editor-panel config vocabulary and
+client/hook API behind it.
+
+### 2. Host it
+
+This is the customer's call, not this skill's — any **persistent** public
+static host they already use or prefer (their own S3/CDN, GitHub Pages,
+Netlify, Vercel, Cloudflare Pages, …) works identically for registration and
+embedding. `localhost` is fine for local dev/preview but is never a shared or
+headlessly-rendered result; an ephemeral tunnel (free-tier ngrok, etc.) is
+not a substitute for persistence either. **Handoff is the default path** —
+hand the user the plugin file and the exact hosting + registration steps for
+*their* chosen host; a turnkey automated static deploy is a fast-follow, not
+built into this skill yet. Localhost is sufficient to build, preview, and
+data-parity-verify the plugin; it is **not** sufficient for Sigma's
+server-side rendering (headless screenshots, scheduled exports) — see
+`reference/plugin-lifecycle.md` §2 before promising a screenshot.
+
+### 3. Register it
+
+```bash
+ruby scripts/register-plugin.rb "<plugin name>" "<hosted URL>" "<description>"
+# -> prints the pluginId on success
+```
+
+This calls `PluginRegister.register_or_get`, which is idempotent (safe to
+re-run) and already handles the two registration gotchas that will otherwise
+cost you a debugging session — a masked HTTP 404 that can accompany a
+*successful* register, and a 403 that means registration is org-admin-gated
+in this org (fall back to handoff, don't retry blindly). Full detail in
+`reference/plugin-lifecycle.md` §1.
+
+### 4. Embed it, bound to data
+
+Emit the workbook-spec plugin element with the shared emitter — **don't
+hand-write this JSON**:
+
+`PluginEmbed.build(id:, plugin_id:, source_element_id:, bindings:, extra_config: {})` (`scripts/plugin_embed.rb`)
+
+`bindings` maps each editor-panel column var to a `columnId` (e.g.
+`{"value" => "actual", "target" => "target"}`); `extra_config` is any other
+non-binding config (e.g. `{"format" => ".0%"}`). The emitter coerces every
+value to a bare string and emits the correct `config.source` shape — see
+`examples/gauge-embed.json` for a full output and
+`reference/plugin-lifecycle.md` §3 for *why* string-coercion matters (the
+failure mode is a silent, misleadingly generic error).
+
+Put the plugin's `source` data element on its own **hidden page** if it
+shouldn't be user-visible — `visibleAsSource:false` alone does not hide it
+(§4). Then hand the finished element off to the `sigma-workbooks` skill's
+normal create/update flow (`POST`/`PUT /v2/workbooks/spec`).
+
+### 5. Verify
+
+- **Data parity (hard gate).** Export the plugin's bound element
+  (`source.elementId`) via the standard workbook export flow and assert the
+  values match the source/warehouse. Works regardless of hosting.
+- **Visual (best-effort).** Screenshot the workbook only when the plugin is
+  publicly hosted — on localhost, skip this honestly rather than faking a
+  render.
+
+## Reference Index
+
+| File | When to load |
+|------|--------------|
+| `reference/plugin-lifecycle.md` | **Always, before registering or embedding.** The full verified-gotcha reference: masked-404/403 registration, `url` set-once, hosting/localhost boundary, bare-string config shape, hidden backing page, `ResizeObserver`, synthetic fallback. |
+| `reference/sdk-api.md` | **Before writing a plugin's editor-panel config or its data/variable/action wiring.** The authoring-surface lookup: every editor-panel config type (`element`, `column`, `text`, `variable`, `action-trigger`, …), the config-value-by-type table, the vanilla-client-vs-React-hook side-by-side, the column-oriented element data shape, and defensive date parsing. |
+| `reference/patterns.md` | **When the plugin needs to do more than display** — JSON settings, edit-mode gating, the variable + action-trigger writeback pattern, dynamic editor-panel reconfiguration, variable-value unwrapping, action-effects, and multi-column roles. Includes a worked (not yet live-verified) click-to-filter writeback recipe. |
+| `plugins/gauge/index.html` + `plugins/gauge/README.md` | The worked example plugin (radial gauge, value vs. target) — copy/adapt its structure for a new archetype. |
+| `examples/gauge-embed.json` | A `PluginEmbed.build` output exemplar — the exact embed shape to match. |
+
+## Framework choice
+
+This skill's worked example (`plugins/gauge/`) is a dependency-free single
+HTML file — the SDK loaded via a CDN `<script>` tag, no build step. That's
+the right default for a focused recreate-as-plugin: fast to iterate,
+nothing to bundle, easy to hand off for hosting. For a larger, more
+interactive plugin (several writeback fields, a real component tree, a
+bespoke settings UI), a bundled React+TypeScript scaffold is a reasonable
+alternative starting point instead of hand-rolling one — for example
+[neil-oliver/sigma-plugin-template](https://github.com/neil-oliver/sigma-plugin-template),
+a community scaffold. That's a pointer, not an endorsement or a
+vendored dependency — this skill doesn't ship or maintain it.
+
+## Cross-Skill References
+
+- **The rest of the workbook** (the data table the plugin reads from, KPIs
+  and controls alongside it, page layout, hidden pages, create/update/PUT
+  mechanics) → `sigma-workbooks` skill.
+- **The underlying data model** the bound element sources from →
+  `sigma-data-models` skill.
+- **Auth, base URL, token refresh** → defer to the `sigma-api` skill.
+
+## Troubleshooting
+
+**`Invalid kind:"plugin"` on workbook create/update.** This is Sigma's masked
+error for a malformed plugin element — almost always a `config` value that
+isn't a bare string (an object/column-ref shape slipped in somewhere other
+than `source`). Re-emit via `PluginEmbed.build` rather than hand-editing. See
+`reference/plugin-lifecycle.md` §3.
+
+**Registration seems to fail but the plugin exists.** Don't trust a non-2xx
+`POST /v2/plugins` response alone — confirm via `GET /v2/plugins` by name (or
+just use `register-plugin.rb`, which already does this). See §1.
+
+**403 registering the plugin.** Org-admin-gated in this org. Hand off the
+built bundle + exact steps to someone with admin credentials; don't drop the
+viz or fabricate a `pluginId`.
+
+**Plugin looks fine at first load, then clips/garbles on resize.** Missing or
+incomplete `ResizeObserver` handling — it must fully recompute geometry from
+the container's current box, not rely on CSS/viewBox scaling alone. See §5.
+
+**Need a screenshot but only have `localhost`.** Sigma's server-side render
+can't reach it. Report the gate as skipped (not passed) and note a public
+host is needed for that check specifically — data-parity is unaffected. See
+§2.

--- a/sigma-plugin-authoring/generated/cursor/rules/sigma-plugin-authoring.mdc
+++ b/sigma-plugin-authoring/generated/cursor/rules/sigma-plugin-authoring.mdc
@@ -1,0 +1,183 @@
+---
+description: "Build, register, host, embed, and data-bind a bespoke Sigma custom plugin (@sigmacomputing/plugin) to recreate a source visualization for which Sigma has no native chart/KPI/table equivalent — a radial gauge, a custom heatmap, a sankey, or any bespoke viz kind outside Sigma's native element set. **Use when a source viz has no native Sigma equivalent and should be recreated as a bespoke plugin** — not when a native Sigma chart, KPI, or table kind already covers it (that's the `sigma-workbooks` skill). Covers the full lifecycle: writing the single-file plugin, registering it via `POST /v2/plugins`, hosting it, embedding it in a workbook spec bound to real data, and verifying value parity. Ships a worked example (a radial gauge / \"value vs. target\" plugin) and the `plugin_embed` emitter. Requires an SIGMA_API_TOKEN — obtain via the sigma-api skill first."
+alwaysApply: false
+---
+
+<!--
+Auto-generated from SKILL.md by ~/sigma-skills/scripts/sync-targets.rb.
+Do not edit by hand — edit SKILL.md and re-run the script.
+-->
+
+> Build, register, host, embed, and data-bind a bespoke Sigma custom plugin (@sigmacomputing/plugin) to recreate a source visualization for which Sigma has no native chart/KPI/table equivalent — a radial gauge, a custom heatmap, a sankey, or any bespoke viz kind outside Sigma's native element set. **Use when a source viz has no native Sigma equivalent and should be recreated as a bespoke plugin** — not when a native Sigma chart, KPI, or table kind already covers it (that's the `sigma-workbooks` skill). Covers the full lifecycle: writing the single-file plugin, registering it via `POST /v2/plugins`, hosting it, embedding it in a workbook spec bound to real data, and verifying value parity. Ships a worked example (a radial gauge / "value vs. target" plugin) and the `plugin_embed` emitter. Requires an SIGMA_API_TOKEN — obtain via the sigma-api skill first.
+
+# Sigma Plugin Authoring (Recreate-as-Plugin)
+
+Sigma's native element kinds (`bar-chart`, `kpi-chart`, `table`, `pivot-table`,
+`point-map`, …) cover most dashboards. Some source vizzes don't map to any of
+them — a radial/semicircle gauge, a calendar heatmap, a sankey, a custom
+ring/dial. For those, recreate the viz as a **Sigma custom plugin**
+(`@sigmacomputing/plugin`): a single-file web app Sigma hosts inside a
+workbook element, wired to real workbook data through an editor-panel
+contract you define.
+
+## Scope
+
+The **plugin lifecycle**: build → register → host → embed → bind → verify.
+Building the rest of the workbook around the plugin (the data table it reads
+from, KPIs/controls alongside it, page layout, the hidden data page) is the
+`sigma-workbooks` skill's job — this skill only covers the plugin-specific
+pieces. Authoring the underlying data model is `sigma-data-models`.
+
+## Decision: does this viz need a plugin at all?
+
+Before reaching for this skill, confirm there's genuinely no native fit:
+check the `sigma-workbooks` skill's chart/KPI/table reference and, if still
+unsure, query the OpenAPI's `kind` enum (see that skill's "Consulting the
+OpenAPI" section). Only recreate as a plugin when the native surface is a
+confirmed miss — plugins carry real lifecycle cost (hosting, registration,
+re-registration on URL change) that a native chart doesn't.
+
+## The recipe
+
+### 1. Build the plugin
+
+Single HTML file, vanilla JS, the SDK loaded via
+`<script src="https://unpkg.com/@sigmacomputing/plugin">`. Declare the data
+contract with `client.config.configureEditorPanel([...])` — one entry per
+variable your embed will bind (an `element` source, one or more `column`
+bindings sourced from it, optional `text`/`number` config). Subscribe to the
+data, render, and:
+
+- Attach a **`ResizeObserver`** to the render container that fully
+  recomputes and redraws on every resize (not CSS-only scaling) — see
+  `reference/plugin-lifecycle.md` §5 for why this is non-negotiable.
+- Include a **synthetic fallback** so the file renders sensible demo data
+  when opened standalone (no Sigma `client`, or incomplete bound data) — see
+  §6.
+
+Use `plugins/gauge/index.html` (+ `plugins/gauge/README.md`) as the worked
+example — a radial gauge with `source`/`value`/`target`/`format` editor-panel
+vars. Copy its structure for a new archetype rather than starting from
+scratch.
+
+A plugin doesn't have to be display-only, either: it can be **interactive**
+— write back to a control or trigger a workbook action from a click, a
+selection, or an edit inside the plugin itself. See `reference/patterns.md`
+for the writeback (variable + action-trigger) pattern and
+`reference/sdk-api.md` for the full editor-panel config vocabulary and
+client/hook API behind it.
+
+### 2. Host it
+
+This is the customer's call, not this skill's — any **persistent** public
+static host they already use or prefer (their own S3/CDN, GitHub Pages,
+Netlify, Vercel, Cloudflare Pages, …) works identically for registration and
+embedding. `localhost` is fine for local dev/preview but is never a shared or
+headlessly-rendered result; an ephemeral tunnel (free-tier ngrok, etc.) is
+not a substitute for persistence either. **Handoff is the default path** —
+hand the user the plugin file and the exact hosting + registration steps for
+*their* chosen host; a turnkey automated static deploy is a fast-follow, not
+built into this skill yet. Localhost is sufficient to build, preview, and
+data-parity-verify the plugin; it is **not** sufficient for Sigma's
+server-side rendering (headless screenshots, scheduled exports) — see
+`reference/plugin-lifecycle.md` §2 before promising a screenshot.
+
+### 3. Register it
+
+```bash
+ruby scripts/register-plugin.rb "<plugin name>" "<hosted URL>" "<description>"
+# -> prints the pluginId on success
+```
+
+This calls `PluginRegister.register_or_get`, which is idempotent (safe to
+re-run) and already handles the two registration gotchas that will otherwise
+cost you a debugging session — a masked HTTP 404 that can accompany a
+*successful* register, and a 403 that means registration is org-admin-gated
+in this org (fall back to handoff, don't retry blindly). Full detail in
+`reference/plugin-lifecycle.md` §1.
+
+### 4. Embed it, bound to data
+
+Emit the workbook-spec plugin element with the shared emitter — **don't
+hand-write this JSON**:
+
+`PluginEmbed.build(id:, plugin_id:, source_element_id:, bindings:, extra_config: {})` (`scripts/plugin_embed.rb`)
+
+`bindings` maps each editor-panel column var to a `columnId` (e.g.
+`{"value" => "actual", "target" => "target"}`); `extra_config` is any other
+non-binding config (e.g. `{"format" => ".0%"}`). The emitter coerces every
+value to a bare string and emits the correct `config.source` shape — see
+`examples/gauge-embed.json` for a full output and
+`reference/plugin-lifecycle.md` §3 for *why* string-coercion matters (the
+failure mode is a silent, misleadingly generic error).
+
+Put the plugin's `source` data element on its own **hidden page** if it
+shouldn't be user-visible — `visibleAsSource:false` alone does not hide it
+(§4). Then hand the finished element off to the `sigma-workbooks` skill's
+normal create/update flow (`POST`/`PUT /v2/workbooks/spec`).
+
+### 5. Verify
+
+- **Data parity (hard gate).** Export the plugin's bound element
+  (`source.elementId`) via the standard workbook export flow and assert the
+  values match the source/warehouse. Works regardless of hosting.
+- **Visual (best-effort).** Screenshot the workbook only when the plugin is
+  publicly hosted — on localhost, skip this honestly rather than faking a
+  render.
+
+## Reference Index
+
+| File | When to load |
+|------|--------------|
+| `reference/plugin-lifecycle.md` | **Always, before registering or embedding.** The full verified-gotcha reference: masked-404/403 registration, `url` set-once, hosting/localhost boundary, bare-string config shape, hidden backing page, `ResizeObserver`, synthetic fallback. |
+| `reference/sdk-api.md` | **Before writing a plugin's editor-panel config or its data/variable/action wiring.** The authoring-surface lookup: every editor-panel config type (`element`, `column`, `text`, `variable`, `action-trigger`, …), the config-value-by-type table, the vanilla-client-vs-React-hook side-by-side, the column-oriented element data shape, and defensive date parsing. |
+| `reference/patterns.md` | **When the plugin needs to do more than display** — JSON settings, edit-mode gating, the variable + action-trigger writeback pattern, dynamic editor-panel reconfiguration, variable-value unwrapping, action-effects, and multi-column roles. Includes a worked (not yet live-verified) click-to-filter writeback recipe. |
+| `plugins/gauge/index.html` + `plugins/gauge/README.md` | The worked example plugin (radial gauge, value vs. target) — copy/adapt its structure for a new archetype. |
+| `examples/gauge-embed.json` | A `PluginEmbed.build` output exemplar — the exact embed shape to match. |
+
+## Framework choice
+
+This skill's worked example (`plugins/gauge/`) is a dependency-free single
+HTML file — the SDK loaded via a CDN `<script>` tag, no build step. That's
+the right default for a focused recreate-as-plugin: fast to iterate,
+nothing to bundle, easy to hand off for hosting. For a larger, more
+interactive plugin (several writeback fields, a real component tree, a
+bespoke settings UI), a bundled React+TypeScript scaffold is a reasonable
+alternative starting point instead of hand-rolling one — for example
+[neil-oliver/sigma-plugin-template](https://github.com/neil-oliver/sigma-plugin-template),
+a community scaffold. That's a pointer, not an endorsement or a
+vendored dependency — this skill doesn't ship or maintain it.
+
+## Cross-Skill References
+
+- **The rest of the workbook** (the data table the plugin reads from, KPIs
+  and controls alongside it, page layout, hidden pages, create/update/PUT
+  mechanics) → `sigma-workbooks` skill.
+- **The underlying data model** the bound element sources from →
+  `sigma-data-models` skill.
+- **Auth, base URL, token refresh** → defer to the `sigma-api` skill.
+
+## Troubleshooting
+
+**`Invalid kind:"plugin"` on workbook create/update.** This is Sigma's masked
+error for a malformed plugin element — almost always a `config` value that
+isn't a bare string (an object/column-ref shape slipped in somewhere other
+than `source`). Re-emit via `PluginEmbed.build` rather than hand-editing. See
+`reference/plugin-lifecycle.md` §3.
+
+**Registration seems to fail but the plugin exists.** Don't trust a non-2xx
+`POST /v2/plugins` response alone — confirm via `GET /v2/plugins` by name (or
+just use `register-plugin.rb`, which already does this). See §1.
+
+**403 registering the plugin.** Org-admin-gated in this org. Hand off the
+built bundle + exact steps to someone with admin credentials; don't drop the
+viz or fabricate a `pluginId`.
+
+**Plugin looks fine at first load, then clips/garbles on resize.** Missing or
+incomplete `ResizeObserver` handling — it must fully recompute geometry from
+the container's current box, not rely on CSS/viewBox scaling alone. See §5.
+
+**Need a screenshot but only have `localhost`.** Sigma's server-side render
+can't reach it. Report the gate as skipped (not passed) and note a public
+host is needed for that check specifically — data-parity is unaffected. See
+§2.

--- a/sigma-plugin-authoring/plugins/gauge/README.md
+++ b/sigma-plugin-authoring/plugins/gauge/README.md
@@ -1,0 +1,85 @@
+# Gauge plugin (value vs. target)
+
+A single-file, vanilla-JS Sigma custom plugin (`@sigmacomputing/plugin`) that
+renders a radial (semicircle) gauge — a value swept against a target, colored
+red/amber/green (RAG) by how close it is. It exists to recreate source vizzes
+(a QuickSight/Power BI-style gauge, a "% to target" indicator, …) for which
+Sigma has no native chart kind, as part of WS2's `recreate-as-plugin`
+disposition.
+
+Clean-room, generic data only — the file has no customer names or data. When
+there's no Sigma host (opened directly in a browser) or the bound data is
+incomplete, it falls back to a synthetic `value: 82, target: 100` so it always
+previews standalone.
+
+## Editor-panel bindings
+
+This is the contract other WS2 machinery (`shared/lib/plugin_embed`, the
+gap-scan/emitter) binds to — **do not rename these fields**:
+
+| name     | type                          | meaning                              |
+|----------|-------------------------------|---------------------------------------|
+| `source` | `element`                     | the bound data element                |
+| `value`  | `column` (source: `source`)   | the current value                     |
+| `target` | `column` (source: `source`)   | the target/goal                       |
+| `format` | `text`                        | optional number-format hint for labels|
+
+`format` supports a lightweight subset: a string containing `%` renders a
+percentage (`.1%` → 1 decimal place); a string like `.2f` fixes 2 decimals;
+`d`/`int` rounds to an integer; anything else (including blank) falls back to
+a locale-grouped number.
+
+## Design notes
+
+- **`ResizeObserver` on the render container → full redraw.** This is the
+  fix for the #1 "wonky plugin" failure mode: a plugin that only lets
+  CSS/viewBox scaling handle resize ends up with illegible text or a clipped
+  arc at small panel widths. Every resize here recomputes stroke width, font
+  size, and arc geometry from the container's actual box and re-renders from
+  scratch (not an incremental patch).
+- **Synthetic fallback (`synth()`)** renders whenever `client` is unavailable
+  or the bound `value`/`target` columns don't resolve to a non-empty row, so
+  the plugin is always previewable outside a workbook.
+- Single file, single responsibility: read `{value, target}`, draw the arc.
+  No dependencies beyond the Sigma plugin SDK (loaded via
+  `<script src="https://unpkg.com/@sigmacomputing/plugin">`).
+
+## Register + embed
+
+1. **Host** the file somewhere Sigma's render server can reach — a public
+   static host (for headless PNG export to work) or `localhost` for local
+   preview/dev (data-parity still works either way; only the headless
+   screenshot needs a public host).
+2. **Register** the plugin:
+   ```ruby
+   Sigma.request(:post, '/v2/plugins',
+     body: JSON.generate(name: 'Gauge (value vs. target)',
+                          description: 'Recreate-as-plugin radial gauge',
+                          url: PLUGIN_URL, type: 'element'))
+   # A masked HTTP 404 can accompany a SUCCESSFUL register — always confirm
+   # by name via GET /v2/plugins, never trust the POST status alone.
+   ```
+   The `url` is set-once per registration; re-register (or use the update
+   path, if available in your org) to change it. A 403 means registration is
+   org-admin-gated in that org.
+3. **Embed** the registered plugin in a workbook spec element, bound to a
+   data element. Every `config` value must be a **bare string** — the
+   object/`{kind:"column"}` form is silently rejected (masked as
+   `Invalid kind:"plugin"`):
+   ```json
+   {
+     "id": "gauge-el",
+     "kind": "plugin",
+     "pluginId": "<the registered pluginId>",
+     "config": {
+       "source": { "kind": "element", "elementId": "tbl-src" },
+       "value": "actual",
+       "target": "target"
+     }
+   }
+   ```
+   `scripts/plugin_embed.rb` (`PluginEmbed.build`) emits exactly this shape from
+   `{value: colId, target: colId}` bindings.
+4. **Bind** `tbl-src` to a data element carrying the value + target columns
+   (put it on a separate hidden page — `visibleAsSource:false` alone does
+   not remove it from layout).

--- a/sigma-plugin-authoring/plugins/gauge/index.html
+++ b/sigma-plugin-authoring/plugins/gauge/index.html
@@ -1,0 +1,279 @@
+<!DOCTYPE html>
+<!--
+  gauge/index.html — clean-room WS2 "recreate-as-plugin" radial gauge.
+
+  A single-file, vanilla-JS Sigma custom plugin (@sigmacomputing/plugin) that
+  renders a value-vs-target radial (semicircle) gauge with RAG color, for
+  source vizzes (e.g. a QuickSight/Power BI gauge) that have no native Sigma
+  equivalent. Single responsibility: read {value, target} off a bound
+  element, draw the arc. No customer data anywhere in this file — the
+  standalone/synthetic preview uses generic literals (82 of 100).
+
+  Editor-panel contract (do not rename — this is what shared/lib/plugin_embed
+  binds and what the emitter/gap-scan machinery keys off of):
+    source  (type: element) — the bound data element
+    value   (type: column, source: 'source') — the current value
+    target  (type: column, source: 'source') — the target/goal
+    format  (type: text)    — optional number-format hint for the labels
+
+  Verified Sigma plugin-lifecycle gotchas encoded here (see
+  plugins/sigma-authoring/skills/sigma-plugin-authoring/reference/ once that
+  lands in a later task):
+    - ResizeObserver on the render container -> FULL redraw. This is the #1
+      cause of a "wonky" plugin: a plugin that only lets CSS/viewBox scaling
+      handle resize ends up with illegible text or a clipped arc at small
+      panel widths. Here every resize recomputes stroke-width/font-size from
+      the container's actual box and re-renders from scratch.
+    - A synthetic fallback (synth()) renders whenever `client` is unavailable
+      (no Sigma host — e.g. opening this file directly in a browser) or the
+      bound data is incomplete, so the plugin always previews standalone.
+-->
+<html>
+<head>
+<meta charset="utf-8">
+<title>Gauge (value vs. target)</title>
+<style>
+  html, body {
+    margin: 0;
+    padding: 0;
+    width: 100%;
+    height: 100%;
+    overflow: hidden;
+    background: #ffffff;
+    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+  }
+  #gauge-root {
+    box-sizing: border-box;
+    width: 100%;
+    height: 100%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    position: relative;
+  }
+  #gauge-svg {
+    display: block;
+  }
+  #gauge-caption {
+    position: absolute;
+    left: 0;
+    right: 0;
+    bottom: 6%;
+    text-align: center;
+    color: #6b7280;
+    pointer-events: none;
+  }
+</style>
+</head>
+<body>
+<div id="gauge-root">
+  <svg id="gauge-svg" xmlns="http://www.w3.org/2000/svg"></svg>
+  <div id="gauge-caption"></div>
+</div>
+
+<!--
+  REQUIRED: load React BEFORE the SDK. @sigmacomputing/plugin's UMD build has
+  React as a hard peer dependency — its factory dereferences React at load and,
+  if React is absent, THROWS before assigning `client`, leaving
+  window.SigmaPlugin with NO `client`. The plugin then can never read bound data
+  and silently falls back to synth() (looks like it works, shows demo numbers).
+  Sigma does NOT inject React into the plugin iframe, so the plugin must load it
+  itself. ReactDOM is NOT needed for the vanilla client API. Verified against
+  @sigmacomputing/plugin v1.2.0 (see reference/plugin-lifecycle.md).
+-->
+<script crossorigin src="https://unpkg.com/react@18.3.1/umd/react.production.min.js"></script>
+<script src="https://unpkg.com/@sigmacomputing/plugin"></script>
+<script>
+(function () {
+  'use strict';
+
+  // ---------------------------------------------------------------------
+  // Synthetic fallback — generic demo literals only, never customer data.
+  // Rendered whenever there is no Sigma client, or the bound data can't be
+  // read as a complete {value, target} pair.
+  // ---------------------------------------------------------------------
+  function synth() {
+    return { value: 82, target: 100 };
+  }
+
+  // ---------------------------------------------------------------------
+  // Small format helper for the value/target labels. Supports a lightweight
+  // subset of common hint strings via the optional `format` editor-panel
+  // field; anything unrecognized falls back to a plain grouped number.
+  // ---------------------------------------------------------------------
+  function formatNumber(n, fmt) {
+    var num = Number(n);
+    if (!isFinite(num)) return String(n);
+    var f = (fmt || '').trim();
+    if (f === '') return num.toLocaleString();
+    if (f.indexOf('%') !== -1) {
+      var pctMatch = f.match(/\.(\d+)/);
+      var pctDigits = pctMatch ? Number(pctMatch[1]) : 0;
+      return (num * 100).toFixed(pctDigits) + '%';
+    }
+    var fixedMatch = f.match(/\.(\d+)f/);
+    if (fixedMatch) return num.toFixed(Number(fixedMatch[1]));
+    if (f === 'd' || f === 'int') return Math.round(num).toLocaleString();
+    return num.toLocaleString();
+  }
+
+  // ---------------------------------------------------------------------
+  // Geometry: a 180-degree (semicircle) gauge swept left-to-right.
+  // ---------------------------------------------------------------------
+  function polarPoint(cx, cy, r, deg) {
+    var rad = ((deg - 180) * Math.PI) / 180;
+    return { x: cx + r * Math.cos(rad), y: cy + r * Math.sin(rad) };
+  }
+
+  function arcPath(cx, cy, r, startDeg, endDeg) {
+    var start = polarPoint(cx, cy, r, endDeg);
+    var end = polarPoint(cx, cy, r, startDeg);
+    var large = (endDeg - startDeg) <= 180 ? 0 : 1;
+    return ['M', start.x, start.y, 'A', r, r, 0, large, 0, end.x, end.y].join(' ');
+  }
+
+  // RAG color from the value/target fraction.
+  function ragColor(frac) {
+    if (frac >= 1) return '#22c55e';   // green — at/above target
+    if (frac >= 0.6) return '#eab308'; // amber — approaching target
+    return '#ef4444';                  // red — well below target
+  }
+
+  // ---------------------------------------------------------------------
+  // Render: draws the full gauge into #gauge-svg at the CURRENT container
+  // size. Called on every data update AND on every resize (full redraw,
+  // not incremental) so text/stroke stay legible at any panel size.
+  // ---------------------------------------------------------------------
+  var lastValue = null;
+  var lastTarget = null;
+  var lastFormat = '';
+
+  function render(value, target, fmt) {
+    lastValue = value;
+    lastTarget = target;
+    lastFormat = fmt || '';
+
+    var root = document.getElementById('gauge-root');
+    var svg = document.getElementById('gauge-svg');
+    var caption = document.getElementById('gauge-caption');
+
+    var box = root.getBoundingClientRect();
+    var w = Math.max(60, box.width);
+    var h = Math.max(40, box.height);
+    svg.setAttribute('width', w);
+    svg.setAttribute('height', h);
+    svg.setAttribute('viewBox', '0 0 ' + w + ' ' + h);
+
+    var frac = target > 0 ? Math.max(0, Math.min(1, value / target)) : 0;
+    var color = ragColor(frac);
+
+    // Fit the FULL semicircle inside the box. The dome rises from the baseline
+    // (cy) by the radius (r), so r must not exceed the vertical room ABOVE cy or
+    // the dome top clips off-canvas (the wide-short-panel bug). Constrain r by
+    // BOTH the half-width and (cy - pad); center horizontally.
+    var cx = w / 2;
+    var strokeWidth = Math.max(4, Math.min(w, h * 1.6) * 0.09);
+    var pad = strokeWidth / 2 + 4;              // keep the rounded stroke cap inside the box
+    var cy = Math.min(h - pad, h * 0.80);        // arc baseline, low in the box
+    var r = Math.max(10, Math.min(w / 2 - pad, cy - pad)); // full dome fits above cy AND within width
+    var valueFontSize = Math.max(10, Math.min(w * 0.16, h * 0.34));
+    var targetFontSize = Math.max(8, valueFontSize * 0.42);
+
+    var track = arcPath(cx, cy, r, 0, 180);
+    var fill = arcPath(cx, cy, r, 0, 180 * frac);
+
+    var valueLabel = formatNumber(value, fmt);
+    var targetLabel = formatNumber(target, fmt);
+
+    svg.innerHTML =
+      '<path d="' + track + '" stroke="#e5e7eb" stroke-width="' + strokeWidth +
+        '" fill="none" stroke-linecap="round"/>' +
+      '<path d="' + fill + '" stroke="' + color + '" stroke-width="' + strokeWidth +
+        '" fill="none" stroke-linecap="round"/>' +
+      '<text x="' + cx + '" y="' + (cy - r * 0.15) + '" text-anchor="middle" ' +
+        'font-size="' + valueFontSize + '" font-weight="600" fill="#111827">' + valueLabel + '</text>' +
+      '<text x="' + cx + '" y="' + (cy - r * 0.15 + targetFontSize + 4) + '" text-anchor="middle" ' +
+        'font-size="' + targetFontSize + '" fill="#6b7280">of ' + targetLabel + '</text>';
+
+    caption.textContent = '';
+  }
+
+  function redrawFromLastKnown() {
+    var v = lastValue === null ? synth().value : lastValue;
+    var t = lastTarget === null ? synth().target : lastTarget;
+    render(v, t, lastFormat);
+  }
+
+  // ---------------------------------------------------------------------
+  // Sigma client wiring. Verified against @sigmacomputing/plugin v1.2.0
+  // (dist/umd + dist/esm/index.d.ts):
+  //   - The UMD build exposes its API as `window.SigmaPlugin` (not
+  //     `window.Sigma`). `.client` is the vanilla-JS bridge.
+  //   - Data subscription lives under `client.elements.subscribeToElementData
+  //     (sourceElementId, cb)` — it REQUIRES the source element id.
+  //   - We read bound column ids off the `client.config.subscribe(config => …)`
+  //     object (config.source / config.value / config.target are bare
+  //     ids/strings) so we also get re-notified when the binding changes.
+  //     (`client.config.getKey(k)` also returns the bare value at runtime —
+  //     despite its misleading `Pick<T,K>` type in the .d.ts — but doesn't
+  //     notify on change, so subscribe is the better fit here.)
+  // The `client` object exists even with no Sigma parent (opened standalone),
+  // so we paint the synthetic preview immediately and let real bound data
+  // overwrite it once the element-data subscription delivers.
+  // ---------------------------------------------------------------------
+  var s0 = synth();
+  render(s0.value, s0.target, '');   // immediate paint: standalone preview + pre-data placeholder
+
+  var client =
+    (window.SigmaPlugin && window.SigmaPlugin.client) ||   // real global (v1.2.0 UMD)
+    (window.Sigma && window.Sigma.client) ||               // legacy/alt global, just in case
+    null;
+
+  if (client) {
+    client.config.configureEditorPanel([
+      { name: 'source', type: 'element' },
+      { name: 'value', type: 'column', source: 'source', allowMultiple: false },
+      { name: 'target', type: 'column', source: 'source', allowMultiple: false },
+      { name: 'format', type: 'text' }
+    ]);
+
+    var unsubData = null;
+    client.config.subscribe(function (config) {
+      var sourceId = config && config.source;
+      if (unsubData) { unsubData(); unsubData = null; }   // re-subscribe if the source changes
+      if (!sourceId) {
+        var s = synth();
+        render(s.value, s.target, (config && config.format) || '');
+        return;
+      }
+      unsubData = client.elements.subscribeToElementData(sourceId, function (data) {
+        try {
+          var valueCol = config.value;
+          var targetCol = config.target;
+          var fmt = config.format;
+          var hasValue = data && valueCol && targetCol && data[valueCol] && data[targetCol] &&
+            data[valueCol].length && data[targetCol].length;
+          if (hasValue) {
+            render(Number(data[valueCol][0]), Number(data[targetCol][0]), fmt);
+          } else {
+            var s = synth();
+            render(s.value, s.target, fmt);
+          }
+        } catch (e) {
+          var fb = synth();
+          render(fb.value, fb.target, '');
+        }
+      });
+    });
+  }
+
+  // ResizeObserver on the render container -> full redraw. Mandatory: this
+  // is what keeps the gauge legible as the panel is resized in the Sigma
+  // workbook editor, rather than just letting the SVG stretch.
+  new ResizeObserver(function () {
+    redrawFromLastKnown();
+  }).observe(document.getElementById('gauge-root'));
+})();
+</script>
+</body>
+</html>

--- a/sigma-plugin-authoring/reference/patterns.md
+++ b/sigma-plugin-authoring/reference/patterns.md
@@ -1,0 +1,345 @@
+# Interactivity & Settings Patterns
+
+Recipes for a plugin that does more than passively display one value —
+assumes you've read `reference/sdk-api.md` for the underlying config/data/
+variable/action vocabulary. Like that file, this one does not repeat
+`reference/plugin-lifecycle.md`'s registration/hosting/embedding gotchas.
+
+## Graceful loading / partial config
+
+A plugin renders the moment it's dropped onto a canvas, before the author
+has configured anything. Guide them through setup instead of showing an
+error or a blank box — check state in the order the author actually fills
+it in:
+```js
+function view(config, data) {
+  if (!config.dataSource) return renderMessage('Choose a data source.');
+  if (!config.metricColumn) return renderMessage('Choose a metric column.');
+  const values = data[config.metricColumn];
+  if (!values || values.length === 0) return renderMessage('No rows yet for this selection.');
+  return renderReady(values);
+}
+```
+No source → no column → no data → ready. Treat "ready" as the last branch
+you reach, never the first thing you assume.
+
+## JSON-settings pattern
+
+The built-in editor-panel field types cover simple config, but not a rich,
+bespoke settings UI (several color pickers, nested layout options, a form
+the plugin renders itself). Route that through a single `text` field
+holding a JSON blob instead of trying to model it as editor-panel fields:
+```js
+client.config.configureEditorPanel([
+  { name: 'dataSource', type: 'element' },
+  { name: 'settingsJson', type: 'text', label: 'Settings (internal — do not hand-edit)', defaultValue: '{}', multiline: true },
+  { name: 'editMode', type: 'toggle', label: 'Edit Mode' }
+]);
+
+const DEFAULT_SETTINGS = {
+  title: 'Untitled',
+  theme: 'light',
+  cardStyle: { radius: 8, shadow: true }
+};
+
+function loadSettings(raw) {
+  if (!raw || !raw.trim()) return { ...DEFAULT_SETTINGS };
+  try {
+    const parsed = JSON.parse(raw);
+    return {
+      ...DEFAULT_SETTINGS,
+      ...parsed,
+      // one level of deep merge — a flat spread alone only merges the TOP level
+      cardStyle: { ...DEFAULT_SETTINGS.cardStyle, ...(parsed.cardStyle || {}) }
+    };
+  } catch {
+    return { ...DEFAULT_SETTINGS }; // malformed JSON in the field — never throw, fall back
+  }
+}
+
+function saveSettings(settings) {
+  client.config.set({ settingsJson: JSON.stringify(settings) }); // persists with the workbook
+}
+```
+Always parse in a `try/catch`, and always overlay the parsed object onto
+the defaults rather than trusting it alone — that's what lets a later
+plugin version add a new settings key without breaking every workbook that
+saved the old shape. Settings saved this way persist with the workbook:
+they survive refresh and are shared with anyone viewing it.
+
+## Edit-mode gating
+
+Pair an `editMode` toggle (declared above) with — or in place of — reading
+`client.sigmaEnv`, to decide whether to show builder-only chrome:
+```js
+const showBuilderUI = config.editMode || client.sigmaEnv === 'author';
+```
+`editMode` is an explicit author opt-in (works even for an author who wants
+viewers to see it too); `sigmaEnv` reflects the actual session
+(`'author' | 'viewer' | 'explorer'`) regardless of any toggle. Gate a
+settings-gear icon, inline rename handles, or debug output (row counts, raw
+column IDs) behind whichever — or both — fits the plugin.
+
+## Variable + action-trigger writeback (the headline pattern)
+
+This is how a plugin stops passively displaying data and starts driving the
+workbook. Two editor-panel fields, always declared as a pair:
+```js
+client.config.configureEditorPanel([
+  { name: 'dataSource', type: 'element' },
+  { name: 'categoryColumn', type: 'column', source: 'dataSource', label: 'Category' },
+  { name: 'selected', type: 'variable', label: 'Selected Category', allowedTypes: ['text'] },
+  { name: 'onSelect', type: 'action-trigger', label: 'On Select' }
+]);
+```
+```js
+const [, setSelected] = useVariable(config.selected || '');   // write-only: discard the getter
+const fireOnSelect = useActionTrigger(config.onSelect || '');
+
+function choose(rowValue) {
+  setSelected(String(rowValue));  // 1. the WHAT — text variables want explicit String() coercion
+  fireOnSelect?.();               // 2. the REACT-NOW — tell the workbook something changed
+}
+
+function clear() {
+  setSelected('');   // clear with '' — not null
+  fireOnSelect?.();
+}
+```
+The variable carries the value; the trigger tells the workbook to notice
+it. The workbook builder is the one who wires the variable into a
+filter/control and the trigger into a refresh/navigate elsewhere in
+Sigma — declaring both fields here is what makes that wiring possible.
+
+**Multiple variables in one writeback** — set every value, then fire the
+trigger once:
+```js
+const [, setId] = useVariable(config.selectedId || '');
+const [, setLabel] = useVariable(config.selectedLabel || '');  // the "dual" value+label variant
+const fireOnSelect = useActionTrigger(config.onSelect || '');
+
+function choose(row) {
+  setId(String(row.id));
+  setLabel(String(row.name));
+  fireOnSelect?.();
+}
+```
+The dual (value + label) shape is handy whenever the consuming control
+needs a human-readable label alongside the raw value it filters on.
+
+## Dynamic editor-panel reconfiguration
+
+Keep the panel from cluttering itself with fields the author hasn't opted
+into. Recompute the config array from current config and re-call
+`configureEditorPanel`:
+```js
+function buildPanel(writebackEnabled) {
+  const base = [
+    { name: 'dataSource', type: 'element' },
+    { name: 'categoryColumn', type: 'column', source: 'dataSource', label: 'Category' },
+    { name: 'enableWriteback', type: 'toggle', label: 'Enable Writeback' }
+  ];
+  if (writebackEnabled) {
+    base.push(
+      { name: 'selected', type: 'variable', label: 'Selected Category' },
+      { name: 'onSelect', type: 'action-trigger', label: 'On Select' }
+    );
+  }
+  return base;
+}
+
+client.config.configureEditorPanel(buildPanel(false)); // initial
+
+client.config.subscribe((cfg) => {
+  client.config.configureEditorPanel(buildPanel(!!cfg.enableWriteback)); // reconfigure on change
+});
+```
+(React: the equivalent inside a `useEffect` keyed on `config.enableWriteback`.)
+The `variable`/`action-trigger` fields don't exist in the panel at all
+until the author flips `enableWriteback` on.
+
+## Variable-value unwrapping (footgun)
+
+The current SDK types `getVariable`/`useVariable`'s value as a fixed shape —
+`{ name: string, defaultValue: { type: string, value: any } }` — so the
+value itself lives at `variable.defaultValue.value`, never at the top
+level. Unwrap defensively anyway: some bindings and older SDK versions have
+been observed handing back a flatter `{ value }` shape, and `undefined`
+shows up whenever nothing is bound yet:
+```js
+function unwrapVariable(raw) {
+  if (raw === null || raw === undefined) return null;
+  if (typeof raw !== 'object') return raw;                      // already a plain value
+  if (raw.defaultValue?.value !== undefined) return raw.defaultValue.value; // current shape
+  if (raw.value !== undefined) return raw.value;                 // flatter shape, seen elsewhere
+  return null;
+}
+```
+Date-typed variables have additionally been observed to carry one more
+nesting level around a millisecond timestamp:
+```js
+function unwrapDateVariable(raw) {
+  const inner = unwrapVariable(raw);
+  if (inner && typeof inner === 'object' && 'date' in inner) return new Date(inner.date);
+  return inner ? new Date(inner) : null;
+}
+```
+Run every variable read through one of these before using it. This is a
+footgun specifically because the documented shape works fine in quick
+testing, and only some bindings surface the flatter or extra-nested cases.
+
+## Action-effect (workbook → plugin)
+
+The inverse of a trigger: the workbook calls into the plugin.
+```js
+client.config.configureEditorPanel([
+  { name: 'onReset', type: 'action-effect', label: 'Reset Plugin' }
+]);
+```
+```js
+useActionEffect(config.onReset || '', () => {
+  clearSelection();
+  resetToDefaults();
+});
+```
+Typical uses: a workbook-level "reset all filters" control also resets this
+plugin's internal state, or a scheduled/triggered workbook action tells the
+plugin to refresh.
+
+## Multi-column roles
+
+A plugin needing several distinct roles from the same element (an x-axis,
+a y-axis, a label, a set of tooltip fields) declares one `column` entry per
+role, all pointing at the same `source`:
+```js
+client.config.configureEditorPanel([
+  { name: 'dataSource', type: 'element' },
+  { name: 'xAxis', type: 'column', source: 'dataSource', label: 'X Axis' },
+  { name: 'yAxis', type: 'column', source: 'dataSource', label: 'Y Axis' },
+  { name: 'seriesLabel', type: 'column', source: 'dataSource', label: 'Series Label' },
+  { name: 'tooltipFields', type: 'column', source: 'dataSource', allowMultiple: true, label: 'Tooltip Fields' }
+]);
+```
+`allowMultiple: true` can hand back a single string OR an array depending
+on how many columns are currently picked — always normalize before use:
+```js
+const tooltipIds = Array.isArray(config.tooltipFields)
+  ? config.tooltipFields
+  : [config.tooltipFields].filter(Boolean);
+```
+
+## Worked writeback example — click-to-filter list (documented recipe, not yet live-verified)
+
+The rest of this file has been individual recipes; this ties graceful
+loading, a single-column read, and variable + action-trigger writeback
+together into one small vanilla-JS plugin. It renders a category column as
+a clickable list; clicking a row writes a `selected` variable and fires an
+`onSelect` action-trigger so the workbook can filter something else off the
+choice.
+
+**Honesty note:** unlike the gauge plugin shipped with this skill — which
+has been registered, embedded, and value-verified against a live
+workbook — this recipe has **not** been rendered end-to-end against a live
+Sigma org. Doing that needs a workbook with a control and an action already
+wired to `selected`/`onSelect`, which is a live-workbook setup step outside
+a reference document. Treat this as a documented, SDK-correct starting
+point to adapt and verify yourself — not as a pre-verified artifact.
+
+```html
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>Click-to-filter list (recipe)</title>
+<style>
+  body { margin: 0; font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif; }
+  #list-root { padding: 8px; }
+  .list-row { padding: 6px 10px; cursor: pointer; border-radius: 4px; }
+  .list-row:hover { background: #f3f4f6; }
+  .list-row.is-active { background: #e0e7ff; font-weight: 600; }
+  .list-empty { color: #6b7280; padding: 8px; }
+</style>
+</head>
+<body>
+<div id="list-root"><div class="list-empty">Loading…</div></div>
+
+<script crossorigin src="https://unpkg.com/react@18.3.1/umd/react.production.min.js"></script>
+<script src="https://unpkg.com/@sigmacomputing/plugin"></script>
+<script>
+(function () {
+  'use strict';
+
+  // Loaded via the CDN <script> tag, the SDK's UMD build exposes its named
+  // exports (client, useConfig, ...) on a `window.SigmaPlugin` global rather
+  // than through an import statement. React must load first — it's a hard
+  // peer dependency of the UMD build, which dereferences it at load and,
+  // if absent, throws before assigning `client`, leaving no client at all
+  // (not just a null one). No client (e.g. this file opened directly in a
+  // browser, or React missing) -> render a static demo list, no writeback
+  // wired.
+  var client = (typeof window.SigmaPlugin !== 'undefined') ? window.SigmaPlugin.client : null;
+  var root = document.getElementById('list-root');
+
+  function showMessage(text) {
+    root.innerHTML = '';
+    var msg = document.createElement('div');
+    msg.className = 'list-empty';
+    msg.textContent = text;
+    root.appendChild(msg);
+  }
+
+  function paintList(labels, activeLabel, onPick) {
+    if (!labels.length) return showMessage('No rows for this selection.');
+    root.innerHTML = '';
+    labels.forEach(function (label) {
+      var row = document.createElement('div');
+      row.className = 'list-row' + (label === activeLabel ? ' is-active' : '');
+      row.textContent = label;
+      row.addEventListener('click', function () { onPick(label); });
+      root.appendChild(row);
+    });
+  }
+
+  if (!client) {
+    paintList(['North', 'South', 'East', 'West'], null, function () {});
+    return;
+  }
+
+  client.config.configureEditorPanel([
+    { name: 'source', type: 'element' },
+    { name: 'categoryColumn', type: 'column', source: 'source', allowMultiple: false, label: 'Category Column' },
+    { name: 'selected', type: 'variable', label: 'Selected Category', allowedTypes: ['text'] },
+    { name: 'onSelect', type: 'action-trigger', label: 'On Select' }
+  ]);
+
+  var unsubData = null;
+  var activeLabel = null;
+
+  function handlePick(config, labels, label) {
+    activeLabel = label;
+    // 1. the WHAT — set the variable (text variables want String() coercion).
+    client.config.setVariable(config.selected, String(label));
+    // 2. the REACT-NOW — tell the workbook to notice it.
+    client.config.triggerAction(config.onSelect);
+    paintList(labels, activeLabel, function (nextLabel) { handlePick(config, labels, nextLabel); });
+  }
+
+  client.config.subscribe(function (config) {
+    if (unsubData) { unsubData(); unsubData = null; }
+
+    if (!config.source) return showMessage('Choose a data source.');
+    if (!config.categoryColumn) return showMessage('Choose a category column.');
+
+    unsubData = client.elements.subscribeToElementData(config.source, function (data) {
+      var values = data[config.categoryColumn];
+      if (!values || !values.length) return showMessage('No rows for this selection.');
+
+      var labels = Array.from(new Set(values.filter(function (v) { return v !== null; })));
+      paintList(labels, activeLabel, function (label) { handlePick(config, labels, label); });
+    });
+  });
+})();
+</script>
+</body>
+</html>
+```

--- a/sigma-plugin-authoring/reference/plugin-lifecycle.md
+++ b/sigma-plugin-authoring/reference/plugin-lifecycle.md
@@ -1,0 +1,244 @@
+# Plugin Lifecycle — Verified Gotchas
+
+This is the canonical reference for the `@sigmacomputing/plugin` lifecycle:
+**build → register → host → embed → bind → verify.** Every gotcha below was
+proven against a live Sigma org (the gauge archetype shipped with this skill)
+before being written down here — read this before registering or embedding a
+plugin, not after hitting the failure.
+
+The worked example throughout is the gauge plugin shipped with this skill:
+`plugins/gauge/index.html` (+ `plugins/gauge/README.md`), whose emitter output
+is `examples/gauge-embed.json`.
+
+## 1. Registration: `POST /v2/plugins`
+
+```
+POST /v2/plugins
+{ "name": "<unique plugin name>", "description": "<what it does>",
+  "url": "<hosted index.html URL>", "type": "element" }
+```
+
+A successful register returns a `pluginId`. **Always call
+`scripts/register-plugin.rb` (`PluginRegister.register_or_get`)** rather
+than hand-rolling this — it already encodes the two gotchas below and is
+idempotent (safe to call repeatedly for the same `name`).
+
+### Masked 404 can accompany a *successful* register
+
+Sigma has been observed to return a non-2xx (masked 404-shaped) response on a
+`POST /v2/plugins` call that actually registered the plugin. **Never treat a
+non-2xx POST response as a hard failure by itself.** Always follow up with
+`GET /v2/plugins` and search the `entries` for a plugin matching the `name` you
+just sent — if it's there, the register succeeded regardless of what the POST
+response said. `register_or_get` does this automatically: GET-by-name first
+(idempotent short-circuit), POST if not found, then re-GET-by-name before
+deciding pass/fail.
+
+### Registration may be 403 org-admin-gated
+
+In some orgs, plugin registration requires org-admin credentials — a
+non-admin token gets a real 401/403 (not the masked-404 case above; this one
+is a genuine permission denial, confirmed by the follow-up GET *also* coming
+up empty). **Fall back to handoff**: hand the user the built plugin bundle,
+the exact hosting steps, and the exact `curl`/`register-plugin.rb` invocation
+to run once they have an org-admin token. Never silently drop the viz or fake
+a `pluginId`. `register_or_get` raises `PluginRegister::PermissionError` with
+this message shape so callers can catch it and switch to handoff.
+
+### `url` is set-once per registration
+
+Once registered, a plugin's `url` cannot be edited via the same registration
+call — if the hosted bundle moves (e.g. from localhost to a public host, or a
+new static-deploy URL), **re-register** (a new `POST /v2/plugins`, which
+mints a new `pluginId`) rather than expecting an in-place update. Downstream
+workbook specs that embedded the old `pluginId` will need to be repointed to
+the new one.
+
+## 2. Hosting: localhost is dev-iteration only; a PERSISTENT public host is required for anyone else to see it render
+
+A plugin hosted on `localhost` renders correctly in any **human's browser**
+that has it open — so building, previewing, and even binding real workbook
+data against it all work fine on localhost. What does **not** work on
+localhost: Sigma's **server-side rendering** (headless PNG export, scheduled
+PDF/email sends, any path that doesn't route through a human's browser)
+cannot reach it — it needs a **publicly reachable URL**. Nor does any
+*other* human — a teammate, a reviewer, an end user — who doesn't have that
+same localhost open. Treat localhost as dev-iteration only: fine for the
+person actively building the plugin, never sufficient for a shared or
+headlessly-rendered result.
+
+An **ephemeral tunnel** (a free-tier `ngrok`/`cloudflared` process, etc.) is
+not a fix either — it dies with the process, and some free tiers inject an
+interstitial page that a headless render server can't click through (no
+human to send the bypass header). The requirement is **persistence**, not
+just "has a public DNS name."
+
+**This is a hosting-platform decision the customer/user owns — this skill
+does not prescribe a vendor.** Ask (or use context to infer) which persistent
+public static host they prefer, then register the plugin at *that* host's
+URL. Common options, none of them a default:
+
+- The customer's own static-hosting setup (an existing S3+CloudFront /
+  internal CDN / corporate web server they already use for internal tools).
+- GitHub Pages, Netlify, Vercel, Cloudflare Pages, or any comparable static
+  host, on whichever account/org the customer controls.
+
+The registration and embed mechanics are **entirely host-neutral** —
+`register-plugin.rb` (`PluginRegister.register_or_get`) and
+`plugin_embed.rb` (`PluginEmbed.build`) don't care which host served the
+bundle, only that its URL is persistent and reachable. Once you have *a*
+persistent public URL from *any* host, the steps in §1/§3 are identical.
+
+Practical consequence for verification: treat **data-parity** (export the
+plugin's bound element and compare the numbers) as the hard, always-provable
+gate — it works regardless of host. Treat the **visual screenshot** as
+depending on the host being persistent and public; on localhost or a dead/
+ephemeral tunnel, skip it with an honest note rather than faking a render.
+
+**Handoff is the default; turnkey is opt-in.** Emit the plugin bundle plus
+the exact host + register steps and let the user (or their CI) host it on
+their platform of choice — that's always correct and requires no new
+infrastructure trust from this skill. Automating a static deploy end-to-end
+is a fast-follow, not built into this skill; if the user already has an
+authenticated static-host CLI available, using it to get a persistent public
+URL up front makes the visual gate provable too, but never assume a
+particular one is present or preferred.
+
+*Worked example (illustrative only — not the standard):* this skill's own
+live acceptance test hosts the gauge plugin at
+`https://<your-org>.github.io/<repo>/gauge/`, a GitHub Pages site on a
+dedicated public repo (`main` branch, `/` root), used purely to prove the
+render lifecycle end-to-end during this skill's development. Substitute
+the customer's actual preferred host for production use — this URL is a
+demonstration, not a dependency.
+
+## 3. Embed shape: every *binding* value is a bare string
+
+The Sigma workbook-spec plugin element looks like:
+
+```json
+{
+  "id": "<element id>",
+  "kind": "plugin",
+  "pluginId": "<from registration>",
+  "config": {
+    "source": { "kind": "element", "elementId": "<bound data element id>" },
+    "<editor-panel var>": "<columnId or literal, as a STRING>"
+  }
+}
+```
+
+`config.source` is the **one** structured field — a fixed
+`{"kind":"element","elementId":...}` object naming the data element the
+plugin reads from. **Every other key in `config`** — every editor-panel
+binding (`value`, `target`, or whatever variables the plugin's
+`configureEditorPanel` declared) and any extra config (e.g. `format`) — **must
+be a bare string**, even when the underlying value is a `columnId` or a
+number. Sending a binding as a nested object (e.g. the
+`{"kind":"column","columnId":"..."}` shape used elsewhere in workbook specs)
+is **silently rejected**: the API does not name the offending field, it masks
+the failure as a generic `Invalid kind:"plugin"` error on the whole element.
+If you hit that error, the first thing to check is whether a config value
+that should be a string got emitted as an object or a number.
+
+**Don't hand-write this JSON — call the emitter:**
+
+`PluginEmbed.build(id:, plugin_id:, source_element_id:, bindings:, extra_config: {})` — `scripts/plugin_embed.rb`
+
+It coerces every `bindings`/`extra_config` value to a string (so a
+numeric `2` becomes `"2"`) and always emits the correct `config.source` shape.
+`bindings` maps editor-panel var name → `columnId` (e.g.
+`{"value" => "actual", "target" => "target"}`); `extra_config` is anything
+else non-binding (e.g. `{"format" => ".0%"}`). See
+`examples/gauge-embed.json` for a full worked output.
+
+## 4. The plugin's backing data element needs its own hidden page
+
+The `source.elementId` a plugin binds to is a normal table/element in the
+workbook — but if you don't want it visible to end users, **put it on a
+separate hidden page**. Setting `visibleAsSource:false` on the element alone
+does **not** remove it from layout / visibility — pages are the actual
+visibility boundary. See the `sigma-workbooks` skill's layout reference for
+how to mark a page hidden.
+
+## 5. `ResizeObserver` is mandatory — the #1 "wonky plugin" cause
+
+A plugin that only relies on CSS or SVG `viewBox` scaling to handle resize
+ends up with illegible text or a clipped/distorted drawing at small panel
+widths — this is the single most common way a hand-built plugin looks broken
+in a real dashboard (where panels get resized constantly). The fix: attach a
+`ResizeObserver` to the render container and, on every resize event, **fully
+recompute** geometry (stroke width, font size, arc/shape dimensions) from the
+container's actual current box and re-render from scratch — not an
+incremental CSS-only patch. The gauge plugin
+(`plugins/gauge/index.html`) does exactly this: its `ResizeObserver` callback
+calls the same size-driven `render()` function used for the initial paint, so
+the same code path is exercised whether the panel first loads at 1100px or
+gets dragged down to 550px.
+
+## 6. Synthetic fallback — preview standalone, without a Sigma host
+
+Every plugin should render *something* sensible when opened directly in a
+browser (no Sigma `client`) or when the bound `value`/`target` columns don't
+resolve to a complete row — a `synth()` path that fabricates plausible demo
+data (the gauge uses `value: 82, target: 100`). This makes the plugin file
+independently previewable (open it in a browser, or screenshot it at multiple
+widths) before it's ever registered or embedded, which is the fastest way to
+iterate on layout/rendering without round-tripping through Sigma.
+
+## 7. The SDK's UMD build needs React loaded BEFORE it (silent-synth trap)
+
+`@sigmacomputing/plugin`'s UMD/CDN build — what
+`<script src="https://unpkg.com/@sigmacomputing/plugin">` gives you — has
+**React as a hard peer dependency**. Its factory dereferences React at load; if
+React isn't already on the page it **throws before assigning `client`**, leaving
+`window.SigmaPlugin` an empty object with no `client`. The plugin then has no way
+to read bound data and silently falls through to its `synth()` fallback (§6) —
+so it *looks* like it works (shows demo numbers) while never touching real data.
+Sigma does **not** inject React into the plugin iframe, so a vanilla single-file
+plugin must load React itself, **first**:
+
+```html
+<script crossorigin src="https://unpkg.com/react@18.3.1/umd/react.production.min.js"></script>
+<script src="https://unpkg.com/@sigmacomputing/plugin"></script>
+```
+
+`ReactDOM` is **not** required for the vanilla `client` API — only `React`. Pin
+the version. For a plugin that must render in restrictive/offline contexts, host
+React and the SDK on the plugin's **own origin** instead of a CDN. This is the
+single most likely reason a freshly built plugin "renders fine" but shows demo
+numbers instead of your data. Verified against `@sigmacomputing/plugin` v1.2.0;
+see `reference/sdk-api.md` for the full `client` shape.
+
+## 8. Sigma's server-side PNG export does NOT hydrate plugin data
+
+The workbook **PNG export / screenshot** API renders a plugin's page,
+initializes its `client`, and fires `config.subscribe` with the correct
+bindings — but it does **not** deliver the plugin's asynchronous element data
+before it snapshots (the `subscribeToElementData` callback never fires in that
+environment, even with the source element on the exported page). So a
+server-rendered screenshot of a plugin shows its **`synth()` fallback, not live
+data** — a limitation of PNG export for plugins, not a plugin bug. For
+verification:
+
+- **Do not** treat a plugin's PNG-export screenshot as proof it reads real data
+  — it structurally cannot show that.
+- Verify **data-parity at the element level**: export the bound
+  `source.elementId` and assert its values (headless, independent of the
+  plugin).
+- Confirm the plugin's **live rendering** of that data only in a **live browser
+  session** (interactive workbook or a signed embed), where Sigma pushes element
+  data to the subscription normally.
+- Watch for coincidental literals: the gauge's `synth()` fallback happens to
+  use `82`/`100` as demo numbers, so a screenshot showing "82 of 100" proves
+  nothing either way — it's exactly the coincidence that let the original
+  silent-synth bug hide behind a correct-looking render; element-level
+  data-parity is the real gate.
+
+## 9. Emitter recap
+
+| Concern | Tool |
+|---|---|
+| Register (idempotent, masked-404/403-aware) | `scripts/register-plugin.rb` (`PluginRegister.register_or_get`) |
+| Emit the embed JSON (bare-string config, correct `source` shape) | `scripts/plugin_embed.rb` (`PluginEmbed.build`) |
+| Worked example (plugin + emitter output) | `plugins/gauge/` + `examples/gauge-embed.json` |

--- a/sigma-plugin-authoring/reference/sdk-api.md
+++ b/sigma-plugin-authoring/reference/sdk-api.md
@@ -1,0 +1,339 @@
+# SDK API Reference — Editor Panel, Client, and Hooks
+
+Lookup-oriented reference for the `@sigmacomputing/plugin` surface a plugin
+uses to declare its data contract (the editor panel) and read/write
+config, element data, variables, and actions once embedded. It does **not**
+cover getting a plugin registered, hosted, or embedded — that's
+`reference/plugin-lifecycle.md` (masked 404/403 on registration, `url`
+set-once, the localhost/hosting boundary, the bare-string `config` shape,
+the hidden backing page, `ResizeObserver`, the synthetic-fallback
+convention). Read that first if you haven't shipped a plugin before; this
+file assumes it and only adds the authoring surface.
+
+Every fact below is checked against the SDK's own published type
+declarations (`@sigmacomputing/plugin`, npm/GitHub — `sigmacomputing/plugin`,
+MIT — a different, unrestricted source from the clean-room secondary
+material this reference otherwise drew guidance from). Where the two
+disagreed, this file follows the published types and says so.
+
+## 1. Editor-panel config types
+
+`client.config.configureEditorPanel([...])` (or the `useEditorPanelConfig`
+hook, called once per render inside a component) declares the fields a
+workbook author fills in from Sigma's side panel for this plugin element.
+Every entry needs a unique `name` — the key you read its value back under —
+and a `type`. One of each type, with the properties specific to it:
+
+**`element`** — the one data-source picker every data-driven plugin needs.
+```js
+{ name: 'dataSource', type: 'element' }
+```
+Every `column`/`variable`-adjacent entry that needs to scope to it names it
+via `source: 'dataSource'`.
+
+**`column`** — pick a column out of an `element` entry.
+```js
+{
+  name: 'metricColumn',
+  type: 'column',
+  source: 'dataSource',                  // required — the element entry to pick from
+  allowMultiple: false,                  // true -> string[]; false -> string
+  allowedTypes: ['number', 'integer'],   // restrict to specific ValueType(s)
+  label: 'Metric'
+}
+```
+
+**`text`** — free-form string input; the backbone of the JSON-settings
+pattern (`patterns.md`) when paired with `multiline: true`.
+```js
+{
+  name: 'title', type: 'text', label: 'Panel Title',
+  defaultValue: '', placeholder: 'Untitled panel',
+  multiline: false,   // true renders a textarea
+  secure: false         // true masks input and omits it from pre-hydrated/URL config
+}
+```
+
+**`toggle`** / **`checkbox`** — both resolve to a `boolean`; pick whichever
+label style reads better in the panel. Both accept an optional
+`defaultValue: boolean`.
+```js
+{ name: 'showLegend', type: 'toggle', label: 'Show Legend', defaultValue: true }
+```
+
+**`radio`** — small fixed choice set.
+```js
+{
+  name: 'orientation', type: 'radio',
+  values: ['vertical', 'horizontal'],
+  singleLine: true,       // render inline instead of stacked — good for 2-3 options
+  defaultValue: 'vertical',
+  label: 'Orientation'
+}
+```
+
+**`dropdown`** — larger fixed choice set.
+```js
+{
+  name: 'aggregation', type: 'dropdown',
+  values: ['sum', 'avg', 'min', 'max'],
+  width: '160',            // pixel width — the SDK types this as a string, not a number
+  defaultValue: 'sum',
+  label: 'Aggregation'
+}
+```
+
+**`color`** — a color-picker input; value is a color string.
+```js
+{ name: 'accentColor', type: 'color', label: 'Accent Color' }
+```
+
+**`variable`** — bind to a workbook control variable; the read/write half
+of interactivity (see the writeback pattern in `patterns.md`).
+```js
+{
+  name: 'activeCategory', type: 'variable', label: 'Active Category',
+  allowedTypes: ['text']   // restrict to a ControlType — see enum below
+}
+```
+
+**`interaction`** — bind to cross-element selection state.
+**Deprecated as of the current published SDK — "Use Action API instead."**
+The type still exists and the `client.config.getInteraction`/`setInteraction`
+methods still work, but new plugins should reach for `action-trigger` +
+`action-effect` (below) instead of `interaction` for cross-element behavior.
+```js
+{ name: 'crossSelect', type: 'interaction', label: 'Selection Binding' } // legacy
+```
+
+**`action-trigger`** — the plugin fires a workbook action.
+```js
+{ name: 'onSelect', type: 'action-trigger', label: 'On Select' }
+```
+Paired with a `variable` for the headline writeback pattern: set the
+variable (the *what*), then fire the trigger (the *react now*).
+
+**`action-effect`** — the workbook invokes a callback inside the plugin;
+the inverse direction of `action-trigger`.
+```js
+{ name: 'onReset', type: 'action-effect', label: 'Reset Plugin' }
+```
+
+**`url-parameter`** — sync a value to the page URL for deep-linking. Note:
+this type's own declared shape omits `label` — it has no display label.
+```js
+{ name: 'deepLinkFilter', type: 'url-parameter' }
+```
+
+**`group`** — a purely visual grouping of related entries in the panel; no
+`source` property (unlike `column`/`dropdown`) and no runtime config value
+of its own.
+```js
+{ name: 'advanced', type: 'group', label: 'Advanced' }
+```
+
+### Config-value-by-type
+
+What `client.config.getKey(name)` / `useConfig()` hands back for each type:
+
+| Config `type` | Runtime value |
+|---|---|
+| `element` | `string` (element ID) or `undefined` until chosen |
+| `column`, `allowMultiple: false` | `string` (column ID) or `undefined` |
+| `column`, `allowMultiple: true` | `string[]` |
+| `text` | `string` |
+| `toggle` / `checkbox` | `boolean` |
+| `radio` / `dropdown` | one member of `values` |
+| `color` | `string` |
+| `variable` | `string` — a config ID; pass it to `getVariable`/`useVariable`, it is not the variable's value |
+| `interaction` (deprecated) | `string` — a config ID; pass to `getInteraction`/`setInteraction` |
+| `action-trigger` | `string` — a config ID; pass to `triggerAction`/`useActionTrigger` |
+| `action-effect` | `string` — a config ID; pass to `registerEffect`/`useActionEffect` |
+| `url-parameter` | `string` — a config ID; pass to the URL-parameter methods |
+| `group` | no runtime value — structural only |
+
+### ControlType (valid `allowedTypes` for a `variable` entry)
+`'boolean' | 'date' | 'number' | 'text' | 'text-list' | 'number-list' | 'date-list' | 'number-range' | 'date-range'`
+
+### ValueType (valid `allowedTypes` for a `column` entry)
+`'boolean' | 'datetime' | 'number' | 'integer' | 'text' | 'variant' | 'link' | 'error'`
+
+## 2. Reading config & data — two idioms
+
+> ⚠️ **Load React before the SDK.** The UMD build
+> (`<script src="https://unpkg.com/@sigmacomputing/plugin">`) has React as a
+> hard peer dependency and **throws at load if React is absent**, leaving
+> `window.SigmaPlugin` with no `client` — so *none* of the calls below work and
+> the plugin silently synths. Put a React `<script>` (React alone; ReactDOM not
+> needed for `client`) before the SDK. Full detail + the fix snippet:
+> `reference/plugin-lifecycle.md` §7.
+
+Every read/write has a vanilla `client.*` form and, in a React plugin, a
+hook form; both talk to the same underlying channel. Pick one idiom per
+file — don't mix them for the same value.
+
+**Namespace note:** several of these live under `client.config.*` in the
+current published SDK even though they aren't strictly about "config" —
+`getVariable`/`setVariable`, `getInteraction`/`setInteraction`,
+`triggerAction`, `registerEffect`, `setLoadingState`, and the
+URL-parameter methods are all `client.config.X`, not top-level `client.X`.
+Only `client.elements.*`, `client.style.*`, `client.sigmaEnv`, and
+`client.destroy()` sit outside `config`.
+
+### Side-by-side
+
+| Concern | Vanilla client API | React hook |
+|---|---|---|
+| Define the editor panel | `client.config.configureEditorPanel(entries)` | `useEditorPanelConfig(entries)` |
+| Read all config | `client.config.get()` / `client.config.subscribe(cb)` | `useConfig()` |
+| Read one config value | `client.config.getKey(name)` | `useConfig(name)` or destructure from `useConfig()` |
+| Write config | `client.config.set(partial)` / `client.config.setKey(name, value)` | same calls — there's no separate writer hook |
+| Element data | `client.elements.subscribeToElementData(sourceId, cb)` | `useElementData(sourceId)` |
+| Column metadata | `client.elements.subscribeToElementColumns(sourceId, cb)` | `useElementColumns(sourceId)` |
+| Variable read/write | `client.config.getVariable(id)` / `client.config.setVariable(id, ...values)` / `client.config.subscribeToWorkbookVariable(id, cb)` | `const [variable, setVariable] = useVariable(id)` |
+| Fire an action | `client.config.triggerAction(id)` | `const fire = useActionTrigger(id); fire()` |
+| Receive an action | `client.config.registerEffect(id, cb)` — returns an unsubscribe fn | `useActionEffect(id, cb)` |
+| Interaction (selection) — **deprecated**, prefer action-trigger/-effect | `client.config.getInteraction(id)` / `client.config.setInteraction(id, elementId, selection)` | `useInteraction(id, elementId)` — also deprecated |
+| URL parameter | `client.config.getUrlParameter(name)` / `client.config.setUrlParameter(name, value)` / `client.config.subscribeToUrlParameter(name, cb)` | `useUrlParameter(name)` |
+| Style | `client.style.get()` / `client.style.subscribe(cb)` | `usePluginStyle()` |
+| Environment | `client.sigmaEnv` | same — a plain property, no hook needed |
+| Loading indicator | `client.config.setLoadingState(bool)` | `useLoadingState(initialBool)` returns `[isLoading, setIsLoading]` |
+| Teardown | `client.destroy()` | handled by component unmount in practice |
+
+The SDK also ships `usePlugin()` (the whole `PluginInstance`) and
+`usePaginatedElementData`/`elements.fetchMoreElementData` (data beyond the
+default page size) — real, but out of scope for this reference; see the
+package's own README for those.
+
+### Vanilla client API surface
+```js
+import { client } from '@sigmacomputing/plugin';
+
+client.config.configureEditorPanel(entries);
+client.config.get();                        // full config object, once
+client.config.getKey('metricColumn');        // one value, once
+client.config.set({ title: 'New Title' });   // shallow merge into current config
+client.config.setKey('title', 'New Title');  // write a single key
+const stopConfig = client.config.subscribe((cfg) => { /* runs on every change */ });
+
+client.elements.subscribeToElementData(sourceId, (data) => { /* column-oriented rows */ });
+client.elements.subscribeToElementColumns(sourceId, (cols) => { /* metadata */ });
+
+client.config.getVariable(varId);                        // { name, defaultValue: { type, value } }
+client.config.setVariable(varId, newValue);               // range variables take 2 args
+const stopVar = client.config.subscribeToWorkbookVariable(varId, (v) => {});
+
+client.config.triggerAction(actionId);
+const stopEffect = client.config.registerEffect(effectId, () => { /* workbook triggered this */ });
+
+client.config.getUrlParameter('deepLinkFilter');           // { value: string }
+client.config.setUrlParameter('deepLinkFilter', 'east-region');
+const stopUrl = client.config.subscribeToUrlParameter('deepLinkFilter', (v) => {});
+
+client.style.get();               // Promise<{ backgroundColor: string }> — workbook theme
+client.style.subscribe((style) => {});
+
+client.sigmaEnv;                  // 'author' | 'viewer' | 'explorer'
+client.config.setLoadingState(true);  // show/hide Sigma's own loading indicator for this element
+client.destroy();                 // tear down every subscription this client created
+```
+`setVariable`/`setKey`/`set`/`triggerAction` are declared to return `void`
+(they post a message to the host and don't hand back a result to await).
+Some example code still wraps them in `await` anyway — harmless on a
+non-`Promise` return, and it defers the next statement to a microtask,
+which is a cheap way to make sure a variable write has a moment to
+propagate before a dependent trigger fires.
+
+### React hooks
+```js
+import {
+  useConfig, useEditorPanelConfig,
+  useElementData, useElementColumns,
+  useVariable, useActionTrigger, useActionEffect
+} from '@sigmacomputing/plugin';
+
+useEditorPanelConfig(entries);                    // define the panel from inside a component
+const config = useConfig();                       // all config values, re-renders on change
+const rows = useElementData(config.dataSource || '');
+const cols = useElementColumns(config.dataSource || '');
+const [variable, setVariable] = useVariable(config.activeCategory || '');
+const fireOnSelect = useActionTrigger(config.onSelect || '');
+useActionEffect(config.onReset || '', () => { /* workbook told the plugin to reset */ });
+```
+Guard every hook call with `|| ''` when the underlying config key might
+still be `undefined` — the plugin renders before the author finishes
+configuring it (see the graceful-loading pattern in `patterns.md`).
+
+## 3. Element data shape
+
+Data from `useElementData`/`subscribeToElementData` is **column-oriented**:
+```ts
+{ [columnId: string]: any[] }   // the SDK types values loosely; in practice
+                                 // each entry is a string, number, boolean, or null
+```
+Every column array is the same length (one entry per row).
+
+**Column IDs are not display names.** A key like `col-3f8a1c` says nothing
+about what the column *is* — resolve the human-readable name from the
+parallel column-metadata object (`useElementColumns`/`subscribeToElementColumns`):
+```ts
+{
+  [columnId: string]: {
+    id: string;
+    name: string;         // display name, e.g. "Order Total"
+    columnType: string;   // ValueType — 'text' | 'number' | 'integer' | 'datetime' | 'boolean' | ...
+    // Commonly also carries a `format` object at runtime — { type: string, format: string } —
+    // with a d3-format string for numeric types (e.g. "$,.2f") or a d3-time-format string for
+    // date/datetime types (e.g. "%Y-%m-%d"). This isn't part of the published column-metadata
+    // type as of SDK v1.2.0, so read it defensively: `columnMeta?.format?.format`.
+  }
+}
+```
+
+### Column → row transform
+Most rendering libraries want rows, not columns:
+```js
+function toRows(columnData, columnIds, columnMeta) {
+  const length = columnData[columnIds[0]]?.length ?? 0;
+  const rows = [];
+  for (let i = 0; i < length; i++) {
+    const row = {};
+    for (const id of columnIds) {
+      const key = columnMeta?.[id]?.name ?? id;
+      row[key] = columnData[id][i];
+    }
+    rows.push(row);
+  }
+  return rows;
+}
+```
+
+## 4. Defensive date handling
+
+Dates can arrive as an ISO string, a numeric timestamp (epoch seconds *or*
+milliseconds — inconsistent across sources), or an already-constructed
+`Date`. Never assume one shape:
+```js
+function parseDate(raw) {
+  if (raw === null || raw === undefined) return null;
+  if (raw instanceof Date) return isNaN(raw.getTime()) ? null : raw;
+  if (typeof raw === 'number') {
+    // Below ~10 billion, treat as epoch seconds; otherwise it's already milliseconds.
+    const ms = raw < 1e10 ? raw * 1000 : raw;
+    const d = new Date(ms);
+    return isNaN(d.getTime()) ? null : d;
+  }
+  if (typeof raw === 'string') {
+    const d = new Date(raw);
+    return isNaN(d.getTime()) ? null : d;
+  }
+  return null;
+}
+```
+Use the column-metadata `format.format` (a d3-time-format string, when
+present — see the hedge above) if you need to render a date the way Sigma
+would, rather than hard-coding a display format.
+
+This is a **column-value** parsing concern. A *variable's* date value has
+its own, different wrapping problem (an extra object layer, not a type
+ambiguity) — see the unwrap recipe in `patterns.md`.

--- a/sigma-plugin-authoring/scripts/lib/sigma_rest.rb
+++ b/sigma-plugin-authoring/scripts/lib/sigma_rest.rb
@@ -1,0 +1,137 @@
+# Sigma REST API wrapper with automatic 401 retry + token refresh.
+#
+# Sigma OAuth bearer tokens expire after ~1 hour. Long-running scripts (a
+# 30-min conversion, an hour+ batch orchestration, an assessment readout)
+# routinely outlive a single token and would otherwise fail mid-run.
+#
+# This module mirrors the shape of `tableau_rest.rb`. It provides:
+#   - `Sigma.refresh_token!`         — re-do client_credentials exchange,
+#                                       update in-memory token under a mutex
+#   - `Sigma.request(method, path)`  — catches 401, refreshes once, retries
+#
+# Required env: SIGMA_BASE_URL, SIGMA_CLIENT_ID, SIGMA_CLIENT_SECRET.
+# Optional env: SIGMA_API_TOKEN (initial token; refreshed on demand).
+#
+# Usage:
+#   require_relative 'lib/sigma_rest'
+#   wb = Sigma.request(:get, "/v2/workbooks/#{id}")
+#   Sigma.request(:post, '/v2/workbooks/spec', body: spec.to_json)
+#
+# All methods return parsed Hash/Array (or raw bytes for binary endpoints).
+
+require 'net/http'
+require 'uri'
+require 'json'
+require 'base64'
+
+# File-based token handoff (shell-neutral, kills the `eval "$(get-token.sh)"`
+# bash idiom that PowerShell/cmd cannot run). scripts/get_token.py writes
+# <WORK>/auth.json = {"SIGMA_API_TOKEN": ..., "SIGMA_BASE_URL": ...}. Read it
+# here so any shell/agent can mint once (python) and every downstream Ruby
+# script picks the token up. Precedence: explicit env ALWAYS wins → auth.json →
+# (below) client-credential self-mint via refresh_token!. auth.json should be
+# kept out of version control — it holds a live bearer token, never print it.
+if ENV['SIGMA_API_TOKEN'].nil?
+  _auth_candidates = [ENV['SIGMA_WORKDIR'], Dir.pwd].compact
+                        .map { |d| File.join(d, 'auth.json') }
+  _auth_path = _auth_candidates.find { |p| File.exist?(p) }
+  if _auth_path
+    begin
+      _auth = JSON.parse(File.read(_auth_path, encoding: 'bom|utf-8'))
+      ENV['SIGMA_API_TOKEN'] ||= _auth['SIGMA_API_TOKEN'] if _auth['SIGMA_API_TOKEN']
+      ENV['SIGMA_BASE_URL']  ||= _auth['SIGMA_BASE_URL']  if _auth['SIGMA_BASE_URL']
+    rescue JSON::ParserError
+      # A corrupt auth.json must not wedge the run — fall through to self-mint.
+    end
+  end
+end
+
+module Sigma
+  class Error < StandardError; end
+  class AuthError < Error; end
+
+  @token_mutex = Mutex.new
+  @token_override = nil
+  @refresh_inflight = false
+
+  module_function
+
+  def base_url
+    ENV.fetch('SIGMA_BASE_URL') { raise Error, 'SIGMA_BASE_URL not set' }
+  end
+
+  def auth_token
+    @token_mutex.synchronize { @token_override } || ENV['SIGMA_API_TOKEN'] || refresh_token!
+  end
+
+  # Re-do the OAuth client_credentials exchange and store the new token.
+  # Thread-safe and single-flight: concurrent callers all wait for one
+  # exchange and share the result. Returns the new token.
+  def refresh_token!
+    @token_mutex.synchronize do
+      return @token_override if @refresh_inflight
+      @refresh_inflight = true
+    end
+    begin
+      cid    = ENV.fetch('SIGMA_CLIENT_ID')     { raise AuthError, 'SIGMA_CLIENT_ID not set' }
+      secret = ENV.fetch('SIGMA_CLIENT_SECRET') { raise AuthError, 'SIGMA_CLIENT_SECRET not set' }
+      creds = Base64.strict_encode64("#{cid}:#{secret}")
+      uri = URI("#{base_url}/v2/auth/token")
+      req = Net::HTTP::Post.new(uri)
+      req['Authorization'] = "Basic #{creds}"
+      req['Content-Type']  = 'application/x-www-form-urlencoded'
+      req.body = 'grant_type=client_credentials'
+      res = Net::HTTP.start(uri.host, uri.port, use_ssl: true, read_timeout: 30) { |h| h.request(req) }
+      raise AuthError, "token exchange -> #{res.code} #{res.body}" unless res.is_a?(Net::HTTPSuccess)
+      tok = JSON.parse(res.body)['access_token']
+      raise AuthError, "token exchange returned no access_token: #{res.body}" if tok.nil? || tok.empty?
+      @token_mutex.synchronize { @token_override = tok }
+      # Surface the refreshed token to child processes / shell evals.
+      ENV['SIGMA_API_TOKEN'] = tok
+      tok
+    ensure
+      @token_mutex.synchronize { @refresh_inflight = false }
+    end
+  end
+
+  def request(method, path, body: nil, content_type: 'application/json', accept: 'application/json', binary: false, http: nil)
+    uri = URI("#{base_url}#{path}")
+    attempts = 0
+    loop do
+      attempts += 1
+      req = case method
+            when :get    then Net::HTTP::Get.new(uri)
+            when :post   then Net::HTTP::Post.new(uri)
+            when :put    then Net::HTTP::Put.new(uri)
+            when :patch  then Net::HTTP::Patch.new(uri)
+            when :delete then Net::HTTP::Delete.new(uri)
+            else raise ArgumentError, "unsupported method #{method}"
+            end
+      req['Authorization'] = "Bearer #{auth_token}"
+      req['Accept']        = accept
+      if body
+        req['Content-Type'] = content_type
+        req.body = body
+      end
+
+      res = if http
+              http.request(req)
+            else
+              Net::HTTP.start(uri.host, uri.port, use_ssl: true, read_timeout: 120) { |h| h.request(req) }
+            end
+
+      # Sigma returns 401 with code:"unauthorized" when the bearer expires.
+      # Refresh once and retry; on a second 401, surface the error.
+      if res.code.to_i == 401 && attempts == 1 && ENV['SIGMA_CLIENT_ID']
+        refresh_token!
+        next
+      end
+      unless res.is_a?(Net::HTTPSuccess)
+        raise Error, "#{method.upcase} #{path} -> #{res.code} #{res.message}\n#{res.body}"
+      end
+      return res.body if binary
+      return res.body unless accept == 'application/json'
+      return res.body.empty? ? nil : JSON.parse(res.body)
+    end
+  end
+end

--- a/sigma-plugin-authoring/scripts/plugin_embed.rb
+++ b/sigma-plugin-authoring/scripts/plugin_embed.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+# plugin_embed.rb — emits the VERIFIED Sigma {kind:"plugin"} element block.
+# ALL config values are bare strings (object form is rejected, masked
+# "Invalid kind:\"plugin\""). Stdlib only (json); Ruby 2.6-compatible.
+require 'json'
+module PluginEmbed
+  def self.build(id:, plugin_id:, source_element_id:, bindings:, extra_config: {})
+    raise ArgumentError, 'id required' if id.to_s.empty?
+    raise ArgumentError, 'plugin_id required' if plugin_id.to_s.empty?
+    raise ArgumentError, 'source_element_id required' if source_element_id.to_s.empty?
+    config = { 'source' => { 'kind' => 'element', 'elementId' => source_element_id } }
+    (bindings || {}).each { |k, v| config[k.to_s] = v.to_s }        # bare string columnId
+    (extra_config || {}).each { |k, v| config[k.to_s] = v.to_s }    # ALL config values -> string
+    { 'id' => id, 'kind' => 'plugin', 'pluginId' => plugin_id, 'config' => config }
+  end
+end

--- a/sigma-plugin-authoring/scripts/register-plugin.rb
+++ b/sigma-plugin-authoring/scripts/register-plugin.rb
@@ -1,0 +1,114 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+#
+# register-plugin.rb — idempotent Sigma custom-plugin registration helper.
+#
+# PluginRegister.register_or_get(name:, description:, url:) is IDEMPOTENT:
+#   1. GET /v2/plugins first — if a plugin with this exact `name` already
+#      exists, return its pluginId. Never creates a duplicate.
+#   2. Else POST /v2/plugins {name,description,url,type:"element"}, then
+#      re-GET /v2/plugins and find by name. A non-2xx POST is NEVER treated
+#      as a hard failure by itself — Sigma is documented to sometimes return
+#      a masked 404 (or other error) on an otherwise-successful register, so
+#      the confirming GET is always attempted before deciding.
+#   3. Only if, after POST+GET, the plugin still isn't found AND the POST
+#      response clearly indicated an auth/permission failure (401/403) does
+#      this raise PluginRegister::PermissionError: "plugin registration is
+#      permission-gated (org-admin) — <detail>". Any other unresolved case
+#      raises a plain error (never a faked pluginId).
+#
+# Full detail on both gotchas: reference/plugin-lifecycle.md §1.
+#
+# Usage (library):
+#   $LOAD_PATH.unshift File.expand_path('lib', __dir__)
+#   require 'sigma_rest'
+#   require 'register-plugin'
+#   plugin_id = PluginRegister.register_or_get(
+#     name: "My Plugin", description: "...", url: "https://example.com/plugin/"
+#   )
+#
+# Usage (CLI):
+#   ruby scripts/register-plugin.rb "<name>" "<url>" ["<description>"]
+#   -> prints the pluginId to stdout on success (exit 0); on failure, prints
+#      an error to stderr and exits non-zero.
+#
+# Env: SIGMA_BASE_URL, SIGMA_CLIENT_ID, SIGMA_CLIENT_SECRET (or an
+#      SIGMA_API_TOKEN minted via the sigma-api skill). See
+#      scripts/lib/sigma_rest.rb for the full auth/retry contract — it
+#      auto-refreshes on a 401 mid-run.
+
+require 'json'
+
+$LOAD_PATH.unshift File.expand_path('lib', __dir__)
+require 'sigma_rest'
+
+module PluginRegister
+  # Raised only when a POST /v2/plugins failure is unambiguously an auth/
+  # permission problem (401/403) AND the confirming GET also came up empty.
+  class PermissionError < StandardError; end
+
+  module_function
+
+  # Look up a plugin by exact `name` via GET /v2/plugins. Returns the plugin
+  # Hash (with at least a 'pluginId' or 'id' key) or nil if none matches.
+  def find_by_name(name)
+    list = Sigma.request(:get, '/v2/plugins?pageSize=1000')
+    list = (JSON.parse(list) rescue nil) if list.is_a?(String)
+    entries = (list.is_a?(Hash) && (list['entries'] || list['plugins'])) || []
+    entries.find { |p| p['name'] == name }
+  end
+
+  # Idempotent register-or-get. Returns the pluginId (String). Raises
+  # PermissionError on a confirmed 401/403 with no plugin found afterward, or
+  # a plain RuntimeError for any other unresolved failure.
+  def register_or_get(name:, description:, url:)
+    existing = find_by_name(name)
+    existing_id = existing && (existing['pluginId'] || existing['id'])
+    return existing_id if existing_id
+
+    post_error = nil
+    begin
+      Sigma.request(:post, '/v2/plugins',
+                    body: JSON.generate(name: name, description: description, url: url, type: 'element'))
+    rescue Sigma::Error => e
+      # Never trust the POST's own status — the masked-404 quirk means even a
+      # successful register can raise here. Always fall through to the
+      # confirming GET below before deciding anything.
+      post_error = e
+    end
+
+    plugin = find_by_name(name)
+    plugin_id = plugin && (plugin['pluginId'] || plugin['id'])
+    return plugin_id if plugin_id
+
+    if post_error && post_error.message =~ /-> (401|403)\b/
+      raise PermissionError,
+            "plugin registration is permission-gated (org-admin) — #{post_error.message[0, 300]}"
+    end
+
+    raise "plugin registration failed: could not confirm pluginId for #{name.inspect} via " \
+          "GET /v2/plugins after POST#{post_error ? " (POST raised: #{post_error.message[0, 300]})" : ' (POST returned 2xx)'}"
+  end
+end
+
+if $PROGRAM_NAME == __FILE__
+  name        = ARGV[0]
+  url         = ARGV[1]
+  description = ARGV[2] || ''
+
+  if name.nil? || url.nil?
+    warn 'Usage: ruby register-plugin.rb "<name>" "<url>" ["<description>"]'
+    exit 2
+  end
+
+  begin
+    plugin_id = PluginRegister.register_or_get(name: name, description: description, url: url)
+    puts plugin_id
+  rescue PluginRegister::PermissionError => e
+    warn e.message
+    exit 1
+  rescue StandardError => e
+    warn "register-plugin failed: #{e.message}"
+    exit 1
+  end
+end

--- a/sigma-plugin-authoring/scripts/test-gauge-plugin-static.rb
+++ b/sigma-plugin-authoring/scripts/test-gauge-plugin-static.rb
@@ -1,0 +1,47 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+#
+# test-gauge-plugin-static.rb — static-lint gate for the clean-room gauge
+# plugin (sigma-plugin-authoring/plugins/gauge/index.html). Does NOT execute
+# the plugin (no browser/JS runtime here) — it asserts the file satisfies the
+# verified Sigma plugin-lifecycle contract by source inspection: loads the
+# @sigmacomputing/plugin SDK, configures an editor panel, declares
+# value+target bindings (the plugin_embed contract), attaches a
+# ResizeObserver (redraw-on-resize — the #1 "wonky plugin" cause), and ships
+# a synthetic fallback so it previews standalone.
+#
+# Usage:  ruby sigma-plugin-authoring/scripts/test-gauge-plugin-static.rb
+require 'json'
+HTML = begin
+  File.read(File.expand_path('../plugins/gauge/index.html', __dir__))
+rescue Errno::ENOENT
+  ''
+end
+$f = 0
+def chk(c, m)
+  puts(c ? "[ok] #{m}" : "[FAIL] #{m}")
+  $f += 1 unless c
+end
+chk(HTML.include?('@sigmacomputing/plugin'), 'loads the @sigmacomputing/plugin SDK')
+chk(HTML.include?('configureEditorPanel'),   'configures an editor panel')
+chk(HTML =~ /['"]value['"]/ && HTML =~ /['"]target['"]/, 'declares value + target bindings')
+chk(HTML.include?('ResizeObserver'),         'attaches a ResizeObserver (redraw-on-resize)')
+chk(HTML.downcase.include?('synth') || HTML.include?('fallback'), 'has a synthetic fallback')
+# Data-binding contract (verified against @sigmacomputing/plugin v1.2.0 UMD +
+# dist/esm/index.d.ts). These guard the bug class that let a plugin silently
+# render synthetic data forever: the wrong SDK global, and the wrong data-
+# subscription path/arity.
+chk(HTML.include?('SigmaPlugin'),
+    'references the real SDK global window.SigmaPlugin (not the nonexistent window.Sigma)')
+chk(HTML =~ /elements\s*\.\s*subscribeToElementData/,
+    'reads bound data via client.elements.subscribeToElementData(sourceId, cb)')
+# React peer-dep: @sigmacomputing/plugin's UMD build THROWS at load if React is
+# absent, leaving window.SigmaPlugin with no `client` -> the plugin can never
+# read data and silently synths. React MUST be loaded BEFORE the SDK script.
+# Anchor on the actual <script src=…> tags (the SDK name also appears in prose
+# comments, so a plain string index would match the wrong position).
+react_idx = HTML =~ %r{<script[^>]*\bsrc=["'][^"']*react[@./][^"']*\.js}
+sdk_idx   = HTML =~ %r{<script[^>]*\bsrc=["'][^"']*@sigmacomputing/plugin}
+chk(react_idx && sdk_idx && react_idx < sdk_idx,
+    'loads React BEFORE the @sigmacomputing/plugin SDK (UMD peer dependency)')
+exit($f.zero? ? 0 : 1)


### PR DESCRIPTION
## Summary

Adds a new self-contained skill, `sigma-plugin-authoring/`, covering the full lifecycle for recreating a source visualization that has **no native Sigma element equivalent** (a radial/semicircle gauge, a custom heatmap, a sankey, …) as a bespoke `@sigmacomputing/plugin`:

**build → register → host → embed → bind → verify**

- `SKILL.md` — the recipe, decision guardrail ("does this viz actually need a plugin?"), Reference Index, and Troubleshooting, written in this repo's voice and cross-linking `sigma-workbooks` / `sigma-data-models` / `sigma-api` as peer skills.
- `reference/plugin-lifecycle.md`, `reference/sdk-api.md`, `reference/patterns.md` — the full verified-gotcha reference, editor-panel/client/hook API lookup, and interactivity recipes (JSON settings, edit-mode gating, variable + action-trigger writeback, multi-column roles).
- `plugins/gauge/` — a **live-verified** worked example: a single-file, dependency-free radial gauge plugin (value vs. target, RAG-colored), registered against a live Sigma org and value-verified end-to-end.
- `scripts/plugin_embed.rb` — the emitter for the `{kind:"plugin"}` workbook-spec element (bare-string config coercion, correct `config.source` shape).
- `scripts/register-plugin.rb` — idempotent `POST /v2/plugins` registration (masked-404/403-aware).
- `scripts/test-gauge-plugin-static.rb` — static-lint gate for the gauge plugin (8/8 checks pass).
- `generated/{cline,codex,continue,cursor}` — the four non-Claude agent variants, produced via `ruby scripts/sync-targets.rb sigma-plugin-authoring`.

This mirrors the just-landed `sigma-plugin-authoring` skill in the private `sigma-migration-skills` repo (both-repos decision) — same verified lifecycle knowledge, reframed for this repo's conventions: Ruby-only (no Python twin), flat top-level skill dir (no `shared/`), no plugin.json/version-bump governance. Auth in `register-plugin.rb` follows this repo's existing per-skill-vendored `scripts/lib/sigma_rest.rb` pattern (already established by `custom-sql-to-data-model`), rather than the migration repo's shared lib.

Two gotchas worth flagging explicitly since they're easy to reintroduce when hand-rolling a plugin:

- **React peer-dependency (plugin-lifecycle.md §7).** `@sigmacomputing/plugin`'s UMD/CDN build has React as a hard peer dependency — if React isn't loaded on the page *before* the SDK script, the SDK throws at load and silently leaves `window.SigmaPlugin` with no `client`. The plugin then falls back to its synthetic demo data forever, with no visible error — it just never touches real data. Fix: load React first, always.
- **PNG export doesn't hydrate plugin data (plugin-lifecycle.md §8).** Sigma's server-side screenshot/PNG-export path initializes a plugin's `client` and fires `config.subscribe`, but never delivers the plugin's element data before snapshotting — so a server-rendered screenshot of a plugin always shows its synthetic fallback, never live data. Data-parity verification has to happen at the bound *element* level (independent of the plugin), not via a screenshot.

## Test plan

- [x] `ruby sigma-plugin-authoring/scripts/test-gauge-plugin-static.rb` → 8/8 checks pass
- [x] `ruby -c sigma-plugin-authoring/scripts/plugin_embed.rb` → Syntax OK
- [x] `ruby -c sigma-plugin-authoring/scripts/register-plugin.rb` → Syntax OK
- [x] `ruby -c sigma-plugin-authoring/scripts/lib/sigma_rest.rb` → Syntax OK
- [x] `register-plugin.rb` require-chain smoke test (no args / missing env) → clean, expected errors, no load-path failure
- [x] `ruby scripts/sync-targets.rb sigma-plugin-authoring` → all 4 generated variants present
- [x] Grepped the new skill directory for customer/personal names → none found
- [x] `README.md` Skills table updated with a `sigma-plugin-authoring` row

🤖 Generated with [Claude Code](https://claude.com/claude-code)