### PR TITLE
chore(sigma-plugin-authoring): scrub internal 'WS2' codename from customer-facing docs

### DIFF
--- a/sigma-plugin-authoring/plugins/gauge/README.md
+++ b/sigma-plugin-authoring/plugins/gauge/README.md
@@ -4,7 +4,7 @@ A single-file, vanilla-JS Sigma custom plugin (`@sigmacomputing/plugin`) that
 renders a radial (semicircle) gauge — a value swept against a target, colored
 red/amber/green (RAG) by how close it is. It exists to recreate source vizzes
 (a QuickSight/Power BI-style gauge, a "% to target" indicator, …) for which
-Sigma has no native chart kind, as part of WS2's `recreate-as-plugin`
+Sigma has no native chart kind, as part of this skill's `recreate-as-plugin`
 disposition.
 
 Clean-room, generic data only — the file has no customer names or data. When
@@ -14,7 +14,7 @@ previews standalone.
 
 ## Editor-panel bindings
 
-This is the contract other WS2 machinery (`shared/lib/plugin_embed`, the
+This is the contract other skill machinery (`shared/lib/plugin_embed`, the
 gap-scan/emitter) binds to — **do not rename these fields**:
 
 | name     | type                          | meaning                              |

--- a/sigma-plugin-authoring/plugins/gauge/index.html
+++ b/sigma-plugin-authoring/plugins/gauge/index.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <!--
-  gauge/index.html — clean-room WS2 "recreate-as-plugin" radial gauge.
+  gauge/index.html — clean-room "recreate-as-plugin" radial gauge.
 
   A single-file, vanilla-JS Sigma custom plugin (@sigmacomputing/plugin) that
   renders a value-vs-target radial (semicircle) gauge with RAG color, for


### PR DESCRIPTION
## Summary
- Removes the internal project codename "WS2" (and "WS2 v1") that leaked into the sigma-plugin-authoring skill's customer-facing prose — replaced with neutral phrasing that preserves the original meaning (e.g. "this skill's", "skill machinery", or simply dropped where it added no meaning).
- Docs/prose only — no code logic, identifiers, or config values changed.

## Details
- 3 occurrences found and fixed, both in `sigma-plugin-authoring/plugins/gauge/`:
  - `index.html` (HTML comment header)
  - `README.md` (x2, prose paragraphs)
- Ran `ruby scripts/sync-targets.rb sigma-plugin-authoring` to regenerate the `generated/` variants — no diff resulted, since none of the generated targets (derived from SKILL.md) referenced "WS2" to begin with.
- Ran the gauge plugin's static lint (`sigma-plugin-authoring/scripts/test-gauge-plugin-static.rb`): 8/8 checks pass, unaffected by this change.
- No repo-wide lint/version-bump CI gate exists in this repo (no `.github/workflows`, no `plugin.json`), so no Skip-Version-Bump trailer was needed.

## Test plan
- [x] `grep -rn -i 'ws2' sigma-plugin-authoring/` returns no matches
- [x] `ruby sigma-plugin-authoring/scripts/test-gauge-plugin-static.rb` → 8/8 pass
- [x] `git diff` confirms only comment/prose text changed in `index.html` and `README.md`, no logic/behavior change