### PR TITLE
feat(sigma-workbooks): composition + styling + composable-richness authoring (WS3)

### DIFF
--- a/sigma-workbooks/reference/specification/layout.md
+++ b/sigma-workbooks/reference/specification/layout.md
@@ -1,6 +1,6 @@
 # Layout
 
-Recipe book for the top-level `layout` XML — when to write it, the two-tag grammar, and the silent-failure traps to watch for. `layout` is a page-level property; its value is the XML string described below. **Default to writing explicit `layout` XML for multi-element workbooks.**
+Recipe book for the `layout` XML — when to write it, the two-tag grammar, and the silent-failure traps to watch for. `layout` is a **single workbook-top-level property** (one XML string holding one `<Page>` block per page — see the grammar below), **not** a per-page field: setting `pages[].layout` silently no-ops and Sigma falls back to auto-arrange (a common, hard-to-spot trap). Its value is the XML string described below. **Default to writing explicit `layout` XML for multi-element workbooks.**
 
 Container *elements* (the `kind: "container"` JSON placeholders that pair with `<GridContainer>` in this XML) are covered in **Container elements** below.
 
@@ -97,7 +97,7 @@ Use stacked rows when you want a section header above a row of charts inside the
 
 ## Page-level fields: `visibility` and `backgroundImage`
 
-Besides `id`, `name`, `elements`, and `layout`, a page supports two optional fields:
+Besides `id`, `name`, and `elements` — and the workbook-top-level `layout` XML whose `<Page id>` block references this page's elements (see the top of this doc; `layout` is NOT a page field) — a page supports two optional fields:
 
 - **`visibility`** — set to `hidden` to hide the page from end users. Omit for a visible page.
 - **`backgroundImage`** — a page-wide background image, same shape as a container's `backgroundImage`: a required `url` plus an optional `style` block (`fit`, `horizontalAlign`, `verticalAlign`, `tiling`). `url` supports `{{formula}}` references.

--- a/sigma-workbooks/reference/specification/styling.md
+++ b/sigma-workbooks/reference/specification/styling.md
@@ -102,6 +102,7 @@ Every field below **round-trips and renders** — verified live 2026-06-26 (POST
 **Gotchas:**
 - The server **lowercases hex** on save (`#0F172A` → `#0f172a`) — cosmetic, not a drop; don't treat it as a failed round-trip.
 - `themeOverrides` is the spec path to **donut/pie slice colors** — set `categoricalScheme` here (the per-element `color.scheme` is still silently dropped on donut/pie — see Recipe 5). This supersedes the old "set the theme in the UI" workaround.
+- `titleFont` sets every element's title **by default**, but a per-element `name:{fontSize,color}` (live-verified 2026-07-28 — see *Things that are NOT designable via spec* below, now corrected) **wins over** `titleFont` for that one element when both are set. Use `titleFont` for a workbook-wide title style and per-element `name` only where one title needs to stand out.
 - Theme vs. the recipes below: a theme is the global skin (selected, org-managed). The recipes here style individual elements from spec fields and **stack on top of** whatever theme is set. For a migration, prefer the source dashboard's look; reach for a theme only when the user asks to apply one.
 
 ---
@@ -530,15 +531,80 @@ value: Week
 
 ---
 
+## Composition styling — the `Styling` module
+
+The recipes above are written to hand-author; the same moves are also available as a small
+shared helper library — `scripts/lib/styling.rb` — for applying a professional look on top of
+a layout built with the `Composition` engine (`reference/workflows/composition.md`) instead of
+re-transcribing hex codes and container shapes into every dashboard. Every field these helpers
+emit is one of the live-verified GO surfaces above; each helper is gated behind an internal
+`SURFACES` map so a future regression can flip a surface off in one place instead of emitting
+an unverified (or now-rejected) shape at every call site.
+
+### Theme
+
+`Styling.theme(accent: nil)` returns `DEFAULT_THEME` — **one** professional, host-agnostic
+palette: an 8-color categorical scale, `ink`/`muted` text colors, and the card/header container
+shapes below — or a shallow variant with `accent` swapped into categorical slot 0 (and
+`theme[:accent]`) when the caller supplies one. There's no branding/logo support and no second
+built-in palette: one palette, optionally re-tinted, matches this doc's stance in the note at the
+top — reach for a theme when the user wants design polish with no stated brand direction; a
+migration's source fidelity or a user's own branding always overrides this.
+
+### `chart_color(theme, categorical: false)`
+
+- Single-series (default): `{ "color": { "by": "single", "value": theme[:categorical][0] } }` —
+  merge onto a bar/line/area/combo element (Recipe 5's single-hue case).
+- Categorical (`categorical: true`): `{ "themeOverrides": { "categoricalScheme": theme[:categorical] } }`
+  — merge at the **workbook** level (a sibling of `pages`/`layout`), not per-element. This is the
+  verified path for donut/pie slice colors too (per-element `color.scheme` is still silently
+  dropped there — see Recipe 5 / *Workbook theme* above).
+
+### `kpi_accent(theme)`
+
+Returns `{ "color": theme[:accent] }` — merge into a KPI element's `name` object
+(`{ "name": { "text": "Revenue", "color": "#2563EB" } }`). This is the KPI **title** color,
+live-verified 2026-07-28 (see the corrected claim under *Things that are NOT designable* below) —
+distinct from `value.color`, which tints the number itself (already documented under
+*Field-observed idioms* above); combine both for a fully accented KPI card.
+
+### `format_for(semantic)`
+
+Returns a `format` fragment — `{ "kind": "number", "formatString": <d3> }` — for one of four
+semantics: `:currency` → `"$,.0f"`, `:integer` → `",.0f"`, `:percent` → `".1%"`, `:decimal` →
+`",.2f"`. These are **d3-format** strings, not Excel-style masks: `"$#,##0"` is hard-rejected at
+POST with a 400 (`Invalid number format string`), never silently dropped — never hand-write an
+Excel-style format string. See Recipe 6 above and `formatting.md` for the full grammar.
+
+### `header(id:, title:, theme:, page_cols: 24)` / `section_card(id:, band:, theme:, page_cols: 24)`
+
+Apply the Recipe-1 hero-header and Recipe-2-style card idioms on top of `Composition.bands()`
+output rather than hand-writing the container + child XML per dashboard:
+
+- `header` emits a `kind: container` styled `theme[:header]`
+  (`{backgroundColor:"#0F172A", borderRadius:"round"}`) plus a separate `kind: text` title child —
+  a container has no field of its own that renders visible text, see `layout.md`'s Container
+  elements section — and the wrapping `<GridContainer>`/`<LayoutElement>` XML fragment.
+- `section_card` wraps one `Composition.bands()` band (`{role:, ids:, r0:, r1:}`) in a
+  `kind: container` styled `theme[:card]`
+  (`{backgroundColor:"#FFFFFF", borderColor:"#E2E8F0", borderWidth:1, borderRadius:"round"}`),
+  tiling the band's element ids side-by-side inside it at the same relative split
+  `Composition.band` would use unwrapped.
+- Both container `style` shapes use the field name **`borderRadius`** (`square|round|pill`) —
+  never the guessed `cornerRadius`, which is silently dropped on readback (the *container-style*
+  row of the GO/NO-GO surface map above). And **never combine `padding` with `borderColor`/`borderWidth`**
+  on the same container — POST 400s ("padding is 'none' but border fields... require default
+  padding"); omit `padding` (its default) whenever a border is set.
+
 ## Things that are NOT designable via spec (as of 2026-05-29)
 
 Don't waste a round-trip trying to set these — the spec API silently drops them.
 
 - **Chart tooltip customization** (spec-findings #10)
 - **Trellis / small-multiples layout** (spec-findings #11)
-- **Donut / pie slice colors** (spec-findings #22)
-- **KPI title color or "hide title" toggle** — `name` always renders as a black title
-- **Element title font size / font family** — the `name` field has no `style` sibling. (Text *elements* CAN set fonts via `<span style="font-family: …">` — see field-observed idioms above; it's only the title `name` that can't.)
+- **Donut / pie slice colors** (spec-findings #22, per-element `color.scheme`; use workbook-level `themeOverrides.categoricalScheme` instead — see *Workbook theme* above)
+- ~~**KPI title color or "hide title" toggle** — `name` always renders as a black title~~ — **RESOLVED, live-verified 2026-07-28**: `name` on a `kpi-chart` (or any element) *is* colorable — `{ "name": { "text": "Revenue", "color": "#2563EB" } }` survives readback and renders the title in that color. This supersedes the "`name` always renders as a black title" claim this doc carried until now — for *this exact shape only*: there is still no `showTitle: false` / "hide title" toggle, so the `name: ' '` (single-space) workaround in Recipe 2 above still stands for suppressing a duplicate title.
+- ~~**Element title font size / font family** — the `name` field has no `style` sibling.~~ — **PARTIALLY RESOLVED, live-verified 2026-07-28**: a per-element `name` object also takes `fontSize` — `{ "name": { "text": "Category Detail", "fontSize": 22, "color": "#DC2626" } }` on a non-KPI element (e.g. a table) survives readback and renders both a visibly larger size and a distinct color, **overriding the workbook-wide `titleFont`** (see *Workbook theme* above) for that one element when both are set. This supersedes the "the `name` field has no `style` sibling" claim this doc carried until now. Font *family* per title remains untested — only `fontSize`/`color` were probed; `themeOverrides.fonts.textFont` (*Workbook theme* above) is still the only verified lever for text font family, and it's global, not per-title.
 - ~~**Workbook-level palette / theme** via spec~~ — **RESOLVED**: now spec-authorable via top-level `themeName` + `themeOverrides` (see *Workbook theme* above).
 - **Chart `tooltip` / `trellis*` fields** (UI-only)
 

--- a/sigma-workbooks/reference/workflows/composition.md
+++ b/sigma-workbooks/reference/workflows/composition.md
@@ -1,6 +1,6 @@
 # Composition: making the design choice
 
-A workbook spec that compiles cleanly and has correct data can still be unusable. Layout, element choice, label clarity, whether to add a comparison vs current state — these are design decisions, not API ones. **This skill has no opinions about what makes a good dashboard.** It asks you to ask.
+A workbook spec that compiles cleanly and has correct data can still be unusable. Layout, element choice, label clarity, whether to add a comparison vs current state — these are design decisions, not API ones. This skill used to claim no opinions on any of that; it now has two verified composition patterns (below) as opinionated starting points — good defaults, not templates to apply blindly. Genuinely ambiguous structural choices (scope, audience, what to group or sort on, single- vs multi-page) still get punted to the user, exactly as before — see the ladder and the ask-section that follow.
 
 ## Calibrate scope to the request
 
@@ -10,7 +10,7 @@ A rough sizing ladder (starting points, not rules):
 
 - **A single thing** — "show total revenue", "a table of orders", "one KPI" → one element. Skip explicit layout XML; auto-arrange is fine for a single element or a uniform stack of tables.
 - **A focused view** — "revenue over time with a region filter" → a few elements plus a control; light layout.
-- **A dashboard** — "a sales dashboard", "an exec overview" → the fuller pattern is appropriate: a KPI row up top, one or two charts, a supporting table, controls, explicit layout XML, and the base/source table on a hidden page (see Defaults below). This is the tier where polish is the point.
+- **A dashboard** — "a sales dashboard", "an exec overview" → the fuller pattern is appropriate: a KPI row up top, one or two charts, a supporting table, controls, explicit layout XML, and the base/source table on a hidden page (see `visibility: hidden` in `reference/specification/schema.md`, and the master-detail pattern below for a worked example). This is the tier where polish is the point.
 
 For concrete shapes at any tier, don't assemble from memory. Fetch a real workbook's spec (`GET /v2/workbooks/{id}/spec`, Steps 1–2) and read the relevant feature docs — a live spec shows current, valid, org-idiomatic structure, including the layout XML the OpenAPI doesn't model. Size up only when the request asks for it.
 
@@ -35,13 +35,212 @@ Agents quietly choose: how many KPIs, which chart kinds, multi-page vs single, w
 
 Example: *"Built a single-page dashboard with 4 KPIs across the top, a revenue-by-region bar chart, and a ranked store table sorted descending by revenue. Used Sales Amount over Net Orders for the headline metric. Tell me if you want any of these changed — different KPI mix, multi-page split, a different sort, etc."*
 
-## Defaults to fall back on when not asking
+## Patterns
 
-These are *defaults, not rules.* The skill doesn't claim they're right for every dashboard; they're starting points when the user's preference isn't known and stopping to ask isn't appropriate.
+Two layout patterns are wired into a shared composition engine (`scripts/lib/composition.rb`). Both take a flat array of elements — each `{ id:, role: }` or `{ id:, kind: }` — and emit the `<LayoutElement elementId="..." gridColumn="a / b" gridRow="c / d"/>` lines for a single `<Page>`'s worth of layout XML. Wrap the engine's output in a `<Page id="<pageId>" ...>` block, then place the assembled XML — one shared prolog plus one `<Page>` block per page — in the **workbook-top-level `layout` field**, NOT `pages[].layout` (which silently no-ops and falls back to auto-arrange). See `reference/specification/layout.md` for the `<Page>`/`<GridContainer>` wrapper and this workbook-level placement. Elements are grouped into horizontal bands by `role`; a band with no elements is skipped and the next band simply starts where the last one left off, so array order doesn't matter — only the role tag does.
 
-- **Source/base tables go on a hidden page.** When a workbook needs a base table (warehouse-table or join source) to feed charts, KPIs, and grouped views, that base table doesn't belong in the dashboard view. Put it on a separate page with `visibility: hidden` (see `reference/specification/schema.md`) and source dashboard elements from it via `elementId`. The base table stays available to the workbook without dropping a million-row dump on the viewer.
-- **Sort ranked tables by the metric the user is ranking on.** "Bottom 10 stores by revenue" implies ascending by revenue; "top products" implies descending. Sorting alphabetically by name is rarely what a meeting attendee wants.
-- **Don't expose intermediate joins as visible elements.** Same rationale as the base-table rule — they're plumbing, not deliverables.
+Role resolution: give an element an explicit `role:`, or let `kind:` infer one — `kpi-chart` → `:kpi`; `table` / `pivot-table` / `input-table` → `:table`; any other kind (every chart kind) defaults to `:supporting`. `:hero`, `:control`, `:insight`, `:master`, and `:detail` are **never** inferred — tag those explicitly. An untagged element infers to `:supporting` — `:exec` places that (merged into its final `:supporting`+`:table` band), but `:master_detail` does NOT: it only consumes `:control`, `:master`, and `:detail`, so an untagged (or explicitly `:kpi`/`:hero`/`:insight`/`:supporting`/`:table`) element passed to `:master_detail` is a role the pattern doesn't place.
+
+An unrecognized explicit role raises (`compose: unknown role <x> for element <id>`) rather than silently dropping the element — and, separately, a *recognized* role the chosen pattern simply doesn't consume now raises too (`compose: role <role> (element <id>) is not used by pattern <pattern>`), e.g. tagging something `:master` and composing with `:exec`, or leaving something `:kpi`/untagged and composing with `:master_detail`. Neither case silently vanishes from the layout anymore.
+
+Within a band, elements split the available width evenly (`band()`, the same helper both patterns use) — the element count in any one band must evenly divide `page_cols` (default 24: 1, 2, 3, 4, 6, 8, 12, or 24 elements fit cleanly). An uneven count raises `ArgumentError` rather than producing a lopsided or clipped layout — pick a clean count, or drop to hand-written layout XML for an odd one.
+
+### `exec` — KPI-strip dashboard
+
+Use this for the "dashboard" tier of the sizing ladder above: an exec overview, a sales dashboard, anything shaped like "a few headline numbers, one dominant chart, supporting detail." It is not the only shape a dashboard can take — it's the default starting point when nothing about the request argues for something else.
+
+Role → band, top to bottom (each optional; skipped if empty):
+
+| Role | Band height | Notes |
+|------|-------------|-------|
+| `:control` | 2 | Filters for the page. Thin, full-width if one control; split evenly if several. |
+| `:kpi` | 6 | The KPI strip — an even split across every `:kpi` element. This is the headline-numbers row. |
+| `:insight` | 3 | Optional narrative/callout band (a text element, a small annotation) between the KPIs and the hero. |
+| `:hero` | 12 | The dominant visual. Tag exactly **one** element `:hero` — `band()` will split the width evenly across *however many* `:hero` elements you pass, so more than one turns this into side-by-side heroes rather than one dominant chart. |
+| `:supporting` + `:table` | 9 | Merged into one final band and split evenly across whatever's left — secondary charts and the detail table together. |
+
+Call:
+
+```ruby
+require_relative 'scripts/lib/composition'
+
+elements = [
+  { id: 'kpi1', role: :kpi }, { id: 'kpi2', role: :kpi },
+  { id: 'kpi3', role: :kpi }, { id: 'kpi4', role: :kpi },
+  { id: 'hero', role: :hero }, { id: 'tbl', role: :table }
+]
+Composition.compose(elements, pattern: :exec)
+```
+
+produces a 4-up KPI strip (each 6 of 24 columns, row 1–7), a full-width hero (row 7–19), and a full-width table (row 19–28) — the exact shape golden-tested in `scripts/lib/testdata/composition_exec_golden.txt`.
+
+### `master-detail` — pick one, see its detail
+
+Use this when the request is shaped like "browse/pick from a list or chart, see the detail for the one selected" — a directory next to a drill-down table, "click a region to see its orders," an index/detail pairing. This is a different shape from `exec`: there's no KPI strip, just one selection surface and one surface that responds to it.
+
+Role → band, top to bottom:
+
+| Role | Band height | Notes |
+|------|-------------|-------|
+| `:control` | 2 | Optional thin, full-width row. If omitted, the master/detail band below starts at row 1 instead of row 3. |
+| `:master` + `:detail` | 14 | Share one tall band, split evenly. With exactly one of each on the default 24-column grid, that's master at columns 1–13 and detail at 13–25. |
+
+`:master` and `:detail` are resolved **only** from an explicit `role:` — never inferred from `kind:`. A bar chart or a table can be either side of this pattern (or neither, in a different pattern), so the engine can't guess which one is the selection surface.
+
+Call:
+
+```ruby
+elements = [
+  { id: 'ctl', role: :control },
+  { id: 'master-chart', role: :master, kind: 'bar-chart' },
+  { id: 'detail-tbl', role: :detail, kind: 'table' }
+]
+Composition.compose(elements, pattern: :master_detail)
+```
+
+(note the pattern name is the symbol `:master_detail`, underscore — the hyphen is only in prose) produces a full-width control row (row 1–3), then master at columns 1–13 and detail at columns 13–25 sharing row 3–17 — see `scripts/lib/testdata/composition_master_detail_golden.txt`. Drop the `:control` element and the master/detail band starts at row 1 instead.
+
+**Critical semantics — verified live against a real Sigma org (2026-07-28), not just spec-shape-valid:**
+
+- **The control filters the detail element only.** Wire it as a `filters[]` entry on the control pointing at the detail table — `{ source: { kind: table, elementId: <detail-element-id> }, columnId: <dimension-column> }` (see `reference/specification/controls.md`). Do not add the master to that `filters[]` array.
+- **The master stays whole.** It is the selection surface the viewer picks from, not a filtered view of the current pick — it must keep rendering every category/row, not just the selected one. Live proof: setting the control's value and exporting the master still returns every category with its correct (unfiltered) totals. This is the intended shape, not a bug to "fix" by also filtering the master.
+- **Put the underlying source table on a hidden page** (`pages[].visibility: hidden`, `reference/specification/schema.md`) and have both the master and the detail `source` from it via `elementId` — same rationale as any base table: it's plumbing the pattern needs, not a deliverable the viewer should see directly.
+- **Clicking the master to set the control's value is a manual UI step — there is no spec node for it.** The spec-authorable half of this pattern is only the control → detail `filters[]` binding above; "clicking a mark sets a control's value" has no representation in the workbook spec and has to be wired by hand in the Sigma UI after the workbook is built. (For automated verification instead of a manual click, the control's value can be driven programmatically through the export API's `parameters` map — see `reference/workflows/validate.md` — but that's a test-time convenience, not a substitute for the real UI interaction.)
+
+### Other defaults
+
+Two general, pattern-independent authoring defaults still apply no matter which composition pattern (or none) is in play:
+
+- **Sort ranked tables by the ranking metric, descending.** "Top 10 stores by revenue" or "top products" implies ranking by the metric in view, highest first — sorting alphabetically by name is rarely what the request meant.
+- **Don't expose intermediate/staging joins as visible elements.** A join or blend built only to feed other elements is plumbing, not a deliverable — keep it on a hidden page (or off the dashboard entirely), same rationale as a source/base table.
+
+**Styling:** once a page is composed, apply a professional look on top — theme, chart color, KPI accent, number format, header/card containers — via the shared `Styling` module; see `reference/specification/styling.md`'s *Composition styling* section.
+
+## Richness — optional building blocks
+
+Everything below is a **menu, not a fixed template.** Each capability is independent and
+optional — usable alone, in any combination, or not at all. None of it is auto-applied:
+offer what fits the request and let the user choose, the same calibrate/ask ethos as the
+rest of this doc. This is not a clone of any one dashboard's branded look — no logos, no
+imposed layout, no house style forced onto every workbook. Reach for these when the
+request calls for polish; a plain KPI-and-chart page (composed with `:exec`, or with no
+pattern at all) is still a completely valid answer on its own.
+
+Each item below emits one spec fragment — via `scripts/lib/richness.rb` or the existing
+`scripts/lib/kpi_card.rb` — that drops into whatever layout is already being built. None
+of them assemble a whole page by themselves.
+
+### Comparative KPI cards (+ optional value styling)
+
+The house default for a KPI is comparative: a value column plus a `comparisonColumn`
+rendered as a Δ badge (see `reference/specification/comparative-kpi-card.yaml` and
+`KpiCard.build`). That comparison is itself optional — a plain single-value KPI is a valid,
+simpler choice; calling `KpiCard.build` with no `comparison_column_id` emits a plain card,
+no Δ badge.
+
+On top of that, `KpiCard.build` takes two further optional kwargs —
+`value_color:` / `value_font_size:` — that accent the number itself:
+`value: {columnId: ..., color: '#FDE047', fontSize: 44}`. Leave both `nil` (the default)
+and the emitted card is byte-identical to a call that never knew these kwargs existed.
+Live-verified: the color renders as a genuinely distinct hue against the default black,
+and the font-size change is directly measurable in the rendered PNG, not just accepted on
+POST.
+
+### AI-insight callout (opt-in, org-dependent)
+
+`Richness.ai_insight(id:, model:, prompt:)` builds a `text`
+element whose `body` is a Cortex-backed formula:
+
+```
+{{ Replace(CallText("SNOWFLAKE.CORTEX.COMPLETE", "<model>", "<prompt>"), '"', "") }}
+```
+
+`CallText`'s real signature is `CallText(<warehouse_function_name>, ...args)` — there is
+**no separate connection argument**; it runs against the referenced column's own
+element/connection. `llama3.1-8b` and `mistral-large2` are live-verified against Sigma's
+own Sample Database Snowflake connection, returning genuinely generated (non-echoed)
+sentences, not an echo of the prompt.
+
+**Opt-in caveat, stated plainly:** this only renders real text where the target org has a
+usable Cortex model configured on its own connection. Offer it, don't force it — and
+never substitute a hand-written or faked summary sentence when an org's Cortex isn't
+available; an unconfigured org just sees a blank or erroring element until Cortex is set
+up there. Meant to sit in a light-tint container alongside the rest of the page, not as a
+load-bearing element the rest of the dashboard depends on.
+
+### Control-driven interactivity (optional)
+
+Two independent, optional pieces, both reusing already-verified control shapes:
+
+- **Dynamic grain.** `Richness.grain_control(id:)` emits a `segmented` Week/Month/Day
+  control (default Month); `Richness.trend_dimension(grain_control_id:, date_ref:)`
+  returns the matching dimension formula for a trend chart —
+  `Switch([<id>],"Week",DateTrunc("week",<date_ref>),"Month",DateTrunc("month",<date_ref>),
+  DateTrunc("day",<date_ref>))`. Live-verified: switching the control across Week/Month/Day
+  changed the chart's exported bucket count exactly as expected (Month=3, Week=14, Day=90
+  over 90 days of data).
+- **Filter row.** `Richness.filter_row(controls:)` emits one or more `list` controls wired
+  to a control → element `filters[]` binding — the same control-filters-target shape
+  already verified for the master-detail pattern above, offered here as a standalone
+  filter row rather than tied to one specific layout.
+
+Use either, both, or neither — a page composed with no controls at all is just as valid a
+choice as one with both.
+
+### Wide pivot (optional)
+
+`Richness.wide_pivot(id:, source_element_id:, rows_by:, values:, columns:)` emits a
+`pivot-table` biased wide rather than crosstabbed: `columns` is the pivot's own column
+definitions (required — see the tables.md pivot recipe), `rowsBy` takes the row shelves,
+`columnsBy` is always `[]`, and `values` is a plain list of metric column-id strings (not
+`{id: ...}` objects — matching the existing pivot precedent). Grand totals are a UI-only
+setting, not a spec field, so this helper doesn't emit or guess one. Reach for this when
+the request wants a wide detail table rather than a small-multiple crosstab; a regular
+table, or a pivot with `columnsBy` populated, are equally valid alternatives depending on
+what's actually asked for.
+
+### Composition pattern choice: `:overview` as one more option
+
+`Composition.compose` (see *Patterns* above) offers a third pattern alongside
+`:exec` and `:master_detail`: `pattern: :overview`, an optional stack of full-width bands,
+each skipped if its role has no elements:
+
+| Role | Band height | Notes |
+|------|-------------|-------|
+| `:header` | 3 | Optional title band. |
+| `:control` | 2 | Optional filter row. |
+| `:kpi` | 8 | Taller than `:exec`'s KPI band — room for a comparison badge and title without clipping. |
+| `:kpi2` | 8 | Optional second KPI row (e.g. rate/percentage metrics kept visually distinct from the headline row). |
+| `:trend` | 12 | A grain-driven or plain trend chart. |
+| `:pivot` | 14 | A wide pivot or detail table. |
+| `:base` | 9 | The base/source row — hide it if it's plumbing, not a deliverable, same convention as the rest of this doc. |
+
+This is **one composition choice among three** (`:exec`, `:master_detail`, `:overview`) —
+plus hand-placed layout XML when none of the three fits. Nothing about a "dashboard"
+request implies `:overview` specifically; pick whichever pattern's shape matches what was
+actually asked for, or ask if that's ambiguous, same as the sizing ladder above.
+
+### What's not here: in-card KPI sparkline (NO-GO)
+
+A sparkline living inside a KPI card itself (title → value → Δ badge → mini trend line,
+all one element) is **not currently spec-authorable.** Adding a real, non-aggregate date
+dimension (e.g. `DateTrunc("month", [Src/Date])`) to a `kpi-chart`'s own `columns` — the
+specific shape this round of testing targeted — still renders no line: the card shows
+title, value, and the Δ badge only, with visible empty space where a spark would go.
+Separately, `trend: {shape: "line"}` was **stripped outright on this readback**
+(`kpi_trend: null`) — narrower than `kpis.md`'s existing claim that the bare `trend` field
+alone "is accepted and persists on readback, but inert without a UI binding."
+
+So: KPI cards in this menu are comparative (value + Δ badge), not comparative-with-spark.
+If a trend needs to sit alongside a KPI, use a separate trend chart — the `:trend` band
+above, or a supporting chart next to the KPI strip — rather than trying to author a
+sparkline inside the KPI element itself.
+
+This is a candidate for a later re-probe, not a closed question — other builds are
+reported to achieve an in-card spark, plausibly through a data-model/Metrics-level
+mechanism rather than the `kpi-chart` `trend` field tested here. Don't claim the in-card
+spark works until a workbook built purely from spec (never opened in the editor) is shown
+actually rendering one.
 
 ## Image-driven cases have their own composition guide
 

--- a/sigma-workbooks/scripts/lib/composition.rb
+++ b/sigma-workbooks/scripts/lib/composition.rb
@@ -1,0 +1,136 @@
+# frozen_string_literal: true
+# composition.rb — pure composition engine: arrange elements (by role) into a
+# polished layout XML fragment for a single <Page>. Sibling-<LayoutElement>
+# form (no GridContainer). Ruby 2.6+, stdlib only. Golden-tested output lives
+# in scripts/lib/testdata/composition_*_golden.txt (see test_composition.rb).
+module Composition
+  ROLES = %i[control kpi insight hero supporting table master detail header kpi2 trend pivot base].freeze
+
+  # Roles each pattern actually places. A role that resolves (explicitly or via
+  # inference) to something OUTSIDE its chosen pattern's set used to be silently
+  # dropped from the emitted layout; check_pattern_roles! (below) now raises
+  # instead — see compose_exec / compose_master_detail.
+  EXEC_ROLES = %i[control kpi insight hero supporting table].freeze
+  MASTER_DETAIL_ROLES = %i[control master detail].freeze
+  OVERVIEW_ROLES = %i[header control kpi kpi2 trend pivot base].freeze
+
+  # kind -> role inference (used when an element has no explicit :role). Chart
+  # kinds default to :supporting; callers wanting a :hero must tag it explicitly.
+  KIND_ROLE = {
+    'kpi-chart' => :kpi, 'table' => :table, 'pivot-table' => :table,
+    'input-table' => :table
+  }.freeze
+  def self.infer_role(kind)
+    KIND_ROLE.fetch(kind.to_s) { :supporting } # chart kinds default to :supporting; caller tags :hero explicitly
+  end
+
+  def self.le(id, c0, c1, r0, r1)
+    "  <LayoutElement elementId=\"#{id}\" gridColumn=\"#{c0} / #{c1}\" gridRow=\"#{r0} / #{r1}\"/>"
+  end
+
+  def self.band(elements, r0, r1, page_cols)
+    n = elements.size
+    return [] if n.zero?
+    raise ArgumentError, "compose: page_cols (#{page_cols}) not evenly divisible by #{n} " \
+                          'element(s) in one band' if page_cols % n != 0
+    w = page_cols / n
+    elements.each_with_index.map { |el, i| le(el[:id], i * w + 1, i * w + 1 + w, r0, r1) }
+  end
+
+  def self.roleize(elements)
+    elements.map do |e|
+      raw = e[:role]
+      role = (raw.nil? || raw == '') ? infer_role(e[:kind]) : raw.to_s.to_sym
+      unless ROLES.include?(role)
+        raise ArgumentError, "compose: unknown role #{role} for element #{e[:id]}"
+      end
+      { id: e[:id], role: role }
+    end
+  end
+
+  # Raise when a resolved role isn't in the pattern's consumed set — e.g.
+  # :master passed to :exec, or :kpi passed to :master_detail. Root fix: such
+  # a role used to fall through every band unrendered and vanish from the
+  # emitted layout with no signal.
+  def self.check_pattern_roles!(roleized, pattern_name, allowed_roles)
+    roleized.each do |e|
+      next if allowed_roles.include?(e[:role])
+      raise ArgumentError, "compose: role #{e[:role]} (element #{e[:id]}) is not used by pattern #{pattern_name}"
+    end
+  end
+
+  # bands: the role -> [r0, r1) row-band computation shared by compose_exec
+  # and compose_master_detail, extracted so callers can get the layout's
+  # structure (which roles land in which row band, and which element ids)
+  # without the gridColumn/XML-emission step. Returns
+  # [{role:, ids:, r0:, r1:}, ...] in row order. Column splitting within a
+  # band still happens in compose_* (via band()), not here — bands() only
+  # decides vertical placement.
+  def self.bands(elements, pattern, page_cols = 24)
+    roleized = roleize(elements)
+    by = Hash.new { |h, k| h[k] = [] }
+    roleized.each { |e| by[e[:role]] << e }
+    row = 1
+    out = []
+    add = lambda do |role, group, h|
+      next if group.empty?
+      out << { role: role, ids: group.map { |e| e[:id] }, r0: row, r1: row + h }
+      row += h
+    end
+    case pattern.to_sym
+    when :exec
+      check_pattern_roles!(roleized, 'exec', EXEC_ROLES)
+      [[:control, 2], [:kpi, 6], [:insight, 3], [:hero, 12]].each { |role, h| add.call(role, by[role], h) }
+      add.call(:supporting, by[:supporting] + by[:table], 9)
+    when :master_detail
+      check_pattern_roles!(roleized, 'master_detail', MASTER_DETAIL_ROLES)
+      add.call(:control, by[:control], 2)
+      add.call(:master_detail, by[:master] + by[:detail], 14)
+    when :overview
+      check_pattern_roles!(roleized, 'overview', OVERVIEW_ROLES)
+      [[:header, 3], [:control, 2], [:kpi, 8], [:kpi2, 8], [:trend, 12], [:pivot, 14], [:base, 9]].each do |role, h|
+        add.call(role, by[role], h)
+      end
+    else
+      raise ArgumentError, "compose: unknown pattern #{pattern.inspect}"
+    end
+    out
+  end
+
+  def self.render_bands(elements, pattern, page_cols)
+    bands(elements, pattern, page_cols).flat_map do |b|
+      band(b[:ids].map { |id| { id: id } }, b[:r0], b[:r1], page_cols)
+    end.join("\n")
+  end
+
+  def self.compose_exec(elements, page_cols)
+    render_bands(elements, :exec, page_cols)
+  end
+
+  # :master_detail — an optional thin full-width :control row on top, then
+  # :master and :detail share one tall gridRow, split evenly across page_cols
+  # (12/12 of 24) via the same band() helper :exec uses. Layout only: the
+  # control->detail filter wiring is authored per-element-spec (see
+  # reference/workflows/composition.md), not emitted here.
+  def self.compose_master_detail(elements, page_cols)
+    render_bands(elements, :master_detail, page_cols)
+  end
+
+  # :overview — an optional stack of full-width bands (each skipped if empty):
+  # :header -> :control (filter row) -> :kpi (tall: comparative cards + Δ badges) -> :kpi2
+  # (optional 2nd KPI row, e.g. rates) -> :trend -> :pivot -> :base. Every band
+  # even-splits its elements across page_cols via the same band() helper
+  # :exec/:master_detail use; only vertical stacking differs.
+  def self.compose_overview(elements, page_cols)
+    render_bands(elements, :overview, page_cols)
+  end
+
+  def self.compose(elements, pattern: :exec, page_cols: 24)
+    case pattern.to_sym
+    when :exec then compose_exec(elements, page_cols)
+    when :master_detail then compose_master_detail(elements, page_cols)
+    when :overview then compose_overview(elements, page_cols)
+    else raise ArgumentError, "compose: unknown pattern #{pattern.inspect}"
+    end
+  end
+end

--- a/sigma-workbooks/scripts/lib/composition_lint.rb
+++ b/sigma-workbooks/scripts/lib/composition_lint.rb
@@ -1,0 +1,110 @@
+# frozen_string_literal: true
+# composition_lint.rb — verify a composed layout XML fragment: each gridRow band
+# tiles the columns [1, page_cols+1) with no gap/overlap, and bands are contiguous
+# vertically with no gap/overlap. A top-level <GridContainer> (Styling's header /
+# section_card card wrappers — scripts/lib/styling.rb) participates in PAGE band
+# tiling exactly like a <LayoutElement>: its own gridColumn/gridRow is the rect
+# checked against the page. Its DIRECT CHILDREN are then validated the SAME way
+# but against the container's OWN rect — column count from the container's
+# gridTemplateColumns ("repeat(N, ...)" -> N; absent -> page_cols), and rows
+# starting at 1 (children use container-relative row numbering, same convention
+# as Styling.header/section_card). Nesting-aware — a stack walk so a nested
+# container's own close tag can't truncate an outer container's body. Returns
+# an array of human-readable errors ([] = clean).
+module CompositionLint
+  TOKENS = %r{</GridContainer>|<GridContainer\b[^>]*?/?>|<LayoutElement\b[^>]*?/?>}m
+
+  module_function
+
+  # Pull {id:, c0:, c1:, r0:, r1:} out of a <GridContainer ...> or
+  # <LayoutElement ...> opening/self-closing tag, independent of attribute
+  # order (a GridContainer carries extra attrs — type, gridTemplateColumns,
+  # gridTemplateRows — between elementId and gridColumn/gridRow).
+  def self.rect_of(tag)
+    { id: tag[/elementId="([^"]*)"/, 1],
+      c0: tag[/gridColumn="\s*(\d+)/, 1].to_i, c1: tag[/gridColumn="\s*\d+\s*\/\s*(\d+)/, 1].to_i,
+      r0: tag[/gridRow="\s*(\d+)/, 1].to_i, r1: tag[/gridRow="\s*\d+\s*\/\s*(\d+)/, 1].to_i }
+  end
+
+  # A container's own local column count, from its gridTemplateColumns
+  # ("repeat(N, ...)" -> N); nil (fall back to page_cols) if absent/unparsed.
+  def self.tmpl_cols_of(tag)
+    tmpl = tag[/gridTemplateColumns="([^"]*)"/, 1]
+    rep = tmpl && tmpl[/repeat\(\s*(\d+)/, 1]
+    rep && rep.to_i
+  end
+
+  # Parse the top-level entries of a layout XML fragment into a tree:
+  # [{type: :element|:container, id:, c0:, c1:, r0:, r1:, tmpl_cols:, children: [...]}, ...]
+  # (tmpl_cols/children only meaningful for :container). A nesting-aware
+  # stack walk so an inner container's </GridContainer> can't truncate an
+  # outer one's body.
+  def self.parse(xml)
+    roots = []
+    stack = []
+    xml.to_s.scan(TOKENS) do
+      tag = Regexp.last_match(0)
+      if tag.start_with?('</GridContainer')
+        node = stack.pop
+        (stack.empty? ? roots : stack.last[:children]) << node if node
+      elsif tag.start_with?('<GridContainer')
+        node = rect_of(tag).merge(type: :container, tmpl_cols: tmpl_cols_of(tag), children: [])
+        if tag.end_with?('/>')
+          (stack.empty? ? roots : stack.last[:children]) << node
+        else
+          stack.push(node)
+        end
+      else
+        node = rect_of(tag).merge(type: :element)
+        (stack.empty? ? roots : stack.last[:children]) << node
+      end
+    end
+    roots.concat(stack) # tolerate unclosed containers rather than dropping them
+    roots
+  end
+
+  # Core check shared by the page and every container: `members` (rects with
+  # id/c0/c1/r0/r1) must tile columns [1, ncols+1) per gridRow band, and bands
+  # must stack contiguously starting at row 1, with no gap/overlap.
+  def self.check_region(members, ncols, label)
+    return [] if members.empty?
+    errors = []
+    bands = members.group_by { |e| [e[:r0], e[:r1]] }
+    bands.each do |(r0, r1), band|
+      cols = band.sort_by { |e| e[:c0] }
+      if cols.first[:c0] != 1
+        errors << "#{label}: band rows #{r0}/#{r1}: does not start at column 1 (starts at #{cols.first[:c0]})"
+      end
+      if cols.last[:c1] != ncols + 1
+        errors << "#{label}: band rows #{r0}/#{r1}: does not fill to #{ncols + 1} (dead columns; ends at #{cols.last[:c1]})"
+      end
+      cols.each_cons(2) do |a, b|
+        errors << "#{label}: band rows #{r0}/#{r1}: column overlap/gap between #{a[:id]} and #{b[:id]} (#{a[:c1]} vs #{b[:c0]})" if a[:c1] != b[:c0]
+      end
+    end
+    band_rows = bands.keys.sort_by { |(r0, _)| r0 }
+    errors << "#{label}: top band does not start at row 1 (starts at #{band_rows.first[0]})" if band_rows.first[0] != 1
+    band_rows.each_cons(2) do |(_, ar1), (br0, _)|
+      errors << "#{label}: vertical gap/overlap between bands (row #{ar1} vs #{br0})" if ar1 != br0
+    end
+    errors
+  end
+
+  # Recursively check every <GridContainer>'s direct children against the
+  # container's OWN rect (not the page).
+  def self.check_containers(node, page_cols)
+    return [] unless node[:type] == :container
+    ncols = node[:tmpl_cols] || page_cols
+    errors = check_region(node[:children], ncols, "container #{node[:id]}")
+    node[:children].each { |child| errors.concat(check_containers(child, page_cols)) }
+    errors
+  end
+
+  def self.check(layout_xml, page_cols: 24)
+    roots = parse(layout_xml)
+    return ['no <LayoutElement> tags found'] if roots.empty?
+    errors = check_region(roots, page_cols, 'page')
+    roots.each { |node| errors.concat(check_containers(node, page_cols)) }
+    errors
+  end
+end

--- a/sigma-workbooks/scripts/lib/kpi_card.rb
+++ b/sigma-workbooks/scripts/lib/kpi_card.rb
@@ -1,0 +1,79 @@
+# frozen_string_literal: true
+#
+# kpi_card.rb — emits the VERIFIED comparative KPI-card shape: a kpi-chart
+# element with a value column AND a comparison column rendered as a Δ badge.
+# Documented as the house default for KPI cards in this skill (see
+# reference/specification/comparative-kpi-card.yaml and
+# reference/workflows/composition.md's "Richness" section).
+#
+#   require_relative 'lib/kpi_card'
+#   el = KpiCard.build(id: 'kpi-rev', name: 'Revenue', source_element_id: 'tbl-1',
+#                      columns: [{'id'=>'rev_cur'}], value_column_id: 'rev_cur',
+#                      comparison_column_id: 'rev_prior', good_direction: :up)
+#
+# This emitter builds ONLY the kpi-chart element (a Hash) — not a whole
+# workbook, container, or layout — so it drops cleanly into any builder that
+# lays out elements separately. Number/percent formatting is a COLUMN concern,
+# not a value concern: pass it on the relevant columns[] entry, e.g.
+# {'id'=>'rev_cur','format'=>{'kind'=>'number','formatString'=>'$,.0f'}} — it
+# rides through the columns passthrough untouched.
+#
+# Stdlib only (json); Ruby 2.6+-compatible. Golden-tested output lives in
+# scripts/lib/testdata/kpi_card_golden.json and
+# kpi_card_value_style_golden.json (see test_kpi_card.rb).
+
+require 'json'
+
+module KpiCard
+  DELTA_GOOD = '#1a7f37' # green
+  DELTA_BAD  = '#cf222e' # red
+
+  # Returns a kpi-chart element Hash. comparison_column_id nil/'' ⇒ single-value
+  # card (no comparison/comparisonColumn keys). Callers may layer tool-specific
+  # decorations (font overrides, extra columns) onto the returned Hash.
+  #
+  # value_color:/value_font_size: are optional accent styling for the value
+  # itself (verified GO shape: value:{columnId,color,fontSize}). Both nil
+  # (the default) ⇒ value is just {'columnId'=>...}, byte-identical to before
+  # these kwargs existed.
+  def self.build(id:, name:, source_element_id:, columns:, value_column_id:,
+                 comparison_column_id: nil,
+                 good_direction: :up, title_color: nil,
+                 value_color: nil, value_font_size: nil)
+    raise ArgumentError, 'id required' if id.to_s.empty?
+    raise ArgumentError, 'value_column_id required' if value_column_id.to_s.empty?
+
+    cols = (columns || []).map { |c| c }
+    has_cmp = comparison_column_id && !comparison_column_id.to_s.empty?
+    if has_cmp && cols.none? { |c| c['id'].to_s == comparison_column_id.to_s }
+      cols = cols + [{ 'id' => comparison_column_id }]
+    end
+
+    name_obj = { 'text' => name }
+    name_obj['color'] = title_color if title_color
+
+    value = { 'columnId' => value_column_id }
+    value['color'] = value_color unless value_color.nil?
+    value['fontSize'] = value_font_size unless value_font_size.nil?
+
+    el = {
+      'id'      => id,
+      'kind'    => 'kpi-chart',
+      'name'    => name_obj,
+      'source'  => { 'kind' => 'table', 'elementId' => source_element_id },
+      'columns' => cols,
+      'value'   => value
+    }
+
+    if has_cmp
+      up = good_direction.to_sym == :up
+      el['comparisonColumn'] = { 'columnId' => comparison_column_id }
+      el['comparison'] = {
+        'display'   => 'delta',
+        'colorGood' => up ? DELTA_GOOD : DELTA_BAD,
+        'colorBad'  => up ? DELTA_BAD : DELTA_GOOD
+      }
+    end
+    el
+  end
+end

--- a/sigma-workbooks/scripts/lib/richness.rb
+++ b/sigma-workbooks/scripts/lib/richness.rb
@@ -1,0 +1,199 @@
+# frozen_string_literal: true
+#
+# richness.rb — four independent, optional "richness" pieces for a dashboard
+# page — each helper emits ONE spec-authorable fragment, never a whole
+# workbook/page. Consumed by callers that already have Composition/Styling
+# output and want to layer in an AI-generated insight, a dynamic date-grain
+# control+dimension, a filter row, or a wide (non-crosstab) pivot table.
+# Ruby 2.6+, stdlib only. Golden-tested output lives in
+# scripts/lib/testdata/richness_golden.json (see test_richness.rb).
+#
+#   require_relative 'lib/richness'
+#   Richness.ai_insight(id: 'ai-1', prompt: 'Say hello.')
+#   ctl = Richness.grain_control(id: 'GrainCtl')
+#   dim = Richness.trend_dimension(grain_control_id: 'GrainCtl', date_ref: '[Src/Date]')
+#
+# GO/NO-GO provenance (verified live against a real Sigma org):
+#   - CallText/AI-insight: GO. CallText's real signature is
+#     CallText(<warehouse_function_name>, ...args) — there is NO separate
+#     connection argument (an earlier assumption was wrong; this is the
+#     corrected shape). Working connection+model verified live: the Sigma
+#     Sample Database Snowflake connection, model "llama3.1-8b" (mistral-
+#     large2 also returned real text at the raw-SQL probe stage). GO here
+#     means "the formula shape is spec-legal and Sigma-side proven to render
+#     real text on a configured connection" — it does NOT mean every target
+#     org has Cortex enabled. This helper therefore ALWAYS emits the formula
+#     when its surface is GO; never fabricate a canned summary in code — the
+#     org's own warehouse computes the real text, or the element renders
+#     blank until Cortex is configured there.
+#   - Dynamic grain (Switch+DateTrunc): GO. Switching the control across
+#     Month/Week/Day changed the exported distinct-bucket count exactly as
+#     expected (Month=3, Week=14, Day=90 over 90 days of demo data).
+#   - filter_row reuses the already-GO master-detail control->element-filter
+#     shape (see reference/workflows/composition.md's master/detail pattern),
+#     not a new richness-specific surface.
+#   - wide_pivot reuses the already-GO general pivot-table rowsBy/columnsBy/
+#     values shape documented in reference/specification/tables.md's pivot
+#     recipe: rowsBy/columnsBy are [{"id":...}] shelves, values is a plain
+#     metric id-string list — also not a new richness-specific surface.
+# All four are gated through SURFACES below anyway (not just the two surfaces
+# with their own dedicated verification pass), so a future regression/
+# deprecation on ANY of them can be flipped off in one place, same discipline
+# as styling.rb.
+#
+# Two live-build fixes below, previously only worked around by callers, are
+# now fixed IN this module:
+#   - wide_pivot 400'd ("Invalid kind: \"pivot-table\"" — a misleading
+#     message; the real cause is a pivot-table element with no `columns`
+#     array). Fixed by adding a required `columns:` param — an already-
+#     shaped [{'id'=>,'name'=>,'formula'=>}, ...] array per tables.md's
+#     pivot recipe, emitted verbatim on the element. `rows_by`/`values` now
+#     reference these columns' OWN ids, not the source element's column ids.
+#   - grain_control 400'd ("controlId: Duplicate id: '<id>'") when the same
+#     string was reused for both the control element's `id` and its
+#     `controlId`. Fixed by adding a `control_id:` param (default
+#     "<id>-ctl") so the two always differ; trend_dimension's
+#     `grain_control_id:` must be given that `controlId` (not the element
+#     `id`) — see its docstring below.
+
+require 'json'
+
+module Richness
+  # GO/NO-GO map. All 4 are GO today; a NO-GO flip makes the gated helper
+  # return an empty/opt-in marker instead of emitting an unverified (or
+  # 400-rejected) shape — never a silently-wrong fallback.
+  SURFACES = {
+    ai_insight: true,     # CallText/AI-insight text element (verified GO live; renders real text only where the target org's connection has Cortex configured — NEVER a fabricated summary)
+    dynamic_grain: true,  # grain_control (segmented control) + trend_dimension (Switch+DateTrunc dimension formula) — verified GO live
+    filter_row: true,     # list control(s) -> element filter, reusing the already-GO master-detail control/filter shape
+    wide_pivot: true      # pivot-table rowsBy + columnsBy:[] + values, reusing the already-GO general Sigma pivot shape
+  }.freeze
+
+  DEFAULT_MODEL = 'llama3.1-8b'
+  GRAIN_VALUES = %w[Week Month Day].freeze
+  DEFAULT_GRAIN = 'Month'
+
+  # Returns a `text` element whose body is a CallText/Cortex formula:
+  # {{ Replace(CallText("SNOWFLAKE.CORTEX.COMPLETE","<model>", "<prompt>") , '"', "") }}
+  # `prompt` is embedded verbatim between the outer quotes the template
+  # supplies — callers wanting a formula-composed prompt (e.g. concatenating
+  # a live aggregate via `" & Text(Sum(...)) & "`) pass that text as-is; this
+  # helper only supplies the CallText/Replace wrapper, never the content.
+  # Meant to sit in a light-tint container (caller wraps — this helper builds
+  # ONLY the text element). NO-GO surface -> {'opt_in'=>true,'id'=>id}: the
+  # formula is withheld, never a faked/hardcoded summary string.
+  def self.ai_insight(id:, model: DEFAULT_MODEL, prompt:, surfaces: SURFACES)
+    raise ArgumentError, 'id required' if id.to_s.empty?
+    raise ArgumentError, 'prompt required' if prompt.to_s.empty?
+    return { 'opt_in' => true, 'id' => id } unless surfaces[:ai_insight]
+
+    body = "{{ Replace(CallText(\"SNOWFLAKE.CORTEX.COMPLETE\", \"#{model}\", \"#{prompt}\") , '\"', \"\") }}"
+    { 'id' => id, 'kind' => 'text', 'body' => body }
+  end
+
+  # Returns a `segmented` control element (Week/Month/Day, default Month).
+  # `id` is the control ELEMENT's id; `controlId` is a SEPARATE handle that
+  # defaults to "<id>-ctl" when `control_id:` is omitted. The two MUST
+  # differ — Sigma 400s ("controlId: Duplicate id: '<id>'") when the same
+  # string is reused for both (a live-build finding). Pass the returned
+  # element's `controlId` (NOT its `id`) as `grain_control_id:` to
+  # trend_dimension so its Switch(...) formula references this exact
+  # control. NO-GO surface -> {'opt_in'=>true,'id'=>id}.
+  def self.grain_control(id:, control_id: nil, name: 'Grain', surfaces: SURFACES)
+    raise ArgumentError, 'id required' if id.to_s.empty?
+    return { 'opt_in' => true, 'id' => id } unless surfaces[:dynamic_grain]
+
+    cid = control_id.to_s.empty? ? "#{id}-ctl" : control_id
+    {
+      'id' => id,
+      'kind' => 'control',
+      'controlId' => cid,
+      'name' => name,
+      'controlType' => 'segmented',
+      'selectionMode' => 'single',
+      'value' => DEFAULT_GRAIN,
+      'source' => { 'kind' => 'manual', 'valueType' => 'text', 'values' => GRAIN_VALUES }
+    }
+  end
+
+  # Returns the Switch-driven grain dimension formula string (verified live:
+  # Month/Week/Day buckets change on export). `grain_control_id` is
+  # grain_control's returned `controlId` (NOT its element `id` — the two are
+  # distinct handles, see grain_control above); `date_ref` is a raw Sigma
+  # column reference, e.g. "[Src/Date]". NO-GO surface -> '' (empty string —
+  # no formula emitted).
+  def self.trend_dimension(grain_control_id:, date_ref:, surfaces: SURFACES)
+    raise ArgumentError, 'grain_control_id required' if grain_control_id.to_s.empty?
+    raise ArgumentError, 'date_ref required' if date_ref.to_s.empty?
+    return '' unless surfaces[:dynamic_grain]
+
+    "Switch([#{grain_control_id}],\"Week\",DateTrunc(\"week\",#{date_ref})," \
+      "\"Month\",DateTrunc(\"month\",#{date_ref}),DateTrunc(\"day\",#{date_ref}))"
+  end
+
+  # Returns an array of `list` control element specs, each bound to a base
+  # source column and filtering one or more target elements — the reused
+  # master-detail control->element-filter shape. `controls` is an array of
+  # descriptor Hashes (symbol keys, NOT final JSON — consumed here, like
+  # Composition's `elements:`):
+  #   { id:, control_id:, name:, source_element_id:, column_id:,
+  #     filter_targets: [{ element_id:, column_id: }, ...] }
+  # NO-GO surface -> [] (no controls emitted).
+  def self.filter_row(controls:, surfaces: SURFACES)
+    return [] unless surfaces[:filter_row]
+
+    (controls || []).map do |c|
+      {
+        'id' => c[:id],
+        'kind' => 'control',
+        'controlId' => c[:control_id],
+        'name' => c[:name],
+        'controlType' => 'list',
+        'mode' => 'include',
+        'selectionMode' => 'single',
+        'values' => [],
+        'source' => {
+          'kind' => 'source',
+          'source' => { 'kind' => 'table', 'elementId' => c[:source_element_id] },
+          'columnId' => c[:column_id]
+        },
+        'filters' => (c[:filter_targets] || []).map do |t|
+          { 'source' => { 'kind' => 'table', 'elementId' => t[:element_id] }, 'columnId' => t[:column_id] }
+        end
+      }
+    end
+  end
+
+  # Returns a `pivot-table` element biased WIDE: columns: columns (REQUIRED
+  # — an already-shaped [{'id'=>...,'name'=>...,'formula'=>...}, ...] array,
+  # the pivot's OWN columns per tables.md's pivot recipe; each `formula`
+  # references the source element's fields directly, e.g. "[Src/Region]" for
+  # a passthrough dimension or "Sum([Src/Revenue])" for a measure — passed
+  # through verbatim, same convention as KpiCard.build's `columns:`).
+  # rowsBy: rows_by and values: values then reference these columns' OWN
+  # ids (NOT the source element's column ids) — rows_by is already-shaped
+  # [{"id"=>...}, ...] shelf entries, values is a plain metric id-string
+  # list. columnsBy: [] (must be empty — a non-crosstab pivot). Omitting
+  # `columns` (or passing an empty array) 400s live ("Invalid kind:
+  # \"pivot-table\"" — a misleading message; the real cause is the missing
+  # `columns` array), so it's a required, non-empty param here (a live-build
+  # finding). Grand totals are a UI-only setting, not a spec field — not
+  # emitted here; note it in caller docs, don't guess a field name. NO-GO
+  # surface -> {'opt_in'=>true,'id'=>id}.
+  def self.wide_pivot(id:, source_element_id:, rows_by:, values:, columns:, surfaces: SURFACES)
+    raise ArgumentError, 'id required' if id.to_s.empty?
+    raise ArgumentError, 'source_element_id required' if source_element_id.to_s.empty?
+    raise ArgumentError, 'columns required' if columns.nil? || columns.empty?
+    return { 'opt_in' => true, 'id' => id } unless surfaces[:wide_pivot]
+
+    {
+      'id' => id,
+      'kind' => 'pivot-table',
+      'source' => { 'kind' => 'table', 'elementId' => source_element_id },
+      'columns' => columns,
+      'rowsBy' => rows_by,
+      'columnsBy' => [],
+      'values' => values
+    }
+  end
+end

--- a/sigma-workbooks/scripts/lib/styling.rb
+++ b/sigma-workbooks/scripts/lib/styling.rb
@@ -1,0 +1,132 @@
+# frozen_string_literal: true
+# styling.rb — spec-authorable dashboard styling helpers that decorate
+# Composition output: theme (palette), chart color, KPI accent, number
+# format, header/section container. Ruby 2.6+, stdlib only.
+require_relative 'composition'
+
+module Styling
+  # One professional, host-agnostic palette. No branding.
+  DEFAULT_THEME = {
+    categorical: %w[#2563EB #0EA5E9 #14B8A6 #F59E0B #8B5CF6 #EF4444 #10B981 #64748B],
+    ink: '#0F172A', muted: '#64748B',
+    # Verified live: field is borderRadius ("round"), borderColor/borderWidth;
+    # do NOT put padding alongside border fields (POST 400).
+    card: { 'backgroundColor' => '#FFFFFF', 'borderColor' => '#E2E8F0',
+            'borderWidth' => 1, 'borderRadius' => 'round' },
+    header: { 'backgroundColor' => '#0F172A', 'borderRadius' => 'round' },
+    accent: '#2563EB'
+  }.freeze
+
+  # Returns a theme; an accent override tints categorical slot 0 + accent.
+  def self.theme(accent: nil)
+    return DEFAULT_THEME if accent.nil? || accent.to_s.empty?
+    t = Marshal.load(Marshal.dump(DEFAULT_THEME))         # deep copy (stdlib)
+    t[:categorical] = [accent.to_s] + t[:categorical][1..-1]
+    t[:accent] = accent.to_s
+    t
+  end
+
+  # GO/NO-GO map, seeded from a live spec-readback probe against a real Sigma
+  # org: every surface below survived GET-spec readback AND rendered a real
+  # pixel hit. All 6 are GO today, but gating every helper through this map
+  # (instead of hardcoding `true` at each call site) means a future
+  # regression/deprecation can flip one surface off in one place — the gated
+  # helper then returns an empty patch instead of emitting an unverified (or
+  # 400-rejected) shape.
+  SURFACES = {
+    kpi_name_color: true,     # name:{text,color} on a kpi-chart (value.color bonus also GO, not emitted here)
+    chart_color_by: true,     # color:{by:"single",value:"#hex"} on a chart element
+    categorical_scheme: true, # workbook-level themeOverrides:{categoricalScheme:[...]}
+    format_string: true,      # format:{kind:"number",formatString:<d3>} — Excel-style formatString is 400-rejected, never emitted
+    container_style: true,    # container style:{backgroundColor,borderRadius,borderColor,borderWidth} (borderRadius, NOT cornerRadius; never combine with padding)
+    typography: true          # themeOverrides.titleFont + per-element name:{fontSize} — verified GO live, but no helper below emits it (out of scope here); kept for a complete surface map
+  }.freeze
+
+  # d3-format grammar (NOT Excel) — verified live, surviving strings.
+  D3_FORMATS = {
+    currency: '$,.0f',
+    integer: ',.0f',
+    percent: '.1%',
+    decimal: ',.2f'
+  }.freeze
+
+  # Chart color patch: single-series `color:{by:"single",value:}` (categorical
+  # slot 0) by default, or the workbook-level categorical-scheme patch when
+  # categorical: true. NO-GO surface -> {} (nothing emitted).
+  def self.chart_color(theme, categorical: false, surfaces: SURFACES)
+    if categorical
+      return {} unless surfaces[:categorical_scheme]
+      { 'themeOverrides' => { 'categoricalScheme' => theme[:categorical] } }
+    else
+      return {} unless surfaces[:chart_color_by]
+      { 'color' => { 'by' => 'single', 'value' => theme[:categorical][0] } }
+    end
+  end
+
+  # Fragment to merge into a KPI element's `name` object: name:{text:,color:}.
+  # NO-GO surface -> {} (nothing to merge).
+  def self.kpi_accent(theme, surfaces: SURFACES)
+    return {} unless surfaces[:kpi_name_color]
+    { 'color' => theme[:accent] }
+  end
+
+  # Number-format fragment for a column's `format` field.
+  # semantic: :currency / :integer / :percent / :decimal.
+  def self.format_for(semantic, surfaces: SURFACES)
+    return {} unless surfaces[:format_string]
+    d3 = D3_FORMATS[semantic.to_sym]
+    raise ArgumentError, "format_for: unknown semantic #{semantic.inspect}" if d3.nil?
+    { 'kind' => 'number', 'formatString' => d3 }
+  end
+
+  # Thin full-width header band (rows 1..3): a styled `kind:container` +
+  # a separate `kind:text` title child (containers have no title-rendering
+  # field of their own — see reference/specification/layout.md Recipe 1),
+  # plus the `<GridContainer>` layout fragment wrapping the title
+  # `<LayoutElement>`. If container-style is NO-GO, returns the header as a
+  # plain text element with no wrapping container (a bare `<LayoutElement>`).
+  def self.header(id:, title:, theme:, page_cols: 24, surfaces: SURFACES)
+    title_id = "#{id}-title"
+    text_el = { 'id' => title_id, 'kind' => 'text',
+                'body' => "# <span style=\"color: #FFFFFF\">#{title}</span>" }
+    r0 = 1
+    r1 = 3
+    unless surfaces[:container_style]
+      layout = "  <LayoutElement elementId=\"#{title_id}\" gridColumn=\"1 / #{page_cols + 1}\" gridRow=\"#{r0} / #{r1}\"/>"
+      return { element: [text_el], layout: layout }
+    end
+    container_id = "#{id}-bg"
+    container_el = { 'id' => container_id, 'kind' => 'container', 'style' => theme[:header] }
+    layout = [
+      "<GridContainer elementId=\"#{container_id}\" type=\"grid\" gridColumn=\"1 / #{page_cols + 1}\" gridRow=\"#{r0} / #{r1}\" " \
+        "gridTemplateColumns=\"repeat(#{page_cols}, 1fr)\" gridTemplateRows=\"auto\">",
+      "  <LayoutElement elementId=\"#{title_id}\" gridColumn=\"1 / #{page_cols + 1}\" gridRow=\"#{r0} / #{r1}\"/>",
+      '</GridContainer>'
+    ].join("\n")
+    { element: [container_el, text_el], layout: layout }
+  end
+
+  # Wraps one Composition.bands()-style band ({role:,ids:,r0:,r1:}) in a
+  # styled card container: a `kind:container` (theme[:card]) at the band's
+  # page-level rect, with its ids tiled side-by-side inside (same even
+  # column split Composition.band uses, on the container's own relative row
+  # range). If container-style is NO-GO, returns the band's bare
+  # (unwrapped) `<LayoutElement>` render, matching plain Composition output.
+  def self.section_card(id:, band:, theme:, page_cols: 24, surfaces: SURFACES)
+    ids = band[:ids]
+    height = band[:r1] - band[:r0]
+    unless surfaces[:container_style]
+      wrap = Composition.band(ids.map { |i| { id: i } }, band[:r0], band[:r1], page_cols).join("\n")
+      return { element: nil, wrap: wrap }
+    end
+    container_el = { 'id' => id, 'kind' => 'container', 'style' => theme[:card] }
+    children = Composition.band(ids.map { |i| { id: i } }, 1, 1 + height, page_cols).join("\n")
+    wrap = [
+      "<GridContainer elementId=\"#{id}\" type=\"grid\" gridColumn=\"1 / #{page_cols + 1}\" gridRow=\"#{band[:r0]} / #{band[:r1]}\" " \
+        "gridTemplateColumns=\"repeat(#{page_cols}, 1fr)\" gridTemplateRows=\"auto\">",
+      children,
+      '</GridContainer>'
+    ].join("\n")
+    { element: container_el, wrap: wrap }
+  end
+end

--- a/sigma-workbooks/scripts/lib/test_composition.rb
+++ b/sigma-workbooks/scripts/lib/test_composition.rb
@@ -1,0 +1,143 @@
+# frozen_string_literal: true
+# test_composition.rb — run directly: ruby scripts/lib/test_composition.rb (from sigma-workbooks/)
+require_relative 'composition'
+$failures = 0
+def check(desc); ok = yield; puts(ok ? "[ok] #{desc}" : "[FAIL] #{desc}"); $failures += 1 unless ok; end
+
+golden = File.read(File.join(__dir__, 'testdata', 'composition_exec_golden.txt')).strip
+els = [
+  { id: 'kpi1', role: :kpi }, { id: 'kpi2', role: :kpi },
+  { id: 'kpi3', role: :kpi }, { id: 'kpi4', role: :kpi },
+  { id: 'hero', role: :hero }, { id: 'tbl', role: :table }
+]
+check('exec layout matches golden') { Composition.compose(els, pattern: :exec).strip == golden }
+check('kpi band widths sum to 24 (4 KPIs -> 6 each)') do
+  Composition.compose(els, pattern: :exec).include?('gridColumn="1 / 7"') &&
+    Composition.compose(els, pattern: :exec).include?('gridColumn="19 / 25"')
+end
+check('raises when a band is not evenly divisible (5 KPIs into 24)') do
+  bad = (1..5).map { |i| { id: "k#{i}", role: :kpi } }
+  begin; Composition.compose(bad, pattern: :exec); false
+  rescue ArgumentError; true; end
+end
+check('infer_role: kpi-chart -> :kpi, table -> :table, bar-chart -> :supporting') do
+  Composition.infer_role('kpi-chart') == :kpi && Composition.infer_role('table') == :table &&
+    Composition.infer_role('bar-chart') == :supporting
+end
+check('unknown pattern raises') do
+  begin; Composition.compose(els, pattern: :nope); false; rescue ArgumentError; true; end
+end
+check('empty-string role resolves via inference (no drop)') do
+  out = Composition.compose([{ id: 'k1', role: '', kind: 'kpi-chart' }], pattern: :exec)
+  out.include?('elementId="k1"') && out.include?('gridColumn="1 / 25"')
+end
+check('unrecognized explicit role raises') do
+  begin
+    Composition.compose([{ id: 'bad1', role: :chart }], pattern: :exec)
+    false
+  rescue ArgumentError => e
+    e.message == 'compose: unknown role chart for element bad1'
+  end
+end
+
+md_golden = File.read(File.join(__dir__, 'testdata', 'composition_master_detail_golden.txt')).strip
+md_els = [
+  { id: 'ctl', role: :control },
+  { id: 'master-chart', role: :master, kind: 'bar-chart' },
+  { id: 'detail-tbl', role: :detail, kind: 'table' }
+]
+check('master_detail: master 1/13 and detail 13/25 share a gridRow, matches golden') do
+  out = Composition.compose(md_els, pattern: :master_detail)
+  out.strip == md_golden &&
+    out.include?('elementId="master-chart" gridColumn="1 / 13" gridRow="3 / 17"') &&
+    out.include?('elementId="detail-tbl" gridColumn="13 / 25" gridRow="3 / 17"')
+end
+check('master_detail: control row is optional (master/detail band starts at row 1 without it)') do
+  out = Composition.compose([{ id: 'm', role: :master }, { id: 'd', role: :detail }], pattern: :master_detail)
+  out.include?('elementId="m" gridColumn="1 / 13" gridRow="1 / 15"') &&
+    out.include?('elementId="d" gridColumn="13 / 25" gridRow="1 / 15"')
+end
+check('regression: :exec output unchanged after adding :master_detail') do
+  Composition.compose(els, pattern: :exec).strip == golden
+end
+
+# Root fix: a role a pattern doesn't consume must RAISE, never silently
+# vanish from the emitted layout.
+check(':master passed to :exec raises') do
+  begin
+    Composition.compose([{ id: 'm1', role: :master }], pattern: :exec)
+    false
+  rescue ArgumentError => e
+    e.message == 'compose: role master (element m1) is not used by pattern exec'
+  end
+end
+check(':kpi passed to :master_detail raises') do
+  begin
+    Composition.compose([{ id: 'k1', role: :kpi }], pattern: :master_detail)
+    false
+  rescue ArgumentError => e
+    e.message == 'compose: role kpi (element k1) is not used by pattern master_detail'
+  end
+end
+check('regression: normal :exec call with control/kpi/hero/supporting/table still succeeds') do
+  out = Composition.compose([
+    { id: 'ctl', role: :control }, { id: 'k1', role: :kpi }, { id: 'hero1', role: :hero },
+    { id: 'sup1', role: :supporting }, { id: 'tbl1', role: :table }
+  ], pattern: :exec)
+  %w[ctl k1 hero1 sup1 tbl1].all? { |id| out.include?("elementId=\"#{id}\"") }
+end
+
+# :overview — optional stack of bands: header -> control -> kpi -> kpi2 ->
+# trend -> pivot -> base, each skipped if empty, even-split within a band.
+overview_golden = File.read(File.join(__dir__, 'testdata', 'composition_overview_golden.txt')).strip
+overview_els = [
+  { id: 'hdr', role: :header },
+  { id: 'ctl', role: :control },
+  { id: 'kpi1', role: :kpi }, { id: 'kpi2', role: :kpi },
+  { id: 'rate1', role: :kpi2 }, { id: 'rate2', role: :kpi2 },
+  { id: 'trend1', role: :trend },
+  { id: 'pivot1', role: :pivot },
+  { id: 'base1', role: :base }, { id: 'base2', role: :base }, { id: 'base3', role: :base }
+]
+check('overview: bands() returns expected [{role,ids,r0,r1}] stack for a partial set') do
+  stack = Composition.bands(
+    [{ id: 'h', role: :header }, { id: 'k', role: :kpi }, { id: 'tr', role: :trend }, { id: 'pv', role: :pivot }],
+    :overview
+  )
+  stack == [
+    { role: :header, ids: ['h'], r0: 1, r1: 4 },
+    { role: :kpi, ids: ['k'], r0: 4, r1: 12 },
+    { role: :trend, ids: ['tr'], r0: 12, r1: 24 },
+    { role: :pivot, ids: ['pv'], r0: 24, r1: 38 }
+  ]
+end
+check('overview: full-stack compose(pattern: :overview) matches golden') do
+  Composition.compose(overview_els, pattern: :overview).strip == overview_golden
+end
+check('overview: unused bands are skipped, not emitted empty') do
+  out = Composition.compose([{ id: 'tr', role: :trend }], pattern: :overview)
+  out.strip == '<LayoutElement elementId="tr" gridColumn="1 / 25" gridRow="1 / 13"/>'
+end
+check(':master passed to :overview raises (role not consumed by pattern)') do
+  begin
+    Composition.compose([{ id: 'm1', role: :master }], pattern: :overview)
+    false
+  rescue ArgumentError => e
+    e.message == 'compose: role master (element m1) is not used by pattern overview'
+  end
+end
+check(':header passed to :exec raises (overview role not consumed by exec)') do
+  begin
+    Composition.compose([{ id: 'h1', role: :header }], pattern: :exec)
+    false
+  rescue ArgumentError => e
+    e.message == 'compose: role header (element h1) is not used by pattern exec'
+  end
+end
+check('regression: :exec golden still matches after adding :overview') do
+  Composition.compose(els, pattern: :exec).strip == golden
+end
+check('regression: :master_detail golden still matches after adding :overview') do
+  Composition.compose(md_els, pattern: :master_detail).strip == md_golden
+end
+exit($failures.zero? ? 0 : 1)

--- a/sigma-workbooks/scripts/lib/test_composition_lint.rb
+++ b/sigma-workbooks/scripts/lib/test_composition_lint.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+# test_composition_lint.rb — run directly: ruby scripts/lib/test_composition_lint.rb (from sigma-workbooks/)
+require_relative 'composition'
+require_relative 'composition_lint'
+require_relative 'styling'
+$f = 0; def check(d); ok = yield; puts(ok ? "[ok] #{d}" : "[FAIL] #{d}"); $f += 1 unless ok; end
+good = Composition.compose([{ id: 'a', role: :kpi }, { id: 'b', role: :kpi }, { id: 'h', role: :hero }], pattern: :exec)
+check('clean exec layout has no lint errors') { CompositionLint.check(good).empty? }
+overlap = %Q(  <LayoutElement elementId="x" gridColumn="1 / 13" gridRow="1 / 7"/>\n  <LayoutElement elementId="y" gridColumn="10 / 25" gridRow="1 / 7"/>)
+check('detects column overlap in a band') { CompositionLint.check(overlap).any? { |e| e =~ /overlap/i } }
+gap = %Q(  <LayoutElement elementId="x" gridColumn="1 / 7" gridRow="1 / 7"/>)
+check('detects a band that does not fill page_cols (dead columns)') { CompositionLint.check(gap).any? { |e| e =~ /fill|dead|sum/i } }
+
+# --- <GridContainer> card wrappers (styled layouts) ---
+
+# (a) a real styled layout: header GridContainer (rows 1/3, full width) +
+# a carded kpi band + a bare hero band + a bare supporting band, all stacked
+# contiguously below the header. Built from the real Styling/Composition
+# helpers (not hand-typed XML) so this reflects what those helpers actually
+# emit.
+theme = Styling::DEFAULT_THEME
+hdr = Styling.header(id: 'hdr', title: 'Dashboard', theme: theme)
+els = [{ id: 'k1', role: :kpi }, { id: 'k2', role: :kpi }, { id: 'hero1', role: :hero }, { id: 'sup1', role: :supporting }]
+bands = Composition.bands(els, :exec).map { |b| b.merge(r0: b[:r0] + 2, r1: b[:r1] + 2) } # shift below the rows-1/3 header
+kpi_band, hero_band, supporting_band = bands
+kpi_card = Styling.section_card(id: 'card-kpi', band: kpi_band, theme: theme)
+hero_render = Composition.band(hero_band[:ids].map { |i| { id: i } }, hero_band[:r0], hero_band[:r1], 24).join("\n")
+supporting_render = Composition.band(supporting_band[:ids].map { |i| { id: i } }, supporting_band[:r0], supporting_band[:r1], 24).join("\n")
+styled_layout = [hdr[:layout], kpi_card[:wrap], hero_render, supporting_render].join("\n")
+check('styled layout (header GridContainer + carded kpi band + hero + supporting) lints clean') do
+  errs = CompositionLint.check(styled_layout)
+  errs.empty? || (puts errs.inspect; false)
+end
+
+# (b) a container whose CHILDREN overflow/gap within its own rect must flag,
+# even though the container's own page-level rect tiles cleanly.
+container_child_gap = %Q(<GridContainer elementId="c1" type="grid" gridColumn="1 / 25" gridRow="1 / 7" gridTemplateColumns="repeat(24, 1fr)" gridTemplateRows="auto">
+  <LayoutElement elementId="a" gridColumn="1 / 7" gridRow="1 / 7"/>
+  <LayoutElement elementId="b" gridColumn="10 / 25" gridRow="1 / 7"/>
+</GridContainer>)
+check('container whose children gap/overflow within its own rect flags') do
+  CompositionLint.check(container_child_gap).any? { |e| e =~ /overlap|gap/i }
+end
+
+# (c) a top-level GridContainer overlapping a sibling band (different, but
+# vertically overlapping, gridRow ranges) still flags — the container's own
+# gridColumn/gridRow now participates in page-level band tiling exactly like
+# a <LayoutElement> would.
+container_sibling_overlap = %Q(<GridContainer elementId="c1" type="grid" gridColumn="1 / 25" gridRow="1 / 7" gridTemplateColumns="repeat(24, 1fr)" gridTemplateRows="auto">
+  <LayoutElement elementId="a" gridColumn="1 / 25" gridRow="1 / 7"/>
+</GridContainer>
+<LayoutElement elementId="b" gridColumn="1 / 25" gridRow="4 / 10"/>)
+check('a top-level GridContainer overlapping a sibling band flags') do
+  CompositionLint.check(container_sibling_overlap).any? { |e| e =~ /overlap/i }
+end
+
+exit($f.zero? ? 0 : 1)

--- a/sigma-workbooks/scripts/lib/test_kpi_card.rb
+++ b/sigma-workbooks/scripts/lib/test_kpi_card.rb
@@ -1,0 +1,83 @@
+# frozen_string_literal: true
+# test_kpi_card.rb — run directly: ruby scripts/lib/test_kpi_card.rb (from sigma-workbooks/)
+require 'json'
+require_relative 'kpi_card'
+
+$failures = 0
+def check(desc)
+  ok = yield
+  puts(ok ? "[ok] #{desc}" : "[FAIL] #{desc}")
+  $failures += 1 unless ok
+end
+
+# Deep-sort hashes/arrays so comparison to the golden file is key-order-independent.
+def sort_deep(o)
+  case o
+  when Hash then o.keys.sort.each_with_object({}) { |k, h| h[k] = sort_deep(o[k]) }
+  when Array then o.map { |e| sort_deep(e) }
+  else o
+  end
+end
+
+golden = JSON.parse(File.read(File.join(__dir__, 'testdata', 'kpi_card_golden.json')))
+value_style_golden = JSON.parse(File.read(File.join(__dir__, 'testdata', 'kpi_card_value_style_golden.json')))
+
+check('comparative card matches golden (sorted-key identical)') do
+  el = KpiCard.build(id: 'kpi-rev', name: 'Revenue', source_element_id: 'tbl-1',
+                     columns: [{ 'id' => 'rev_cur', 'format' => { 'kind' => 'number', 'formatString' => '$,.0f' } }],
+                     value_column_id: 'rev_cur',
+                     comparison_column_id: 'rev_prior',
+                     good_direction: :up, title_color: '#FFFFFF')
+  JSON.generate(sort_deep(el)) == JSON.generate(sort_deep(golden))
+end
+
+check('plain call (no value_color/value_font_size) is byte-identical to pre-change golden (no regression)') do
+  el = KpiCard.build(id: 'kpi-rev', name: 'Revenue', source_element_id: 'tbl-1',
+                     columns: [{ 'id' => 'rev_cur', 'format' => { 'kind' => 'number', 'formatString' => '$,.0f' } }],
+                     value_column_id: 'rev_cur',
+                     comparison_column_id: 'rev_prior',
+                     good_direction: :up, title_color: '#FFFFFF')
+  JSON.generate(sort_deep(el)) == JSON.generate(sort_deep(golden)) &&
+    !el['value'].key?('color') && !el['value'].key?('fontSize')
+end
+
+check('value_color/value_font_size set: emits value:{columnId,color,fontSize} (matches value-style golden)') do
+  el = KpiCard.build(id: 'k', name: 'Rev', source_element_id: 't',
+                     columns: [{ 'id' => 'rev' }], value_column_id: 'rev',
+                     comparison_column_id: 'prior',
+                     value_color: '#FDE047', value_font_size: 44)
+  el['value'] == { 'columnId' => 'rev', 'color' => '#FDE047', 'fontSize' => 44 } &&
+    JSON.generate(sort_deep(el)) == JSON.generate(sort_deep(value_style_golden))
+end
+
+check('single-value card omits comparison keys') do
+  el = KpiCard.build(id: 'k', name: 'X', source_element_id: 't',
+                     columns: [{ 'id' => 'v' }], value_column_id: 'v')
+  !el.key?('comparison') && !el.key?('comparisonColumn') && el['value']['columnId'] == 'v'
+end
+
+check('good_direction :down inverts delta colors') do
+  el = KpiCard.build(id: 'k', name: 'X', source_element_id: 't',
+                     columns: [{ 'id' => 'v' }], value_column_id: 'v',
+                     comparison_column_id: 'p', good_direction: :down)
+  el['comparison']['colorGood'] == '#cf222e' && el['comparison']['colorBad'] == '#1a7f37'
+end
+
+check('comparison_column_id already in columns is not duplicated') do
+  el = KpiCard.build(id: 'k', name: 'X', source_element_id: 't',
+                     columns: [{ 'id' => 'v' }, { 'id' => 'p' }], value_column_id: 'v',
+                     comparison_column_id: 'p')
+  el['columns'].length == 2 && el['comparisonColumn']['columnId'] == 'p' &&
+    el['comparison']['display'] == 'delta'
+end
+
+check('empty value_column_id raises') do
+  begin
+    KpiCard.build(id: 'k', name: 'X', source_element_id: 't', columns: [], value_column_id: '')
+    false
+  rescue ArgumentError
+    true
+  end
+end
+
+exit($failures.zero? ? 0 : 1)

--- a/sigma-workbooks/scripts/lib/test_richness.rb
+++ b/sigma-workbooks/scripts/lib/test_richness.rb
@@ -1,0 +1,219 @@
+# frozen_string_literal: true
+# test_richness.rb — run directly: ruby scripts/lib/test_richness.rb (from sigma-workbooks/)
+require 'json'
+require_relative 'richness'
+$failures = 0
+def check(desc); ok = yield; puts(ok ? "[ok] #{desc}" : "[FAIL] #{desc}"); $failures += 1 unless ok; end
+
+# Deep-sort hashes/arrays so comparison to the golden file is key-order-independent.
+def sort_deep(o)
+  case o
+  when Hash then o.keys.sort.each_with_object({}) { |k, h| h[k] = sort_deep(o[k]) }
+  when Array then o.map { |e| sort_deep(e) }
+  else o
+  end
+end
+
+check('SURFACES: all 4 richness surfaces are GO') do
+  expected = %i[ai_insight dynamic_grain filter_row wide_pivot]
+  Richness::SURFACES.keys.sort == expected.sort && Richness::SURFACES.values.all? { |v| v == true }
+end
+
+# --- ai_insight -------------------------------------------------------------
+
+check('ai_insight: default model + body contains the CallText(...) formula') do
+  el = Richness.ai_insight(id: 'ai-rev', prompt: 'Summarize revenue trends for the period.')
+  el['id'] == 'ai-rev' && el['kind'] == 'text' &&
+    el['body'].include?('{{ Replace(CallText("SNOWFLAKE.CORTEX.COMPLETE", "llama3.1-8b", ' \
+                         '"Summarize revenue trends for the period.") , \'"\', "") }}')
+end
+check('ai_insight: custom model is used verbatim') do
+  el = Richness.ai_insight(id: 'ai-rev2', model: 'mistral-large2', prompt: 'Say hi.')
+  el['body'].include?('CallText("SNOWFLAKE.CORTEX.COMPLETE", "mistral-large2", "Say hi.")')
+end
+check('ai_insight: no separate connection argument — CallText warehouse fn is the FIRST arg') do
+  el = Richness.ai_insight(id: 'ai-rev3', prompt: 'x')
+  el['body'] =~ /CallText\("SNOWFLAKE\.CORTEX\.COMPLETE",\s*"[^"]+",\s*"[^"]*"\)/
+end
+check('ai_insight: id required') do
+  begin; Richness.ai_insight(id: '', prompt: 'x'); false
+  rescue ArgumentError; true; end
+end
+check('ai_insight: prompt required') do
+  begin; Richness.ai_insight(id: 'x', prompt: ''); false
+  rescue ArgumentError; true; end
+end
+check('ai_insight: NO-GO surface -> opt-in marker, never a faked summary') do
+  el = Richness.ai_insight(id: 'ai-rev', prompt: 'x', surfaces: Richness::SURFACES.merge(ai_insight: false))
+  el == { 'opt_in' => true, 'id' => 'ai-rev' }
+end
+
+# --- grain_control / trend_dimension ---------------------------------------
+
+check('grain_control: segmented control, Week/Month/Day, default Month') do
+  ctl = Richness.grain_control(id: 'GrainCtl')
+  ctl == {
+    'id' => 'GrainCtl', 'kind' => 'control', 'controlId' => 'GrainCtl-ctl',
+    'name' => 'Grain', 'controlType' => 'segmented', 'selectionMode' => 'single',
+    'value' => 'Month',
+    'source' => { 'kind' => 'manual', 'valueType' => 'text', 'values' => %w[Week Month Day] }
+  }
+end
+check('grain_control: element id and controlId are DISTINCT (Duplicate id 400 fix)') do
+  ctl = Richness.grain_control(id: 'GrainCtl')
+  ctl['id'] != ctl['controlId'] && ctl['id'] == 'GrainCtl' && ctl['controlId'] == 'GrainCtl-ctl'
+end
+check('grain_control: control_id: override is honored and still distinct from id') do
+  ctl = Richness.grain_control(id: 'GrainCtl', control_id: 'GrainCtlHandle')
+  ctl['id'] == 'GrainCtl' && ctl['controlId'] == 'GrainCtlHandle'
+end
+check('grain_control: id required') do
+  begin; Richness.grain_control(id: ''); false
+  rescue ArgumentError; true; end
+end
+check('grain_control: NO-GO surface -> opt-in marker') do
+  ctl = Richness.grain_control(id: 'GrainCtl', surfaces: Richness::SURFACES.merge(dynamic_grain: false))
+  ctl == { 'opt_in' => true, 'id' => 'GrainCtl' }
+end
+
+check('trend_dimension: exact Switch(...) string (verified live pattern)') do
+  Richness.trend_dimension(grain_control_id: 'GrainCtl-ctl', date_ref: '[Src/Date]') ==
+    'Switch([GrainCtl-ctl],"Week",DateTrunc("week",[Src/Date]),' \
+    '"Month",DateTrunc("month",[Src/Date]),DateTrunc("day",[Src/Date]))'
+end
+check('trend_dimension: references grain_control\'s controlId (not its element id)') do
+  ctl = Richness.grain_control(id: 'GrainCtl')
+  dim = Richness.trend_dimension(grain_control_id: ctl['controlId'], date_ref: '[Src/Date]')
+  dim.include?("[#{ctl['controlId']}]") && !dim.include?("[#{ctl['id']}]")
+end
+check('trend_dimension: grain_control_id required') do
+  begin; Richness.trend_dimension(grain_control_id: '', date_ref: '[Src/Date]'); false
+  rescue ArgumentError; true; end
+end
+check('trend_dimension: date_ref required') do
+  begin; Richness.trend_dimension(grain_control_id: 'GrainCtl-ctl', date_ref: ''); false
+  rescue ArgumentError; true; end
+end
+check('trend_dimension: NO-GO surface -> empty string') do
+  Richness.trend_dimension(grain_control_id: 'GrainCtl-ctl', date_ref: '[Src/Date]',
+                            surfaces: Richness::SURFACES.merge(dynamic_grain: false)) == ''
+end
+
+# --- filter_row --------------------------------------------------------------
+
+FILTER_CONTROLS = [
+  { id: 'ctl-region', control_id: 'RegionCtl', name: 'Region', source_element_id: 'src',
+    column_id: 'col-region', filter_targets: [{ element_id: 'detail-tbl', column_id: 'dt-region' }] },
+  { id: 'ctl-category', control_id: 'CategoryCtl', name: 'Category', source_element_id: 'src',
+    column_id: 'col-category', filter_targets: [
+      { element_id: 'detail-tbl', column_id: 'dt-category' },
+      { element_id: 'master-chart', column_id: 'mc-category' }
+    ] }
+].freeze
+
+check('filter_row: emits one list-control element per descriptor, bound to the base') do
+  rows = Richness.filter_row(controls: FILTER_CONTROLS)
+  rows.length == 2 &&
+    rows[0] == {
+      'id' => 'ctl-region', 'kind' => 'control', 'controlId' => 'RegionCtl',
+      'name' => 'Region', 'controlType' => 'list', 'mode' => 'include',
+      'selectionMode' => 'single', 'values' => [],
+      'source' => { 'kind' => 'source', 'source' => { 'kind' => 'table', 'elementId' => 'src' },
+                    'columnId' => 'col-region' },
+      'filters' => [{ 'source' => { 'kind' => 'table', 'elementId' => 'detail-tbl' }, 'columnId' => 'dt-region' }]
+    }
+end
+check('filter_row: a control can filter multiple target elements') do
+  rows = Richness.filter_row(controls: FILTER_CONTROLS)
+  rows[1]['filters'] == [
+    { 'source' => { 'kind' => 'table', 'elementId' => 'detail-tbl' }, 'columnId' => 'dt-category' },
+    { 'source' => { 'kind' => 'table', 'elementId' => 'master-chart' }, 'columnId' => 'mc-category' }
+  ]
+end
+check('filter_row: empty controls list -> empty array') do
+  Richness.filter_row(controls: []) == []
+end
+check('filter_row: NO-GO surface -> empty array') do
+  Richness.filter_row(controls: FILTER_CONTROLS, surfaces: Richness::SURFACES.merge(filter_row: false)) == []
+end
+
+# --- wide_pivot --------------------------------------------------------------
+
+PIVOT_COLUMNS = [
+  { 'id' => 'piv-region', 'name' => 'Region', 'formula' => '[Src/Region]' },
+  { 'id' => 'piv-category', 'name' => 'Category', 'formula' => '[Src/Category]' },
+  { 'id' => 'piv-revenue', 'name' => 'Revenue', 'formula' => 'Sum([Src/Revenue])' },
+  { 'id' => 'piv-orders', 'name' => 'Orders', 'formula' => 'Sum([Src/Orders])' },
+  { 'id' => 'piv-margin', 'name' => 'Margin', 'formula' => 'Avg([Src/Margin])' }
+].freeze
+
+check('wide_pivot: pivot-table with columns, rowsBy, columnsBy:[], values (metric id strings)') do
+  piv = Richness.wide_pivot(id: 'piv-1', source_element_id: 'src',
+                             columns: PIVOT_COLUMNS,
+                             rows_by: [{ 'id' => 'piv-region' }, { 'id' => 'piv-category' }],
+                             values: %w[piv-revenue piv-orders piv-margin])
+  piv == {
+    'id' => 'piv-1', 'kind' => 'pivot-table',
+    'source' => { 'kind' => 'table', 'elementId' => 'src' },
+    'columns' => PIVOT_COLUMNS,
+    'rowsBy' => [{ 'id' => 'piv-region' }, { 'id' => 'piv-category' }],
+    'columnsBy' => [],
+    'values' => %w[piv-revenue piv-orders piv-margin]
+  }
+end
+check('wide_pivot: columns is a non-empty array (Invalid-kind 400 fix)') do
+  piv = Richness.wide_pivot(id: 'piv-1', source_element_id: 'src', columns: PIVOT_COLUMNS,
+                             rows_by: [{ 'id' => 'piv-region' }, { 'id' => 'piv-category' }],
+                             values: %w[piv-revenue piv-orders piv-margin])
+  piv['columns'].is_a?(Array) && !piv['columns'].empty?
+end
+check('wide_pivot: columnsBy is always [] (wide, not crosstab)') do
+  Richness.wide_pivot(id: 'piv-2', source_element_id: 'src', columns: [{ 'id' => 'c1', 'formula' => '[Src/C1]' }],
+                       rows_by: [{ 'id' => 'c1' }], values: ['c2'])['columnsBy'] == []
+end
+check('wide_pivot: id required') do
+  begin
+    Richness.wide_pivot(id: '', source_element_id: 'src', columns: PIVOT_COLUMNS, rows_by: [], values: [])
+    false
+  rescue ArgumentError; true; end
+end
+check('wide_pivot: source_element_id required') do
+  begin
+    Richness.wide_pivot(id: 'p', source_element_id: '', columns: PIVOT_COLUMNS, rows_by: [], values: [])
+    false
+  rescue ArgumentError; true; end
+end
+check('wide_pivot: columns required (nil 400 fix)') do
+  begin; Richness.wide_pivot(id: 'p', source_element_id: 'src', columns: nil, rows_by: [], values: []); false
+  rescue ArgumentError; true; end
+end
+check('wide_pivot: columns required (empty array 400 fix)') do
+  begin; Richness.wide_pivot(id: 'p', source_element_id: 'src', columns: [], rows_by: [], values: []); false
+  rescue ArgumentError; true; end
+end
+check('wide_pivot: NO-GO surface -> opt-in marker') do
+  piv = Richness.wide_pivot(id: 'piv-1', source_element_id: 'src', columns: PIVOT_COLUMNS, rows_by: [], values: [],
+                             surfaces: Richness::SURFACES.merge(wide_pivot: false))
+  piv == { 'opt_in' => true, 'id' => 'piv-1' }
+end
+
+# --- golden ------------------------------------------------------------------
+
+golden = JSON.parse(File.read(File.join(__dir__, 'testdata', 'richness_golden.json')))
+check('helpers match richness_golden.json (sorted-key identical)') do
+  actual = {
+    'ai_insight' => Richness.ai_insight(id: 'ai-rev', prompt: 'Summarize revenue trends for the period.'),
+    'ai_insight_custom_model' => Richness.ai_insight(id: 'ai-rev2', model: 'mistral-large2',
+                                                      prompt: 'Say one nice thing about the data.'),
+    'grain_control' => Richness.grain_control(id: 'GrainCtl'),
+    'trend_dimension' => Richness.trend_dimension(grain_control_id: 'GrainCtl-ctl', date_ref: '[Src/Date]'),
+    'filter_row' => Richness.filter_row(controls: FILTER_CONTROLS),
+    'wide_pivot' => Richness.wide_pivot(id: 'piv-1', source_element_id: 'src',
+                                         columns: PIVOT_COLUMNS,
+                                         rows_by: [{ 'id' => 'piv-region' }, { 'id' => 'piv-category' }],
+                                         values: %w[piv-revenue piv-orders piv-margin])
+  }
+  JSON.generate(sort_deep(actual)) == JSON.generate(sort_deep(golden))
+end
+
+exit($failures.zero? ? 0 : 1)

--- a/sigma-workbooks/scripts/lib/test_styling.rb
+++ b/sigma-workbooks/scripts/lib/test_styling.rb
@@ -1,0 +1,179 @@
+# frozen_string_literal: true
+# test_styling.rb — run directly: ruby scripts/lib/test_styling.rb (from sigma-workbooks/)
+require 'json'
+require_relative 'styling'
+require_relative 'composition'
+$failures = 0
+def check(desc); ok = yield; puts(ok ? "[ok] #{desc}" : "[FAIL] #{desc}"); $failures += 1 unless ok; end
+
+# Deep-sort hashes/arrays so comparison to the golden file is key-order-independent.
+def sort_deep(o)
+  case o
+  when Hash then o.keys.sort.each_with_object({}) { |k, h| h[k] = sort_deep(o[k]) }
+  when Array then o.map { |e| sort_deep(e) }
+  else o
+  end
+end
+
+check('theme() (no args) returns the default palette') do
+  Styling.theme == Styling::DEFAULT_THEME
+end
+check('theme(accent: nil) returns the default palette') do
+  Styling.theme(accent: nil) == Styling::DEFAULT_THEME
+end
+check("theme(accent: '') returns the default palette") do
+  Styling.theme(accent: '') == Styling::DEFAULT_THEME
+end
+check('DEFAULT_THEME categorical slot 0 + accent are the base blue') do
+  Styling::DEFAULT_THEME[:categorical].first == '#2563EB' && Styling::DEFAULT_THEME[:accent] == '#2563EB'
+end
+check("theme(accent: '#FF6600') tints categorical slot 0") do
+  Styling.theme(accent: '#FF6600')[:categorical].first == '#FF6600'
+end
+check("theme(accent: '#FF6600') tints :accent too") do
+  Styling.theme(accent: '#FF6600')[:accent] == '#FF6600'
+end
+check('accent override leaves categorical slots 1..7 unchanged') do
+  Styling.theme(accent: '#FF6600')[:categorical][1..-1] == Styling::DEFAULT_THEME[:categorical][1..-1]
+end
+check('accent override does not mutate DEFAULT_THEME (deep copy)') do
+  Styling.theme(accent: '#FF6600')
+  Styling::DEFAULT_THEME[:categorical].first == '#2563EB' && Styling::DEFAULT_THEME[:accent] == '#2563EB'
+end
+check('card shape: borderRadius/borderColor/borderWidth, no cornerRadius, no padding') do
+  card = Styling::DEFAULT_THEME[:card]
+  card['borderRadius'] == 'round' && card['borderColor'] == '#E2E8F0' && card['borderWidth'] == 1 &&
+    !card.key?('cornerRadius') && !card.key?('padding')
+end
+check('header shape: backgroundColor + borderRadius only') do
+  header = Styling::DEFAULT_THEME[:header]
+  header == { 'backgroundColor' => '#0F172A', 'borderRadius' => 'round' }
+end
+
+# Composition.bands — role -> [r0, r1) band descriptors.
+check('Composition.bands: kpi + hero (exec) matches the brief example') do
+  out = Composition.bands([{ id: 'k', role: :kpi }, { id: 'h', role: :hero }], :exec)
+  out == [
+    { role: :kpi, ids: ['k'], r0: 1, r1: 7 },
+    { role: :hero, ids: ['h'], r0: 7, r1: 19 }
+  ]
+end
+check('Composition.bands: master_detail with control row') do
+  out = Composition.bands([
+    { id: 'ctl', role: :control },
+    { id: 'master-chart', role: :master },
+    { id: 'detail-tbl', role: :detail }
+  ], :master_detail)
+  out == [
+    { role: :control, ids: ['ctl'], r0: 1, r1: 3 },
+    { role: :master_detail, ids: %w[master-chart detail-tbl], r0: 3, r1: 17 }
+  ]
+end
+check('Composition.bands: unknown pattern raises') do
+  begin; Composition.bands([{ id: 'k', role: :kpi }], :nope); false
+  rescue ArgumentError; true; end
+end
+check('Composition.bands: role not used by pattern raises') do
+  begin; Composition.bands([{ id: 'm1', role: :master }], :exec); false
+  rescue ArgumentError; true; end
+end
+check('Composition.bands: page_cols defaults to 24') do
+  out = Composition.bands([{ id: 'h', role: :hero }], :exec)
+  out == [{ role: :hero, ids: ['h'], r0: 1, r1: 13 }]
+end
+
+# --- chart_color, kpi_accent, format_for, header, section_card ---
+
+check('SURFACES: all 6 verified surfaces are GO') do
+  expected = %i[categorical_scheme chart_color_by container_style format_string kpi_name_color typography]
+  Styling::SURFACES.keys.sort == expected.sort && Styling::SURFACES.values.all? { |v| v == true }
+end
+
+check('chart_color(theme): single-series color:{by:"single",value:} (categorical slot 0)') do
+  Styling.chart_color(Styling::DEFAULT_THEME) == { 'color' => { 'by' => 'single', 'value' => '#2563EB' } }
+end
+check('chart_color(theme, categorical: true): workbook-level categoricalScheme patch') do
+  Styling.chart_color(Styling::DEFAULT_THEME, categorical: true) ==
+    { 'themeOverrides' => { 'categoricalScheme' => Styling::DEFAULT_THEME[:categorical] } }
+end
+check('chart_color: NO-GO chart_color_by -> {}') do
+  Styling.chart_color(Styling::DEFAULT_THEME, surfaces: Styling::SURFACES.merge(chart_color_by: false)) == {}
+end
+check('chart_color: NO-GO categorical_scheme -> {}') do
+  Styling.chart_color(Styling::DEFAULT_THEME, categorical: true,
+                       surfaces: Styling::SURFACES.merge(categorical_scheme: false)) == {}
+end
+
+check('kpi_accent(theme) merges into a name object') do
+  name = { 'text' => 'Revenue' }.merge(Styling.kpi_accent(Styling::DEFAULT_THEME))
+  name == { 'text' => 'Revenue', 'color' => '#2563EB' }
+end
+check('kpi_accent: NO-GO kpi_name_color -> {}') do
+  Styling.kpi_accent(Styling::DEFAULT_THEME, surfaces: Styling::SURFACES.merge(kpi_name_color: false)) == {}
+end
+
+check('format_for(:currency/:integer/:percent/:decimal) — d3-format, not Excel') do
+  Styling.format_for(:currency) == { 'kind' => 'number', 'formatString' => '$,.0f' } &&
+    Styling.format_for(:integer) == { 'kind' => 'number', 'formatString' => ',.0f' } &&
+    Styling.format_for(:percent) == { 'kind' => 'number', 'formatString' => '.1%' } &&
+    Styling.format_for(:decimal) == { 'kind' => 'number', 'formatString' => ',.2f' }
+end
+check('format_for: unknown semantic raises') do
+  begin
+    Styling.format_for(:bogus)
+    false
+  rescue ArgumentError
+    true
+  end
+end
+check('format_for: NO-GO format_string -> {}') do
+  Styling.format_for(:currency, surfaces: Styling::SURFACES.merge(format_string: false)) == {}
+end
+
+check('header: container-style GO emits a container + title text element and a rows-1/3 GridContainer') do
+  h = Styling.header(id: 'hdr', title: 'Dashboard', theme: Styling::DEFAULT_THEME)
+  h[:element].length == 2 &&
+    h[:element][0] == { 'id' => 'hdr-bg', 'kind' => 'container', 'style' => Styling::DEFAULT_THEME[:header] } &&
+    h[:element][1]['kind'] == 'text' &&
+    h[:layout].include?('<GridContainer') && h[:layout].include?('gridRow="1 / 3"') &&
+    h[:layout].include?('elementId="hdr-title"')
+end
+check('header: NO-GO container_style emits a bare text element, no container') do
+  h = Styling.header(id: 'hdr', title: 'Dashboard', theme: Styling::DEFAULT_THEME,
+                      surfaces: Styling::SURFACES.merge(container_style: false))
+  h[:element].length == 1 && h[:element][0]['kind'] == 'text' && !h[:layout].include?('GridContainer')
+end
+
+check('section_card: container-style GO wraps band ids in a themed card GridContainer') do
+  band = { role: :kpi, ids: %w[k1 k2 k3], r0: 7, r1: 13 }
+  sc = Styling.section_card(id: 'card-1', band: band, theme: Styling::DEFAULT_THEME)
+  sc[:element] == { 'id' => 'card-1', 'kind' => 'container', 'style' => Styling::DEFAULT_THEME[:card] } &&
+    sc[:wrap].include?('<GridContainer elementId="card-1"') && sc[:wrap].include?('gridRow="7 / 13"') &&
+    sc[:wrap].scan('<LayoutElement').length == 3
+end
+check('section_card: NO-GO container_style returns bare band render, no container element') do
+  band = { role: :kpi, ids: %w[k1 k2], r0: 1, r1: 7 }
+  sc = Styling.section_card(id: 'card-1', band: band, theme: Styling::DEFAULT_THEME,
+                             surfaces: Styling::SURFACES.merge(container_style: false))
+  sc[:element].nil? && !sc[:wrap].include?('GridContainer') && sc[:wrap].scan('<LayoutElement').length == 2
+end
+
+golden = JSON.parse(File.read(File.join(__dir__, 'testdata', 'styling_golden.json')))
+check('helpers match styling_golden.json (sorted-key identical)') do
+  theme = Styling::DEFAULT_THEME
+  band = { role: :kpi, ids: %w[k1 k2 k3], r0: 7, r1: 13 }
+  actual = {
+    'chart_color_single' => Styling.chart_color(theme),
+    'chart_color_categorical' => Styling.chart_color(theme, categorical: true),
+    'kpi_accent' => Styling.kpi_accent(theme),
+    'format_for_currency' => Styling.format_for(:currency),
+    'format_for_integer' => Styling.format_for(:integer),
+    'format_for_percent' => Styling.format_for(:percent),
+    'format_for_decimal' => Styling.format_for(:decimal),
+    'header' => Styling.header(id: 'hdr', title: 'Dashboard', theme: theme),
+    'section_card' => Styling.section_card(id: 'card-1', band: band, theme: theme)
+  }
+  JSON.generate(sort_deep(actual)) == JSON.generate(sort_deep(golden))
+end
+
+exit($failures.zero? ? 0 : 1)

--- a/sigma-workbooks/scripts/lib/testdata/composition_exec_golden.txt
+++ b/sigma-workbooks/scripts/lib/testdata/composition_exec_golden.txt
@@ -1,0 +1,6 @@
+  <LayoutElement elementId="kpi1" gridColumn="1 / 7" gridRow="1 / 7"/>
+  <LayoutElement elementId="kpi2" gridColumn="7 / 13" gridRow="1 / 7"/>
+  <LayoutElement elementId="kpi3" gridColumn="13 / 19" gridRow="1 / 7"/>
+  <LayoutElement elementId="kpi4" gridColumn="19 / 25" gridRow="1 / 7"/>
+  <LayoutElement elementId="hero" gridColumn="1 / 25" gridRow="7 / 19"/>
+  <LayoutElement elementId="tbl" gridColumn="1 / 25" gridRow="19 / 28"/>

--- a/sigma-workbooks/scripts/lib/testdata/composition_master_detail_golden.txt
+++ b/sigma-workbooks/scripts/lib/testdata/composition_master_detail_golden.txt
@@ -1,0 +1,3 @@
+  <LayoutElement elementId="ctl" gridColumn="1 / 25" gridRow="1 / 3"/>
+  <LayoutElement elementId="master-chart" gridColumn="1 / 13" gridRow="3 / 17"/>
+  <LayoutElement elementId="detail-tbl" gridColumn="13 / 25" gridRow="3 / 17"/>

--- a/sigma-workbooks/scripts/lib/testdata/composition_overview_golden.txt
+++ b/sigma-workbooks/scripts/lib/testdata/composition_overview_golden.txt
@@ -1,0 +1,11 @@
+  <LayoutElement elementId="hdr" gridColumn="1 / 25" gridRow="1 / 4"/>
+  <LayoutElement elementId="ctl" gridColumn="1 / 25" gridRow="4 / 6"/>
+  <LayoutElement elementId="kpi1" gridColumn="1 / 13" gridRow="6 / 14"/>
+  <LayoutElement elementId="kpi2" gridColumn="13 / 25" gridRow="6 / 14"/>
+  <LayoutElement elementId="rate1" gridColumn="1 / 13" gridRow="14 / 22"/>
+  <LayoutElement elementId="rate2" gridColumn="13 / 25" gridRow="14 / 22"/>
+  <LayoutElement elementId="trend1" gridColumn="1 / 25" gridRow="22 / 34"/>
+  <LayoutElement elementId="pivot1" gridColumn="1 / 25" gridRow="34 / 48"/>
+  <LayoutElement elementId="base1" gridColumn="1 / 9" gridRow="48 / 57"/>
+  <LayoutElement elementId="base2" gridColumn="9 / 17" gridRow="48 / 57"/>
+  <LayoutElement elementId="base3" gridColumn="17 / 25" gridRow="48 / 57"/>

--- a/sigma-workbooks/scripts/lib/testdata/kpi_card_golden.json
+++ b/sigma-workbooks/scripts/lib/testdata/kpi_card_golden.json
@@ -1,0 +1,28 @@
+{
+  "columns": [
+    {
+      "id": "rev_cur",
+      "format": { "kind": "number", "formatString": "$,.0f" }
+    },
+    { "id": "rev_prior" }
+  ],
+  "comparison": {
+    "colorBad": "#cf222e",
+    "colorGood": "#1a7f37",
+    "display": "delta"
+  },
+  "comparisonColumn": { "columnId": "rev_prior" },
+  "id": "kpi-rev",
+  "kind": "kpi-chart",
+  "name": {
+    "color": "#FFFFFF",
+    "text": "Revenue"
+  },
+  "source": {
+    "elementId": "tbl-1",
+    "kind": "table"
+  },
+  "value": {
+    "columnId": "rev_cur"
+  }
+}

--- a/sigma-workbooks/scripts/lib/testdata/kpi_card_value_style_golden.json
+++ b/sigma-workbooks/scripts/lib/testdata/kpi_card_value_style_golden.json
@@ -1,0 +1,26 @@
+{
+  "columns": [
+    { "id": "rev" },
+    { "id": "prior" }
+  ],
+  "comparison": {
+    "colorBad": "#cf222e",
+    "colorGood": "#1a7f37",
+    "display": "delta"
+  },
+  "comparisonColumn": { "columnId": "prior" },
+  "id": "k",
+  "kind": "kpi-chart",
+  "name": {
+    "text": "Rev"
+  },
+  "source": {
+    "elementId": "t",
+    "kind": "table"
+  },
+  "value": {
+    "columnId": "rev",
+    "color": "#FDE047",
+    "fontSize": 44
+  }
+}

--- a/sigma-workbooks/scripts/lib/testdata/richness_golden.json
+++ b/sigma-workbooks/scripts/lib/testdata/richness_golden.json
@@ -1,0 +1,149 @@
+{
+  "ai_insight": {
+    "body": "{{ Replace(CallText(\"SNOWFLAKE.CORTEX.COMPLETE\", \"llama3.1-8b\", \"Summarize revenue trends for the period.\") , '\"', \"\") }}",
+    "id": "ai-rev",
+    "kind": "text"
+  },
+  "ai_insight_custom_model": {
+    "body": "{{ Replace(CallText(\"SNOWFLAKE.CORTEX.COMPLETE\", \"mistral-large2\", \"Say one nice thing about the data.\") , '\"', \"\") }}",
+    "id": "ai-rev2",
+    "kind": "text"
+  },
+  "filter_row": [
+    {
+      "controlId": "RegionCtl",
+      "controlType": "list",
+      "filters": [
+        {
+          "columnId": "dt-region",
+          "source": {
+            "elementId": "detail-tbl",
+            "kind": "table"
+          }
+        }
+      ],
+      "id": "ctl-region",
+      "kind": "control",
+      "mode": "include",
+      "name": "Region",
+      "selectionMode": "single",
+      "source": {
+        "columnId": "col-region",
+        "kind": "source",
+        "source": {
+          "elementId": "src",
+          "kind": "table"
+        }
+      },
+      "values": [
+
+      ]
+    },
+    {
+      "controlId": "CategoryCtl",
+      "controlType": "list",
+      "filters": [
+        {
+          "columnId": "dt-category",
+          "source": {
+            "elementId": "detail-tbl",
+            "kind": "table"
+          }
+        },
+        {
+          "columnId": "mc-category",
+          "source": {
+            "elementId": "master-chart",
+            "kind": "table"
+          }
+        }
+      ],
+      "id": "ctl-category",
+      "kind": "control",
+      "mode": "include",
+      "name": "Category",
+      "selectionMode": "single",
+      "source": {
+        "columnId": "col-category",
+        "kind": "source",
+        "source": {
+          "elementId": "src",
+          "kind": "table"
+        }
+      },
+      "values": [
+
+      ]
+    }
+  ],
+  "grain_control": {
+    "controlId": "GrainCtl-ctl",
+    "controlType": "segmented",
+    "id": "GrainCtl",
+    "kind": "control",
+    "name": "Grain",
+    "selectionMode": "single",
+    "source": {
+      "kind": "manual",
+      "valueType": "text",
+      "values": [
+        "Week",
+        "Month",
+        "Day"
+      ]
+    },
+    "value": "Month"
+  },
+  "trend_dimension": "Switch([GrainCtl-ctl],\"Week\",DateTrunc(\"week\",[Src/Date]),\"Month\",DateTrunc(\"month\",[Src/Date]),DateTrunc(\"day\",[Src/Date]))",
+  "wide_pivot": {
+    "columns": [
+      {
+        "formula": "[Src/Region]",
+        "id": "piv-region",
+        "name": "Region"
+      },
+      {
+        "formula": "[Src/Category]",
+        "id": "piv-category",
+        "name": "Category"
+      },
+      {
+        "formula": "Sum([Src/Revenue])",
+        "id": "piv-revenue",
+        "name": "Revenue"
+      },
+      {
+        "formula": "Sum([Src/Orders])",
+        "id": "piv-orders",
+        "name": "Orders"
+      },
+      {
+        "formula": "Avg([Src/Margin])",
+        "id": "piv-margin",
+        "name": "Margin"
+      }
+    ],
+    "columnsBy": [
+
+    ],
+    "id": "piv-1",
+    "kind": "pivot-table",
+    "rowsBy": [
+      {
+        "id": "piv-region"
+      },
+      {
+        "id": "piv-category"
+      }
+    ],
+    "source": {
+      "elementId": "src",
+      "kind": "table"
+    },
+    "values": [
+      "piv-revenue",
+      "piv-orders",
+      "piv-margin"
+    ]
+  }
+}

--- a/sigma-workbooks/scripts/lib/testdata/styling_golden.json
+++ b/sigma-workbooks/scripts/lib/testdata/styling_golden.json
@@ -1,0 +1,72 @@
+{
+  "chart_color_categorical": {
+    "themeOverrides": {
+      "categoricalScheme": [
+        "#2563EB",
+        "#0EA5E9",
+        "#14B8A6",
+        "#F59E0B",
+        "#8B5CF6",
+        "#EF4444",
+        "#10B981",
+        "#64748B"
+      ]
+    }
+  },
+  "chart_color_single": {
+    "color": {
+      "by": "single",
+      "value": "#2563EB"
+    }
+  },
+  "format_for_currency": {
+    "formatString": "$,.0f",
+    "kind": "number"
+  },
+  "format_for_decimal": {
+    "formatString": ",.2f",
+    "kind": "number"
+  },
+  "format_for_integer": {
+    "formatString": ",.0f",
+    "kind": "number"
+  },
+  "format_for_percent": {
+    "formatString": ".1%",
+    "kind": "number"
+  },
+  "header": {
+    "element": [
+      {
+        "id": "hdr-bg",
+        "kind": "container",
+        "style": {
+          "backgroundColor": "#0F172A",
+          "borderRadius": "round"
+        }
+      },
+      {
+        "body": "# <span style=\"color: #FFFFFF\">Dashboard</span>",
+        "id": "hdr-title",
+        "kind": "text"
+      }
+    ],
+    "layout": "<GridContainer elementId=\"hdr-bg\" type=\"grid\" gridColumn=\"1 / 25\" gridRow=\"1 / 3\" gridTemplateColumns=\"repeat(24, 1fr)\" gridTemplateRows=\"auto\">\n  <LayoutElement elementId=\"hdr-title\" gridColumn=\"1 / 25\" gridRow=\"1 / 3\"/>\n</GridContainer>"
+  },
+  "kpi_accent": {
+    "color": "#2563EB"
+  },
+  "section_card": {
+    "element": {
+      "id": "card-1",
+      "kind": "container",
+      "style": {
+        "backgroundColor": "#FFFFFF",
+        "borderColor": "#E2E8F0",
+        "borderRadius": "round",
+        "borderWidth": 1
+      }
+    },
+    "wrap": "<GridContainer elementId=\"card-1\" type=\"grid\" gridColumn=\"1 / 25\" gridRow=\"7 / 13\" gridTemplateColumns=\"repeat(24, 1fr)\" gridTemplateRows=\"auto\">\n  <LayoutElement elementId=\"k1\" gridColumn=\"1 / 9\" gridRow=\"1 / 7\"/>\n  <LayoutElement elementId=\"k2\" gridColumn=\"9 / 17\" gridRow=\"1 / 7\"/>\n  <LayoutElement elementId=\"k3\" gridColumn=\"17 / 25\" gridRow=\"1 / 7\"/>\n</GridContainer>"
+  }
+}


### PR DESCRIPTION
## Summary
- Ports the migration repo's WS3 composition/styling/richness enhancement into this repo's Ruby-only `sigma-workbooks` skill (Python twins dropped — this repo is Ruby-only).
- Adds `sigma-workbooks/scripts/lib/{composition,styling,richness,kpi_card,composition_lint}.rb` — the exec/master-detail/overview layout engine, the `Styling` module (theme, chart color, KPI accent, number format, header/card containers), the four optional Richness building blocks (AI-insight callout, dynamic grain control, filter row, wide pivot), the comparative KPI-card builder, and a layout-XML linter — each paired with a mirrored `test_*.rb` and golden testdata (`scripts/lib/testdata/`).
- Merges the corresponding doc updates into the *existing* `composition.md` / `styling.md` / `layout.md` (not a rewrite-from-scratch): the exec/master-detail/overview composition patterns, the "Richness — optional building blocks" section, the `Styling` module doc section, two stale "not designable via spec" claims resolved (KPI title color, per-element title font size), and the `layout` workbook-top-level correction.
- Regenerated the 4 `generated/` variants via `ruby scripts/sync-targets.rb sigma-workbooks` (no diff — they derive from `SKILL.md`, which is unchanged).

## Honesty/optionality carried over
- In-card KPI sparkline is documented **NO-GO** (not currently spec-authorable).
- The AI-insight (CallText/Cortex) helper is opt-in and never fabricates text — it renders only where the target org has Cortex configured, or emits an opt-in marker.
- No branding, no logos, no house style forced onto every workbook.
- No real customer/personal/company names anywhere in the new or changed files (grep-verified).

## Test plan
- [x] `ruby scripts/lib/test_composition.rb` — 20/20 pass
- [x] `ruby scripts/lib/test_styling.rb` — 29/29 pass
- [x] `ruby scripts/lib/test_richness.rb` — 29/29 pass
- [x] `ruby scripts/lib/test_kpi_card.rb` — 7/7 pass
- [x] `ruby scripts/lib/test_composition_lint.rb` — 6/6 pass
- [x] `ruby scripts/sync-targets.rb sigma-workbooks` — regenerates clean, no unexpected diff

**Do not merge** — opened for review.