### PR TITLE
feat(ws4): Sigma agent + gradient header/cards + actions/input-tables

### DIFF
--- a/sigma-workbooks/SKILL.md
+++ b/sigma-workbooks/SKILL.md
@@ -224,10 +224,11 @@ The reference is feature-sliced — don't read every file up-front. The index ha
 | `reference/specification/charts.md` | Chart, graph, visualization, line / bar / column / stacked / grouped / combo / donut / pie / scatter / share-of / breakdown. Cartesian axes, color channel, trellis, trendlines, reference marks. |
 | `reference/specification/maps.md` | Map visualizations — `geography-map` (GeoJSON shapes), `point-map` (lat/long bubbles), `region-map` (states / counties / countries). |
 | `reference/specification/kpis.md` | KPI, stat, big number, single value, metric card — including layout / value styling, the comparison Δ badge (`comparisonColumn` + `comparison:{display:"delta"}` — spec-authorable and readback-stable; the house default), and the trend/sparkline block (still UI-bound). |
-| `reference/specification/controls.md` | Filter, dropdown, picker, multi-select, date range, date picker, text filter, number range, slider, segmented, hierarchy. |
+| `reference/specification/controls.md` | Filter, dropdown, picker, multi-select, date range, date picker, text filter, number range, slider, segmented, hierarchy. Also the entry (write) text control shape used with buttons/actions. |
 | `reference/specification/content-elements.md` | The non-data elements — `text` (Markdown + inline styling), `image`, `divider`, `embed` (external URLs). Titles, callouts, logos, rules, embedded content. |
 | `reference/specification/input-tables.md` | Operational supplement for `input-table` (spec shape lives in `tables.md`): write-connection requirement, the publish gate, reading data back via warehouse views, element endpoints for auditing, and migration patterns (Excel/planning models). |
-| `reference/specification/styling.md` | **Load when building a dashboard from scratch.** Design recipe library — vetted color palette, hero header strip, KPI card row, section headers, divider rhythm, categorical chart colors. Turns a default-arrange workbook into a designed-looking one without UI editing. |
+| `reference/specification/styling.md` | **Load when building a dashboard from scratch.** Design recipe library — vetted color palette, hero header strip, gradient header/KPI cards + composite sparkline, KPI card row, section headers, divider rhythm, categorical chart colors. Turns a default-arrange workbook into a designed-looking one without UI editing. |
+| `reference/specification/agents.md` | Workbook AI agent, chat with your data, agent, chatbot, AI assistant. The workbook-top-level `agents:[]` array + page-level `chat` element; read-only analyst vs. write/action agent; org-feature gate + graceful degrade. |
 
 ### Sources
 
@@ -253,6 +254,7 @@ The reference is feature-sliced — don't read every file up-front. The index ha
 |------|--------------|
 | `reference/workflows/discover.md` | Finding connections, tables, and column names. Load before composing a new spec. |
 | `reference/workflows/composition.md` | Open-ended design decisions — calibrating workbook complexity to the request, when to ask the user, what to ask, surfacing structural choices in the final summary, and a few safe defaults (hidden source pages, ranked-table sort direction). Load before drafting anything when the prompt leaves significant design choices unmade. |
+| `reference/workflows/actions.md` | Buttons, write-back, insert-rows/clear-control/set-control-value effects, modals (open/close-overlay), the append-only-log pattern, and the masked-error catalog for input-table/control element kinds. Load when the user wants a button, a "log/save/submit" action, or a write-back workflow. |
 | `reference/workflows/crud.md` | POST / GET / PUT against the workbook spec endpoints. Load when creating, retrieving, or updating a workbook. |
 | `reference/workflows/validate.md` | Pre-submit + post-create validation. Load before any POST or PUT. |
 | `reference/workflows/from-image.md` | The user supplied a target image (screenshot, mockup, BI-tool export) to reproduce. Load *before* discovery — it adds explicit observation and validation steps. |

--- a/sigma-workbooks/reference/specification/agents.md
+++ b/sigma-workbooks/reference/specification/agents.md
@@ -1,0 +1,148 @@
+# Agents & chat — the workbook AI agent
+
+A Sigma workbook can carry a **spec-authorable AI agent** that end users chat with
+inside the workbook. It is easy to miss: it is **not a page element** — it's a
+**workbook-top-level `agents:[]` array**, a sibling of `pages`/`layout`/`themeName`.
+An element-kind scan of `pages[].elements[]` alone will never find it and can wrongly
+conclude "not authorable." The agent is *surfaced* on a page via a small `chat`
+element that just references the agent's id.
+
+> **Not in the compiled/public OpenAPI as of this writing.** Unlike most of this
+> skill's surface, `agents[]` / `dataSources` / `tools` / the `chat` element kind
+> do not appear in the compiled OpenAPI asset this skill points to (see
+> `SKILL.md`'s *Sources of truth*) — this shape was recovered by live POST +
+> GET-readback + render probing on a test org, not read off a schema. Treat field
+> names as verified-by-example, not exhaustive; if you need a field not listed
+> here, confirm it against a live workbook readback before relying on it.
+
+## Shape
+
+```yaml
+name: My Workbook
+schemaVersion: 1
+folderId: <folderId>
+agents:
+  - id: ag-analyst
+    name: Analyst
+    instructions: >-
+      You are an analyst for this dataset. Answer questions about revenue,
+      orders, and trends over time. Be concise and quantitative; cite the
+      numbers you used.
+    dataSources:
+      - kind: table
+        elementId: src          # an element id already in this workbook's pages
+pages:
+  - id: pg
+    name: Overview
+    elements:
+      - id: src
+        kind: table
+        # ...
+      - id: chat
+        kind: chat
+        agentId: ag-analyst     # the AGENT's `id` above, not an element id
+```
+
+| Field (agent entry) | Required | Notes |
+|---|---|---|
+| `id` | yes | The agent's handle — referenced by `chat.agentId`, not an element id. |
+| `name` | yes | Display name shown in the chat UI. |
+| `instructions` | yes | System-prompt-style guidance: role, scope, tone. |
+| `dataSources` | yes | Array of `{ kind: table, elementId: <id> }` — one entry per element (table/pivot/etc.) the agent may query. Maps 1:1 to the elements it can see; it cannot see elements not listed here. |
+| `tools` | — | **Omit entirely for a read-only analyst** (see below). Present only on a write/action agent. |
+
+The `chat` page element is minimal: `{ id, kind: "chat", agentId }` — no other
+fields observed. Lay it out like any other element (`gridColumn`/`gridRow` via
+`<LayoutElement>`), typically in a sidebar rail next to the dashboard body.
+
+## Read-only analyst vs. write/action agent
+
+**Read-only analyst — the common case.** The agent entry **omits the `tools` key
+entirely** — not `tools: []`. An empty-but-present `tools` array is a different
+(untested) shape; the verified read-only shape is the key's total absence. It can
+only read the elements named in `dataSources` and answer questions about them.
+
+**Write/action agent — adds `tools`.** Each tool gives the agent an action it can
+invoke (function-calling style), described to the agent via `name`/`description`
+so it knows when to call it:
+
+```yaml
+agents:
+  - id: ag-planner
+    name: Planner
+    instructions: You help log review notes against this dataset.
+    dataSources:
+      - kind: table
+        elementId: src
+    tools:
+      - toolId: log-note
+        kind: action
+        name: Log a review note
+        description: >-
+          Call this to record a review note from the conversation. Pass the
+          note text as the `note` input.
+        steps:
+          - kind: effect
+            effect: insert-rows
+            table: annotations          # an input-table element id (see actions.md)
+            values:
+              an-note:
+                type: agent-input
+                inputName: note         # the agent supplies this at call time
+```
+
+`value: { type: "agent-input", inputName }` is the tool-call analog of the
+`type: "control"` / `type: "constant"` value shapes an `insert-rows` effect takes
+from a button (see `reference/workflows/actions.md`) — instead of pulling from a
+control's current value or a hard-coded constant, the value comes from an argument
+the agent fills in when it decides to call the tool, keyed by `inputName`.
+
+> **Scope note:** the write/action agent shape above documents a live-verified
+> *pattern* — it is not independently exercised end-to-end in this pass (no
+> automated test drives an agent into actually invoking a tool).
+> `Richness.agent`'s `tools:` parameter passes an already-shaped array through
+> **verbatim** (never reshapes it) for exactly this reason: confirm any non-trivial
+> tool/step shape against a live POST + readback before shipping it, same discipline
+> as any other agent-input shape in this doc.
+
+## Org-feature gate + graceful degrade
+
+Sigma's AI-agent feature is an **org-level toggle**. On an org where it's off,
+posting `agents:[]` + a `chat` element either renders nothing useful or fails —
+there's no reliable single error signature to detect this from the spec alone.
+**Don't gate on trial-and-error in a shared build.** The safe pattern:
+
+1. If you know (from asking the user, or a prior probe on that org) that AI agents
+   are enabled, use `agents[]` + `chat` as above.
+2. If you don't know, or you know they're **off**, degrade to a **static text
+   element** with a short list of sample prompts instead of a live chat — e.g.:
+
+   ```yaml
+   - id: chat-fallback
+     kind: text
+     body: |
+       **Ask about this data** (AI agents aren't enabled on this org)
+
+       Try asking your Sigma admin to enable workbook AI agents, then re-add a
+       live chat panel here. Sample questions this dataset can answer:
+       - "What was revenue last month vs. the month before?"
+       - "Which region had the most orders?"
+   ```
+
+Never POST a `chat` element as a cosmetic stand-in when you haven't confirmed the
+org supports it — that's the "faked surface" this skill's docs never do. The
+fallback text element is the honest alternative, not a workaround to make the
+gated feature look implemented.
+
+## Cross-links
+
+- `scripts/lib/richness.rb` — `Richness.agent(id:, name:, instructions:,
+  data_source_ids:, tools: [])` builds the `agents[]` entry (`data_source_ids`
+  maps to `dataSources`; empty `tools:` is omitted from the emitted Hash,
+  matching the read-only shape above). `Richness.chat(id:, agent_id:)` builds
+  the page element. Both are gated behind `Richness::SURFACES[:agent]`; a
+  NO-GO flip returns `{opt_in: true, id:}` rather than emitting an unverified
+  shape.
+- `reference/workflows/actions.md` — the `insert-rows`/`clear-control`/
+  `set-control-value` effect shapes a write-agent's tool `steps[]` reuses, and
+  the append-only-log input-table pattern a logging tool typically targets.

--- a/sigma-workbooks/reference/specification/controls.md
+++ b/sigma-workbooks/reference/specification/controls.md
@@ -170,6 +170,40 @@ filters:
 
 The text control carries the match `mode` and the search string as flat top-level fields. `mode` values include `equals`, `does-not-equal`, `contains`, `does-not-contain`, `starts-with`, `ends-with`, `like`, `matches-regexp`, and their negations.
 
+### Entry (write) text controls — 4 fields are mandatory
+
+The `text`/`text-area` shape above is for **filtering** a downstream column. A
+`text`/`text-area` control used the other way — capturing free-typed input for
+a formula or an action effect's `values` (e.g. a "review note" field feeding an
+`insert-rows` effect, see `reference/workflows/actions.md`'s append-only-log
+pattern) — needs **four additional flat fields** or the element **masked-fails**
+as the opaque `Invalid kind: control`, which reads like the control kind itself
+is broken:
+
+```yaml
+kind: control
+id: note-ctl
+controlId: NoteCtl
+name: Add a review note
+controlType: text-area          # or: text
+mode: equals
+case: insensitive
+includeNulls: when-no-value-is-selected
+showOperators: false
+```
+
+| Field | Value (verified) | Notes |
+|---|---|---|
+| `mode` | `equals` | Same field name as the filter-mode above; `equals` is the verified entry-control value. |
+| `case` | `insensitive` | Case sensitivity for the (unused, in an entry context) match. |
+| `includeNulls` | `when-no-value-is-selected` | Same enum as the date-range control's `includeNulls`. |
+| `showOperators` | `false` | Hides the operator picker — this control is for typing a value, not building a filter expression. |
+
+No `filters` binding is needed on an entry control used this way — its value is
+read via `{ type: control, control: <controlId> }` from wherever it's
+consumed (an action effect's `values`, a formula), not wired to filter another
+element's column.
+
 ## Number Range
 
 ```yaml

--- a/sigma-workbooks/reference/specification/input-tables.md
+++ b/sigma-workbooks/reference/specification/input-tables.md
@@ -15,15 +15,41 @@ table, and a data model can read it through a warehouse view.
 
 1. **Write-enabled connection required.** `source: { kind: empty, connectionId }`
    must point at a connection with `writeAccess: true` (`GET /v2/connections`).
-   A non-write connection fails at POST. Linked tables (`kind: linked`) inherit
-   the parent's connection.
-2. **Data lands in `SIGDS_`-prefixed tables** in the connection's write schema.
+   A non-write connection fails at POST. A linked table's `source` carries its
+   **own** `connectionId` — see *Cross-connection linked tables* below; it is
+   not always simply inherited from the parent element.
+2. **`inputMode` is mandatory — omitting it masked-fails.** Every `input-table`
+   element requires `inputMode: edit | explore | view` (see `tables.md`). Leave
+   it out and the POST doesn't fail with a helpful "missing inputMode" — it
+   fails with the generic **`Invalid kind: "input-table"`**, which reads like
+   the element kind itself is rejected. If you hit that error on an
+   input-table, check `inputMode` first before suspecting anything else about
+   the shape.
+3. **Data lands in `SIGDS_`-prefixed tables** in the connection's write schema.
    Don't query or modify those directly — see "Reading the data" below.
-3. **Data is invisible until Publish.** A query of an input table before the
+4. **Data is invisible until Publish.** A query of an input table before the
    workbook is published returns **0 rows** — the query layer reads the
    published version. Publish, then re-query.
-4. **System columns take no `type`** (`ID`, `CREATED_AT`, `CREATED_BY`,
-   `UPDATED_AT`, `UPDATED_BY`) — adding one breaks the column.
+5. **System columns take no `type`** (`ID`, `CREATED_AT`, `CREATED_BY`,
+   `UPDATED_AT`, `UPDATED_BY`) — adding one breaks the column. They're also
+   never included in an `insert-rows` action effect's `values` — Sigma
+   auto-fills them at insert time (see `reference/workflows/actions.md`).
+
+### Cross-connection linked tables (verified)
+
+A **linked** input table's `source: { kind: linked, from: <parentElementId>,
+connectionId: <connectionId> }` carries its own `connectionId` — and that
+connection **can differ from the parent element's**. Verified live: a
+write-back input table on a write-enabled connection, linked (`from`) to a
+parent element (a pivot/table) sourced on a completely separate, **read-only**
+connection — the linked table still pulled every key row from the parent
+correctly. In other words, cross-connection linking (write-conn child, read-conn
+parent) is a supported pattern, not just same-connection linking. This is a
+narrower, more precise claim than "the connection is inherited" — the parent
+supplies the *keys* (via `{ id, key }` columns), not the *connection*; the
+linked table's own `connectionId` is what determines where its write-back rows
+actually live, and it must be a write-enabled connection regardless of what the
+parent uses.
 
 ## Three types
 
@@ -31,7 +57,7 @@ table, and a data model can read it through a warehouse view.
 |---|---|---|
 | **Empty** | Blank table; rows added/typed/pasted from scratch | `source: { kind: empty, connectionId }` |
 | **CSV** | Pre-populated from a CSV upload, then editable | created from an upload (UI); element is otherwise an empty-style input table |
-| **Linked** | Child of a parent element; key columns bind rows to the parent, entry/formula columns sit alongside | `source: { kind: linked, from: <parentElementId> }` + `{ id, key }` columns |
+| **Linked** | Child of a parent element; key columns bind rows to the parent, entry/formula columns sit alongside | `source: { kind: linked, from: <parentElementId>, connectionId: <connectionId> }` + `{ id, key }` columns |
 
 **Linked tables are spec-authorable as of the 2026-06-11 release** —
 `source.kind: linked` + `from` + `{ id, key }` columns POST and round-trip

--- a/sigma-workbooks/reference/specification/styling.md
+++ b/sigma-workbooks/reference/specification/styling.md
@@ -596,6 +596,128 @@ output rather than hand-writing the container + child XML per dashboard:
   on the same container — POST 400s ("padding is 'none' but border fields... require default
   padding"); omit `padding` (its default) whenever a border is set.
 
+### `gradient_header(id:, title:, subtitle:, gradient:, motif:, motif_side:, logo_url:, page_cols: 24)` — sleek header via a data-URI SVG
+
+A step up from the flat `header` band above: instead of a solid `backgroundColor`,
+the container's `backgroundImage` is a composed **inline SVG, base64-encoded as a
+`data:image/svg+xml;base64,...` URI** — a `linearGradient` (the `gradient:` stops)
+optionally layered with a decorative motif `<g>`. Same `{ element:, layout: }`
+return contract as `header`, so it drops into the same composition call sites.
+
+```yaml
+- id: hdr-bg
+  kind: container
+  style: { borderRadius: round }
+  backgroundImage:
+    url: "data:image/svg+xml;base64,PHN2ZyB4bWxucz0i..."   # composed gradient(+motif) SVG
+    style: { fit: cover }
+- id: hdr-title
+  kind: text
+  verticalAlign: middle
+  body: '# <span style="color: #FFFFFF">Overview</span>'
+```
+
+- `gradient:` is an array of **2–3 hex stops** (default: a neutral, host-agnostic
+  3-stop slate→navy→blue ramp in `DEFAULT_THEME[:header_gradient]` — not red; red,
+  like `theme(accent:)` elsewhere in this file, is a caller override, never a
+  built-in default).
+- `motif:` picks a decorative element layered on top of the gradient, positioned by
+  `motif_side:` (`:right` default, `:left`, `:center`). It's a **menu, not a fixed
+  look** — six geometric, trademark-free options in `Styling::MOTIFS`:
+
+  | Key | Look |
+  |---|---|
+  | `:glow` (default) | A soft radial highlight — the plainest, least busy option. |
+  | `:rings` | Concentric circles + crosshair lines — a "signal/target" mark. |
+  | `:grid` | A faint repeating grid pattern. |
+  | `:waves` | Three nested arcs — a soft "signal wave" mark. |
+  | `:dots` | A repeating dot pattern. |
+  | `:none` | No motif — a plain gradient. |
+
+  A **String** value for `motif:` starting with `http` or `data:` is treated as a
+  **bring-your-own image** and used verbatim as the background instead of composing
+  from the menu — useful for a caller with their own hero graphic. Every menu motif
+  is geometric (circles, grids, arcs, dots) — no logos, letterforms, or third-party
+  marks.
+- `logo_url:` (optional) adds a left-column `image` element inside the same band.
+- NO-GO on the `gradient_header` surface falls back to the plain `header` band
+  above (graceful — never a broken shape); NO-GO on just `motif` (surface still GO)
+  drops to a plain gradient with no decorative `<g>`.
+
+### `gradient_card(id:, kpi_element:, gradient: DEFAULT_THEME[:card_gradient], page_cols: 24)` — gradient KPI card
+
+Decorate-only, like `section_card`: wraps a **caller-built** `kpi-chart` element
+(e.g. from `KpiCard.build`) in a gradient `backgroundImage` container. `gradient:`
+is **optional** — it defaults to `DEFAULT_THEME[:card_gradient]` (a dark slate
+pair, `['#1E293B', '#0F172A']`), so a caller with no brand gradient in mind still
+gets a legible dark card; pass a caller-specific 2–3 hex-stop array to override it.
+
+The composed background is **two layers**, not one — the caller's (or default)
+gradient rect, THEN a dark **scrim**: a vertical `linearGradient` from black at
+~0.55 opacity at the top (where the KPI name+value sit) fading to 0 opacity
+toward the bottom (where a `sparkline` sits). This is what makes a white KPI
+value legible on **any** gradient, bright or dark — not just a dark one — while
+the brand gradient still reads through in the lower half (never fully blacked
+out). It never mutates `kpi_element` or `kpi_card.rb` — it returns
+`{ element:, child_layout:, patch: }`: the container element to add, the inner
+`<LayoutElement>` fragment positioning the KPI inside it, and a `patch` Hash
+the caller merges onto their own copy of the KPI's `value`/`name`/`style` objects:
+
+```yaml
+value: { color: "#FFFFFF" }
+name:  { color: "#FFFFFF" }
+style: { backgroundColor: transparent, padding: none }
+```
+
+so the title and value read white against the gradient. **Merge all three keys
+— `value`, `name`, AND `style`** — not just `value`/`name`: the KPI element keeps
+its own opaque background otherwise, so a live render shows white-on-white even
+with the scrim in place. NO-GO returns the empty
+`{ element: [], child_layout: '', patch: {} }` marker — nothing half-decorated.
+
+### `sparkline(id:, source_element_id:, period_ref:, value_formula:, period_format:)` — the composite in-card sparkline (refines the earlier NO-GO)
+
+`reference/workflows/composition.md` documents an **in-kpi date-column sparkline**
+as NO-GO: adding a real date dimension to a `kpi-chart`'s own `columns` renders no
+line — that finding **still stands**, unchanged.
+
+What **is** live-verified GO is a different shape entirely: a **separate,
+borderless `line-chart`** element stacked *below* the KPI inside the same
+`gradient_card` (or any card) container — not a field on the KPI element at all.
+`Styling.sparkline` builds exactly this:
+
+```yaml
+- id: k-rev-spark
+  kind: line-chart
+  source: { kind: table, elementId: src }
+  columns:
+    - id: k-rev-spark-period
+      formula: '[Src/Period]'
+      format: { kind: datetime, formatString: "%b %Y" }
+    - id: k-rev-spark-value
+      formula: Sum([Src/Revenue])
+  xAxis: { columnId: k-rev-spark-period, format: { marks: none, labels: hidden } }
+  yAxis:
+    columnIds: [k-rev-spark-value]
+    format: { labels: hidden, marks: none, scale: { type: linear, zero: false, hideZeroLine: true } }
+  name: { visibility: hidden }
+  legend: { visibility: hidden }
+  lineAreaStyle: { interpolation: monotone }
+  style: { backgroundColor: transparent, padding: none }
+```
+
+Both axes hide their labels/marks (no chart chrome competing with the KPI above
+it); `scale.zero: false` so a small real trend isn't flattened against a forced
+zero baseline; `name`/`legend` hidden (no title, no legend on a mini chart);
+`backgroundColor: transparent` so it blends into the card around it. Place it in
+the same container as a `gradient_card`-wrapped (or plain) KPI, sized as a thin
+strip beneath the value.
+
+**So:** "no sparkline field on the KPI element" is still true and always will be
+(it's UI-only there) — but "no sparkline in the card" is not. The composite
+pattern (KPI + a stacked borderless line-chart, same card) is the GO way to get
+one.
+
 ## Things that are NOT designable via spec (as of 2026-05-29)
 
 Don't waste a round-trip trying to set these — the spec API silently drops them.

--- a/sigma-workbooks/reference/specification/tables.md
+++ b/sigma-workbooks/reference/specification/tables.md
@@ -186,7 +186,7 @@ The `input-table` element is an editable table — users type values directly in
 `source` is one of:
 
 - `{ kind: empty, connectionId: <YOUR_CONNECTION_ID> }` — provisions a fresh, blank warehouse table.
-- `{ kind: linked, from: <elementId> }` — rows are linked to another element; the connection is inherited, and editable rows are matched to source rows by the `key` columns.
+- `{ kind: linked, from: <elementId> }` — rows are linked to another element, matched to source rows by the `key` columns. ⚠ A linked input table carries its **own** `connectionId` (the write target); it is NOT simply inherited from the parent and may differ from the parent's connection — cross-connection linking (write-conn child, read-conn parent) is supported. See `input-tables.md` → *Cross-connection linked tables*.
 
 `columns[]` items come in four shapes (each also accepts optional `name`, `description`, `hidden`, `format`):
 

--- a/sigma-workbooks/reference/workflows/actions.md
+++ b/sigma-workbooks/reference/workflows/actions.md
@@ -1,0 +1,201 @@
+# Actions — buttons, effects, and write-back workflows
+
+Buttons wire a user click to one or more **effects** — insert rows into an
+input table, reset a control, set a control's value, or open/close a modal.
+They live in `elements[]` like any other element, not nested inside another
+element.
+
+## Button shape
+
+```yaml
+id: btn-log
+kind: button
+text: Log note
+appearance: filled        # filled | outline
+actions:
+  - id: a-log
+    trigger: on-click
+    effects:
+      - effect: insert-rows
+        table: annotations
+        values:
+          an-note: { type: control, control: NoteCtl }
+```
+
+| Field | Required | Notes |
+|---|---|---|
+| `id` | yes | Element id. |
+| `kind` | yes | Always `button`. |
+| `text` | yes | Button label. |
+| `appearance` | — | `filled` \| `outline`. |
+| `actions` | yes | Array; each entry is `{ id, trigger, effects: [...] }`. `trigger: on-click` is the verified case (the OpenAPI also lists `on-select`/`on-primary-cta-click`/`on-secondary-cta-click`/`on-close` for other element/modal contexts — not exercised here). |
+
+A button typically carries one `actions[]` entry with one or more `effects[]` —
+effects in the same action run together off the same click.
+
+## Verified effects
+
+These three round-tripped and rendered correctly on a live test-org build:
+
+### `insert-rows` — write a row into an input table
+
+```yaml
+effect: insert-rows
+table: annotations             # an input-table element's id
+values:
+  an-note: { type: control, control: NoteCtl }
+  an-tag:  { type: constant, value: { type: text, value: "manual" } }
+```
+
+`values` is a map of the input table's **own column ids** to a value descriptor:
+- `{ type: control, control: <controlId> }` — the current value of a control.
+- `{ type: constant, value: { type: text, value: <literal> } }` — a hard-coded
+  literal.
+
+**Never include a system column** (`ID`/`CREATED_AT`/`CREATED_BY`/`UPDATED_AT`/
+`UPDATED_BY`) in `values` — Sigma auto-fills those; see *the append-only-log
+pattern* below.
+
+### `clear-control` — reset a control (page scope only)
+
+```yaml
+effect: clear-control
+scope: { type: page, page: pg }
+usePublishedValue: true
+```
+
+The OpenAPI's `scope` discriminator actually has **three** shapes —
+`{ type: control, control: <controlId> }` (clear one control), `{ type:
+container, container: <containerElementId> }` (clear every control in a
+container), and `{ type: page, page: <pageId> }` (clear every control on a
+page). **Only `page` scope is live-verified here** — an element/container-scoped
+`clear-control` masked-failed the button in live testing (the button silently
+didn't work; no clear error pointed at the cause). Until `control`/`container`
+scope is independently re-verified, build resets around `page` scope only.
+
+### `set-control-value` — set a control programmatically
+
+```yaml
+effect: set-control-value
+control: RegionFilter
+value: { type: constant, value: { type: text, value: "West" } }
+```
+
+The only verified `value` shape is a constant text value (e.g. a "quick filter
+preset" button). Useful paired with a `list`/`segmented` control to give users a
+one-click shortcut into a known filter state.
+
+## Modals: `open-overlay` / `close-overlay`
+
+A workbook page can be marked `type: modal` — a page that renders as an overlay
+rather than a navigable tab. A button's effect opens/closes it:
+
+```yaml
+pages:
+  - id: pg
+    name: Main
+    elements: [ ... , btn-open ]
+  - id: modal-detail
+    type: modal
+    name: Detail
+    elements: [ ... ]
+```
+
+```yaml
+# on the trigger button (lives on the main page)
+effect: open-overlay
+overlayId: modal-detail    # the modal PAGE's `id`, not an element id
+
+# on a close button (typically inside the modal itself)
+effect: close-overlay
+```
+
+`open-overlay` requires `overlayId`; `close-overlay` takes no other fields (it
+closes whatever overlay is open). **These two shapes are documented in the
+compiled OpenAPI** (unlike `insert-rows`, which isn't inlined there as of this
+writing) but were **not** part of this round's live-render probe — confirm with
+a POST + PNG export before shipping a modal flow, same discipline as any other
+shape in this doc.
+
+## The append-only-log pattern
+
+The recurring write-back shape: an **empty input table** as a log, a **control**
+to capture what the user types, and a **button** that inserts a row.
+
+```yaml
+# 1. The entry control — see controls.md's "Entry (write) text controls" note:
+#    these four fields are mandatory or the control masked-fails.
+- id: note-ctl
+  kind: control
+  controlId: NoteCtl
+  name: Add a review note
+  controlType: text-area
+  mode: equals
+  case: insensitive
+  includeNulls: when-no-value-is-selected
+  showOperators: false
+
+# 2. The button — inserts one row per click, reading the control's live value.
+- id: btn-log
+  kind: button
+  text: Log note
+  appearance: filled
+  actions:
+    - id: a-log
+      trigger: on-click
+      effects:
+        - effect: insert-rows
+          table: annotations
+          values:
+            an-note: { type: control, control: NoteCtl }
+
+# 3. The log itself — an empty input table. System columns take NO `type` and
+#    are auto-filled by Sigma (CREATED_AT/CREATED_BY) — never pass them in
+#    insert-rows `values` above; doing so breaks the column.
+- id: annotations
+  kind: input-table
+  inputMode: edit
+  source: { kind: empty, connectionId: <WRITE_CONNECTION_ID> }
+  columns:
+    - id: an-note
+      type: text
+      name: Review note
+    - id: CREATED_AT
+    - id: CREATED_BY
+```
+
+Each click appends a new, timestamped, attributed row — nothing is ever
+overwritten. This is the shape to reach for "log an action," "flag this record,"
+or "leave a comment," anywhere a durable audit trail matters more than an
+editable cell.
+
+## Masked-error catalog
+
+Sigma's spec validator returns the same opaque, unhelpful message for several
+distinct root causes on these element kinds. If you hit one of these, check the
+listed cause **first** before assuming the element kind itself is unsupported.
+
+| Error | Real cause | Fix |
+|---|---|---|
+| `Invalid kind: "input-table"` | `inputMode` was omitted. | Always set `inputMode: edit` (or `explore`/`view` — see `input-tables.md`). It's technically documented as required in `tables.md`, but omitting it produces this generic message rather than a field-specific one. |
+| `Invalid kind: "control"` (on a `text`/`text-area` control used for **entry**, not filtering) | One or more of `mode`, `case`, `includeNulls`, `showOperators` was omitted. | Set all four — see `controls.md`'s "Entry (write) text controls" section. |
+| Button silently does nothing on click | An element/container-scoped `clear-control`. | Use `scope: { type: page, page: <id> }` only (see above). |
+
+## Cross-links
+
+- `scripts/lib/actions.rb` — `Actions.button(id:, text:, effects:,
+  appearance:)`, `Actions.input_table_empty(id:, connection_id:, columns:,
+  name:)`, `Actions.input_table_linked(id:, from:, connection_id:, columns:,
+  name:)`, and the three effect builders `Actions.insert_rows_effect(table:,
+  values:)` / `Actions.clear_control_effect(page:)` /
+  `Actions.set_control_value_effect(control:, text:)` build exactly the shapes
+  above (`inputMode: "edit"` always emitted; `clear_control_effect` only ever
+  emits page scope). Gated behind `Actions::SURFACES`; a NO-GO flip returns
+  `{opt_in: true, id:}` (element builders) or `{}` (effect builders) rather than
+  a faked shape.
+- `reference/specification/input-tables.md` — the write-connection requirement,
+  the publish-before-query gate, and the linked-table cross-connection pattern.
+- `reference/specification/controls.md` — full control-element field reference.
+- `reference/specification/agents.md` — a write/action agent's `tools[].steps[]`
+  reuses these same effect shapes, driven by agent input instead of a button
+  click.

--- a/sigma-workbooks/scripts/lib/actions.rb
+++ b/sigma-workbooks/scripts/lib/actions.rb
@@ -1,0 +1,172 @@
+# frozen_string_literal: true
+#
+# actions.rb — thin, spec-authorable builders for buttons, input tables
+# (write-back), and the action effects that connect them. Ruby 2.6+, stdlib
+# only. Golden-tested output lives in scripts/lib/testdata/actions_golden.json
+# (see test_actions.rb).
+#
+#   require_relative 'lib/actions'
+#   btn = Actions.button(id: 'btn-log', text: 'Log note',
+#                         effects: [Actions.insert_rows_effect(table: 'annotations', values: {...})])
+#   tbl = Actions.input_table_empty(id: 'annotations', connection_id: WRITE, columns: [...])
+#
+# Live-verified shape facts (verified live against a real Sigma org, building
+# a multi-KPI command-center-style workbook with buttons + an append-only-log
+# input table):
+#   - `inputMode:"edit"` on an input-table element is MANDATORY. Omit it and
+#     the POST masked-fails as `Invalid kind:"input-table"` — a misleading
+#     message; the real cause is the missing inputMode. Both input_table_*
+#     builders below always emit it.
+#   - Empty input table: source:{kind:"empty",connectionId:<WRITE conn>}.
+#     Linked input table: source:{kind:"linked",from:<parent element id>,
+#     connectionId:<WRITE conn>} — the parent element (`from`) may live on a
+#     DIFFERENT (read-only) connection than the write-back table itself
+#     (verified: a Sample-DB pivot fed a write-conn linked table). System
+#     columns (e.g. CREATED_AT/CREATED_BY) take no `type` and are auto-filled
+#     by Sigma — callers pass them as bare {'id'=>...} column entries and
+#     never include them in insert-rows `values`.
+#   - Button: {id, kind:"button", text, appearance:"filled"|"outline",
+#     actions:[{id, trigger:"on-click", effects:[...]}]}. `action_id:`
+#     defaults to "a-<id>" (deterministic — no time/random) so callers don't
+#     have to invent a second id for the single action most buttons carry;
+#     pass action_id: explicitly for a different handle.
+#   - Effects verified live: insert-rows (values is a pass-through Hash of
+#     colId => {type:"control",control:} | {type:"constant",value:{type:"text",value:}}
+#     entries — this module does not reshape `values`, callers build it),
+#     clear-control (an ELEMENT-scoped clear-control masked-failed the button
+#     live — only page scope is verified, so this builder only emits
+#     scope:{type:"page",page:}), set-control-value (constant text value).
+#
+# All builders are gated through Actions::SURFACES (same discipline as
+# richness.rb/styling.rb): a NO-GO flip on `button`/`input_table_empty`/
+# `input_table_linked` returns {'opt_in'=>true,'id'=>id} (never a faked
+# element); a NO-GO flip on `effects` (the 3 effect builders share one gate —
+# they're trivial shape helpers, not independently-risky surfaces) returns
+# {} (never a faked effect spliced into a caller's actions: array).
+
+require 'json'
+
+module Actions
+  SURFACES = {
+    button: true,             # {kind:"button"} + actions:[{trigger,effects}] — verified GO live
+    input_table_empty: true,  # input-table, source.kind:"empty" — verified GO live; inputMode:"edit" mandatory (masked-error fix)
+    input_table_linked: true, # input-table, source.kind:"linked" (cross-connection from a read-only parent) — verified GO live
+    effects: true             # insert-rows / clear-control / set-control-value shape helpers — verified GO live, one gate for all 3
+  }.freeze
+
+  # Returns a `button` element: {id, kind:"button", text, appearance,
+  # actions:[{id, trigger, effects}]}. `effects` is a pass-through array —
+  # build entries with insert_rows_effect/clear_control_effect/
+  # set_control_value_effect (or already-shaped Hashes) and pass them here
+  # verbatim; this builder never reshapes them. `action_id:` defaults to
+  # the deterministic "a-<id>" when omitted (nil) — pass action_id: '' or
+  # any other string explicitly to use a different handle. NO-GO surface ->
+  # {'opt_in'=>true,'id'=>id}.
+  def self.button(id:, text:, effects:, appearance: 'filled', trigger: 'on-click', action_id: nil, surfaces: SURFACES)
+    raise ArgumentError, 'id required' if id.to_s.empty?
+    raise ArgumentError, 'text required' if text.to_s.empty?
+    return { 'opt_in' => true, 'id' => id } unless surfaces[:button]
+
+    aid = action_id.nil? ? "a-#{id}" : action_id
+    {
+      'id' => id,
+      'kind' => 'button',
+      'text' => text,
+      'appearance' => appearance,
+      'actions' => [{ 'id' => aid, 'trigger' => trigger, 'effects' => effects }]
+    }
+  end
+
+  # Returns an `input-table` element sourced empty (a fresh write-back table,
+  # e.g. an append-only log): {id, kind:"input-table", inputMode:"edit",
+  # source:{kind:"empty",connectionId:}, columns:}. `inputMode:"edit"` is
+  # ALWAYS emitted — it is mandatory (see module docstring's masked-error
+  # note). `columns` is passed through verbatim (already-shaped column
+  # entries, including bare {'id'=>'CREATED_AT'} system-column entries with
+  # no `type`). `name:` (optional; a text-style Hash or plain string, caller's
+  # choice — passed through verbatim) is OMITTED entirely when not given, not
+  # emitted as nil. NO-GO surface -> {'opt_in'=>true,'id'=>id}.
+  def self.input_table_empty(id:, connection_id:, columns:, name: nil, surfaces: SURFACES)
+    raise ArgumentError, 'id required' if id.to_s.empty?
+    raise ArgumentError, 'connection_id required' if connection_id.to_s.empty?
+    raise ArgumentError, 'columns required' if columns.nil? || columns.empty?
+    return { 'opt_in' => true, 'id' => id } unless surfaces[:input_table_empty]
+
+    out = {
+      'id' => id,
+      'kind' => 'input-table',
+      'inputMode' => 'edit',
+      'source' => { 'kind' => 'empty', 'connectionId' => connection_id },
+      'columns' => columns
+    }
+    out['name'] = name unless name.nil?
+    out
+  end
+
+  # Returns an `input-table` element sourced linked from a parent element
+  # (e.g. a write-back "targets" table keyed off a read-only pivot):
+  # {id, kind:"input-table", inputMode:"edit", source:{kind:"linked",from:,
+  # connectionId:}, columns:}. `from` is the PARENT element's id — verified
+  # live to work even when the parent sits on a different (read-only)
+  # connection than `connection_id` (the write connection this table itself
+  # lives on). Same `columns`/`name:` pass-through contract as
+  # input_table_empty. NO-GO surface -> {'opt_in'=>true,'id'=>id}.
+  def self.input_table_linked(id:, from:, connection_id:, columns:, name: nil, surfaces: SURFACES)
+    raise ArgumentError, 'id required' if id.to_s.empty?
+    raise ArgumentError, 'from required' if from.to_s.empty?
+    raise ArgumentError, 'connection_id required' if connection_id.to_s.empty?
+    raise ArgumentError, 'columns required' if columns.nil? || columns.empty?
+    return { 'opt_in' => true, 'id' => id } unless surfaces[:input_table_linked]
+
+    out = {
+      'id' => id,
+      'kind' => 'input-table',
+      'inputMode' => 'edit',
+      'source' => { 'kind' => 'linked', 'from' => from, 'connectionId' => connection_id },
+      'columns' => columns
+    }
+    out['name'] = name unless name.nil?
+    out
+  end
+
+  # Returns an `insert-rows` effect Hash: {effect, table, values}. `values`
+  # is a pass-through Hash of colId => {type:"control",control:} |
+  # {type:"constant",value:{type:"text",value:}} entries (or any other
+  # already-shaped value descriptor) — never reshaped here; system columns
+  # (CREATED_AT/CREATED_BY) are never included, Sigma auto-fills them.
+  # NO-GO surface -> {} (never a faked effect spliced into a caller's
+  # actions: array).
+  def self.insert_rows_effect(table:, values:, surfaces: SURFACES)
+    raise ArgumentError, 'table required' if table.to_s.empty?
+    return {} unless surfaces[:effects]
+
+    { 'effect' => 'insert-rows', 'table' => table, 'values' => values }
+  end
+
+  # Returns a `clear-control` effect Hash: {effect, scope:{type:"page",page:},
+  # usePublishedValue:true}. Page scope ONLY — an element-scoped
+  # clear-control masked-failed the button live, so this builder never emits
+  # any other scope shape. NO-GO surface -> {}.
+  def self.clear_control_effect(page:, surfaces: SURFACES)
+    raise ArgumentError, 'page required' if page.to_s.empty?
+    return {} unless surfaces[:effects]
+
+    { 'effect' => 'clear-control', 'scope' => { 'type' => 'page', 'page' => page }, 'usePublishedValue' => true }
+  end
+
+  # Returns a `set-control-value` effect Hash: {effect, control,
+  # value:{type:"constant",value:{type:"text",value:text}}}. `text` is
+  # always wrapped as a constant text value (the only shape verified live).
+  # NO-GO surface -> {}.
+  def self.set_control_value_effect(control:, text:, surfaces: SURFACES)
+    raise ArgumentError, 'control required' if control.to_s.empty?
+    raise ArgumentError, 'text required' if text.to_s.empty?
+    return {} unless surfaces[:effects]
+
+    {
+      'effect' => 'set-control-value',
+      'control' => control,
+      'value' => { 'type' => 'constant', 'value' => { 'type' => 'text', 'value' => text } }
+    }
+  end
+end

--- a/sigma-workbooks/scripts/lib/richness.rb
+++ b/sigma-workbooks/scripts/lib/richness.rb
@@ -1,17 +1,20 @@
 # frozen_string_literal: true
 #
-# richness.rb — four independent, optional "richness" pieces for a dashboard
+# richness.rb — independent, optional "richness" pieces for a dashboard
 # page — each helper emits ONE spec-authorable fragment, never a whole
 # workbook/page. Consumed by callers that already have Composition/Styling
 # output and want to layer in an AI-generated insight, a dynamic date-grain
-# control+dimension, a filter row, or a wide (non-crosstab) pivot table.
-# Ruby 2.6+, stdlib only. Golden-tested output lives in
-# scripts/lib/testdata/richness_golden.json (see test_richness.rb).
+# control+dimension, a filter row, a wide (non-crosstab) pivot table, or a
+# workbook AI agent + chat element. Ruby 2.6+, stdlib only. Golden-tested
+# output lives in scripts/lib/testdata/richness_golden.json (see
+# test_richness.rb).
 #
 #   require_relative 'lib/richness'
 #   Richness.ai_insight(id: 'ai-1', prompt: 'Say hello.')
 #   ctl = Richness.grain_control(id: 'GrainCtl')
 #   dim = Richness.trend_dimension(grain_control_id: 'GrainCtl', date_ref: '[Src/Date]')
+#   ag = Richness.agent(id: 'ag-1', name: 'Analyst', instructions: 'Be helpful.', data_source_ids: ['src'])
+#   chat = Richness.chat(id: 'chat-1', agent_id: 'ag-1')
 #
 # GO/NO-GO provenance (verified live against a real Sigma org):
 #   - CallText/AI-insight: GO. CallText's real signature is
@@ -41,6 +44,16 @@
 # deprecation on ANY of them can be flipped off in one place, same discipline
 # as styling.rb.
 #
+# `agent`/`chat` addition: the Sigma workbook AI agent is a workbook-TOP-LEVEL
+# `agents:[]` array entry (not a page element), verified live building a
+# multi-KPI command-center-style workbook. Read-only analyst = the entry
+# OMITS `tools` entirely. The page-level `chat` element just references the
+# agent's id. Sigma's AI-agent feature is an org-level toggle — when it's off
+# for a target org, callers should degrade to a static text element with
+# sample prompts rather than POST a chat element that will masked-fail; that
+# fallback pattern is documented in reference/workflows/actions.md, not
+# re-derived here.
+#
 # Two live-build fixes below, previously only worked around by callers, are
 # now fixed IN this module:
 #   - wide_pivot 400'd ("Invalid kind: \"pivot-table\"" — a misleading
@@ -59,14 +72,15 @@
 require 'json'
 
 module Richness
-  # GO/NO-GO map. All 4 are GO today; a NO-GO flip makes the gated helper
+  # GO/NO-GO map. All 5 are GO today; a NO-GO flip makes the gated helper
   # return an empty/opt-in marker instead of emitting an unverified (or
   # 400-rejected) shape — never a silently-wrong fallback.
   SURFACES = {
     ai_insight: true,     # CallText/AI-insight text element (verified GO live; renders real text only where the target org's connection has Cortex configured — NEVER a fabricated summary)
     dynamic_grain: true,  # grain_control (segmented control) + trend_dimension (Switch+DateTrunc dimension formula) — verified GO live
     filter_row: true,     # list control(s) -> element filter, reusing the already-GO master-detail control/filter shape
-    wide_pivot: true      # pivot-table rowsBy + columnsBy:[] + values, reusing the already-GO general Sigma pivot shape
+    wide_pivot: true,     # pivot-table rowsBy + columnsBy:[] + values, reusing the already-GO general Sigma pivot shape
+    agent: true           # workbook-level agents[] entry + page-level {kind:"chat"} element — verified GO live; org-feature-gated on the Sigma side (see agent/chat docstrings for the graceful-degrade contract)
   }.freeze
 
   DEFAULT_MODEL = 'llama3.1-8b'
@@ -195,5 +209,51 @@ module Richness
       'columnsBy' => [],
       'values' => values
     }
+  end
+
+  # Returns a workbook-level `agents[]` entry (NOT a page element — the
+  # workbook spec's top-level `agents:` array; pair with `chat` below for the
+  # page-level element that surfaces it). `data_source_ids` map 1:1, in
+  # order, to `dataSources:[{kind:"table",elementId:}, ...]`. `tools:` empty
+  # (the default) means a READ-ONLY analyst — the returned Hash OMITS the
+  # `tools` key entirely (not `tools:[]`); this exact omission is the
+  # live-verified read-only shape. Pass a non-empty `tools:` array
+  # (already-shaped `{toolId,kind:"action",name,description,steps:[...]}`
+  # entries) for a write/action agent — added verbatim, never reshaped here.
+  # Sigma's AI-agent feature is an org-level gate: when it's off for the
+  # target org, the agent/chat surface degrades to a static element rather
+  # than a 400 (see `chat`'s docstring and reference/workflows/actions.md for
+  # the caller-side fallback pattern). NO-GO surface ->
+  # {'opt_in'=>true,'id'=>id}: never emit a faked agent.
+  def self.agent(id:, name:, instructions:, data_source_ids:, tools: [], surfaces: SURFACES)
+    raise ArgumentError, 'id required' if id.to_s.empty?
+    raise ArgumentError, 'name required' if name.to_s.empty?
+    raise ArgumentError, 'instructions required' if instructions.to_s.empty?
+    return { 'opt_in' => true, 'id' => id } unless surfaces[:agent]
+
+    out = {
+      'id' => id,
+      'name' => name,
+      'instructions' => instructions,
+      'dataSources' => (data_source_ids || []).map { |eid| { 'kind' => 'table', 'elementId' => eid } }
+    }
+    out['tools'] = tools unless tools.nil? || tools.empty?
+    out
+  end
+
+  # Returns the page-level `chat` element that surfaces an `agent` entry:
+  # {id, kind:"chat", agentId}. `agent_id` is the AGENT's `id` (the same
+  # string used in the `agents[]` entry `agent` built above), not an
+  # element id. Same org-feature gate as `agent` — when Sigma AI agents are
+  # off for the target org, callers should degrade to a static text element
+  # with sample prompts instead (documented in reference/workflows/
+  # actions.md, not re-derived here). NO-GO surface -> {'opt_in'=>true,
+  # 'id'=>id}: never emit a faked chat element.
+  def self.chat(id:, agent_id:, surfaces: SURFACES)
+    raise ArgumentError, 'id required' if id.to_s.empty?
+    raise ArgumentError, 'agent_id required' if agent_id.to_s.empty?
+    return { 'opt_in' => true, 'id' => id } unless surfaces[:agent]
+
+    { 'id' => id, 'kind' => 'chat', 'agentId' => agent_id }
   end
 end

--- a/sigma-workbooks/scripts/lib/styling.rb
+++ b/sigma-workbooks/scripts/lib/styling.rb
@@ -3,6 +3,7 @@
 # Composition output: theme (palette), chart color, KPI accent, number
 # format, header/section container. Ruby 2.6+, stdlib only.
 require_relative 'composition'
+require 'base64'
 
 module Styling
   # One professional, host-agnostic palette. No branding.
@@ -14,7 +15,16 @@ module Styling
     card: { 'backgroundColor' => '#FFFFFF', 'borderColor' => '#E2E8F0',
             'borderWidth' => 1, 'borderRadius' => 'round' },
     header: { 'backgroundColor' => '#0F172A', 'borderRadius' => 'round' },
-    accent: '#2563EB'
+    accent: '#2563EB',
+    # Neutral 3-stop gradient (dark slate -> navy -> accent blue) for
+    # Styling.gradient_header. NOT red -- red is a caller override, same
+    # discipline as theme(accent:) tinting the flat palette above.
+    header_gradient: %w[#0F172A #1E3A8A #2563EB],
+    # Live-render fix: dark default so Styling.gradient_card's `gradient:`
+    # can be omitted -- a caller with no brand gradient in mind still gets a
+    # legible dark card (paired with the scrim in compose_card_svg below,
+    # white KPI text stays legible either way).
+    card_gradient: %w[#1E293B #0F172A]
   }.freeze
 
   # Returns a theme; an accent override tints categorical slot 0 + accent.
@@ -39,7 +49,32 @@ module Styling
     categorical_scheme: true, # workbook-level themeOverrides:{categoricalScheme:[...]}
     format_string: true,      # format:{kind:"number",formatString:<d3>} — Excel-style formatString is 400-rejected, never emitted
     container_style: true,    # container style:{backgroundColor,borderRadius,borderColor,borderWidth} (borderRadius, NOT cornerRadius; never combine with padding)
-    typography: true          # themeOverrides.titleFont + per-element name:{fontSize} — verified GO live, but no helper below emits it (out of scope here); kept for a complete surface map
+    typography: true,         # themeOverrides.titleFont + per-element name:{fontSize} — verified GO live, but no helper below emits it (out of scope here); kept for a complete surface map
+    # A container backgroundImage:{url:"data:image/svg+xml;base64,...",
+    # style:{fit:"cover"}} carrying a composed <linearGradient>+motif SVG
+    # survived readback + a real render. Two independent gates:
+    # gradient_header (the whole surface; NO-GO falls back to the flat
+    # Styling.header band) and motif (the optional decorative <g> layered on
+    # top of a *menu-key* motif; NO-GO degrades that case to a plain gradient
+    # with no motif, never a broken shape. It does NOT touch a bring-your-own
+    # image URL -- that path has nothing to do with the decorative
+    # SVG-fragment library this gate protects, so it is honored
+    # unconditionally).
+    gradient_header: true,
+    motif: true,
+    # A gradient backgroundImage CARD container (Styling.gradient_card,
+    # wrapping a caller-built kpi-chart with a white-text patch) and a
+    # separate borderless `line-chart` composite sparkline (Styling.sparkline)
+    # both survived readback + a real render. NO-GO gradient_card -> the
+    # empty {element:[],child_layout:'',patch:{}} marker (graceful — never
+    # mutates or half-decorates the caller's kpi_element). NO-GO sparkline ->
+    # {'opt_in'=>true,'id'=>} (never a faked chart shape). Live-render fix
+    # (user-reported "can't see the numbers"): gradient_card's composed
+    # background now also carries a dark scrim (see compose_card_svg/
+    # CARD_SCRIM_TOP_OPACITY) so white KPI text stays legible on ANY caller
+    # gradient, not just dark ones.
+    gradient_card: true,
+    sparkline: true
   }.freeze
 
   # d3-format grammar (NOT Excel) — verified live, surviving strings.
@@ -49,6 +84,50 @@ module Styling
     percent: '.1%',
     decimal: ',.2f'
   }.freeze
+
+  # Opacity of the dark scrim composed behind a gradient_card's top band
+  # (where the KPI name+value sit), fading to 0 by the bottom (where a
+  # sparkline sits) -- see compose_card_svg. A single named constant so a
+  # future legibility regression is a one-line tune, not a hunt through the
+  # SVG string.
+  CARD_SCRIM_TOP_OPACITY = 0.55
+
+  # Motif menu for Styling.gradient_header. Each fragment is a fixed,
+  # deterministic SVG string local to its own origin (0,0) -- gradient_header
+  # wraps it in a positioning <g transform="translate(x,86)"> per motif_side,
+  # so the fragments themselves never hardcode a page position. All
+  # geometric, trademark-free, white low-opacity strokes/fills. :none is the
+  # empty-string identity (no motif layered on the gradient).
+  GLOW_MOTIF_FRAGMENT = '<defs><radialGradient id="motif-glow" cx="0.5" cy="0.5" r="0.6">' \
+                        '<stop offset="0" stop-color="#FFFFFF" stop-opacity="0.2"/>' \
+                        '<stop offset="1" stop-color="#FFFFFF" stop-opacity="0"/></radialGradient></defs>' \
+                        '<rect x="-260" y="-105" width="520" height="210" fill="url(#motif-glow)"/>'
+  RINGS_MOTIF_FRAGMENT = '<g fill="none" stroke="#FFFFFF" stroke-opacity="0.12" stroke-width="1.4">' \
+                         '<circle r="40"/><circle r="74"/><circle r="108"/>' \
+                         '<line x1="-130" y1="0" x2="130" y2="0"/><line x1="0" y1="-130" x2="0" y2="130"/></g>'
+  GRID_MOTIF_FRAGMENT = '<defs><pattern id="motif-grid" width="40" height="40" patternUnits="userSpaceOnUse">' \
+                        '<path d="M 40 0 L 0 0 0 40" fill="none" stroke="#FFFFFF" stroke-opacity="0.12" stroke-width="1"/>' \
+                        '</pattern></defs><rect x="-260" y="-105" width="520" height="210" fill="url(#motif-grid)"/>'
+  WAVES_MOTIF_FRAGMENT = '<g fill="none" stroke="#FFFFFF" stroke-opacity="0.14" stroke-width="2">' \
+                         '<path d="M -150 0 A 150 150 0 0 1 150 0"/>' \
+                         '<path d="M -110 0 A 110 110 0 0 1 110 0"/>' \
+                         '<path d="M -70 0 A 70 70 0 0 1 70 0"/></g>'
+  DOTS_MOTIF_FRAGMENT = '<defs><pattern id="motif-dots" width="24" height="24" patternUnits="userSpaceOnUse">' \
+                        '<circle cx="4" cy="4" r="2" fill="#FFFFFF" fill-opacity="0.16"/></pattern></defs>' \
+                        '<rect x="-260" y="-105" width="520" height="210" fill="url(#motif-dots)"/>'
+
+  MOTIFS = {
+    glow: -> { GLOW_MOTIF_FRAGMENT },
+    rings: -> { RINGS_MOTIF_FRAGMENT },
+    grid: -> { GRID_MOTIF_FRAGMENT },
+    waves: -> { WAVES_MOTIF_FRAGMENT },
+    dots: -> { DOTS_MOTIF_FRAGMENT },
+    none: -> { '' }
+  }.freeze
+
+  # motif_side -> x translate (page-space, viewBox 0 0 1600 210); y is fixed
+  # at 86 for every side.
+  GRADIENT_MOTIF_X = { right: 1440, left: 160, center: 800 }.freeze
 
   # Chart color patch: single-series `color:{by:"single",value:}` (categorical
   # slot 0) by default, or the workbook-level categorical-scheme patch when
@@ -128,5 +207,212 @@ module Styling
       '</GridContainer>'
     ].join("\n")
     { element: container_el, wrap: wrap }
+  end
+
+  # True when `motif` is a caller-supplied image reference (bring-your-own),
+  # not a Styling::MOTIFS menu key.
+  def self.bring_your_own_motif?(motif)
+    motif.is_a?(String) && (motif.start_with?('http') || motif.start_with?('data:'))
+  end
+
+  # data:image/svg+xml;base64,... URI for an inline SVG string. Ruby 2.6
+  # stdlib only (Base64.strict_encode64 -- no embedded newlines, unlike encode64).
+  def self.svg_data_uri(svg)
+    'data:image/svg+xml;base64,' + Base64.strict_encode64(svg)
+  end
+
+  # Composes the gradient_header background SVG: viewBox 0 0 1600 210, a
+  # linearGradient from `gradient`'s 2-3 hex stops, plus an optional motif
+  # <g> positioned per motif_side. `motif` here is always a Styling::MOTIFS
+  # key (bring-your-own URLs are handled by the caller before this is
+  # reached -- see gradient_header).
+  def self.compose_gradient_svg(gradient, motif, motif_side)
+    unless gradient.is_a?(Array) && [2, 3].include?(gradient.length)
+      raise ArgumentError, "compose_gradient_svg: gradient must be an array of 2-3 hex stops (got #{gradient.inspect})"
+    end
+    offsets = gradient.length == 2 ? %w[0 1] : %w[0 0.5 1]
+    stops = gradient.each_with_index.map { |hex, i| "<stop offset=\"#{offsets[i]}\" stop-color=\"#{hex}\"/>" }.join
+    motif_key = motif.is_a?(String) ? motif.to_sym : motif
+    motif_fn = MOTIFS.fetch(motif_key) { raise ArgumentError, "compose_gradient_svg: unknown motif #{motif.inspect}" }
+    frag = motif_fn.call
+    tx = GRADIENT_MOTIF_X.fetch(motif_side, GRADIENT_MOTIF_X[:right])
+    motif_group = frag.empty? ? '' : "<g transform=\"translate(#{tx},86)\">#{frag}</g>"
+    '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1600 210" preserveAspectRatio="xMidYMid slice">' \
+      "<defs><linearGradient id=\"hg\" x1=\"0\" y1=\"0\" x2=\"1\" y2=\"0.45\">#{stops}</linearGradient></defs>" \
+      "<rect width=\"1600\" height=\"210\" fill=\"url(#hg)\"/>#{motif_group}</svg>"
+  end
+
+  # Sleek gradient header band (rows 1..4): a container whose backgroundImage
+  # is a composed data-URI SVG (linearGradient + optional motif), an optional
+  # left-side logo image, a white title text element, and an optional
+  # subtitle text element. Same { element:, layout: } contract as
+  # Styling.header. `motif:` is a Styling::MOTIFS key (default :glow) or a
+  # bring-your-own `http`/`data:` URL string used verbatim as the background
+  # (SVG compose skipped). NO-GO gradient_header falls back to the existing
+  # flat Styling.header band (graceful, never a broken/fake surface). NO-GO
+  # motif (gradient_header still GO) silently drops the motif <g> for a
+  # *menu-key* motif, keeping the plain gradient -- also graceful, never
+  # broken. A bring-your-own motif URL is checked FIRST and honored
+  # unconditionally, regardless of SURFACES[:motif] -- that gate exists only
+  # to protect the decorative SVG-fragment library, not the caller's own
+  # image (an arbitrary URL in backgroundImage.url either way).
+  def self.gradient_header(id:, title:, subtitle: nil, gradient: DEFAULT_THEME[:header_gradient],
+                            motif: :glow, motif_side: :right, logo_url: nil, page_cols: 24, surfaces: SURFACES)
+    unless surfaces[:gradient_header]
+      return header(id: id, title: title, theme: DEFAULT_THEME, page_cols: page_cols, surfaces: surfaces)
+    end
+
+    bg_url = if bring_your_own_motif?(motif)
+               motif
+             else
+               effective_motif = surfaces[:motif] ? motif : :none
+               svg_data_uri(compose_gradient_svg(gradient, effective_motif, motif_side))
+             end
+
+    container_id = "#{id}-bg"
+    logo_id = "#{id}-logo"
+    title_id = "#{id}-title"
+    subtitle_id = "#{id}-subtitle"
+
+    container_el = { 'id' => container_id, 'kind' => 'container', 'style' => { 'borderRadius' => 'round' },
+                     'backgroundImage' => { 'url' => bg_url, 'style' => { 'fit' => 'cover' } } }
+    title_el = { 'id' => title_id, 'kind' => 'text', 'verticalAlign' => 'middle',
+                 'body' => "# <span style=\"color: #FFFFFF\">#{title}</span>" }
+
+    elements = [container_el]
+    elements << { 'id' => logo_id, 'kind' => 'image', 'url' => logo_url, 'style' => { 'fit' => 'contain' } } if logo_url
+    elements << title_el
+    if subtitle
+      elements << { 'id' => subtitle_id, 'kind' => 'text', 'verticalAlign' => 'middle',
+                    'body' => "<span style=\"color: #CBD5E1\">#{subtitle}</span>" }
+    end
+
+    r0 = 1
+    r1 = 4
+    title_r1 = subtitle ? 3 : r1
+    text_c0 = logo_url ? 3 : 1
+    lines = ["<GridContainer elementId=\"#{container_id}\" type=\"grid\" gridColumn=\"1 / #{page_cols + 1}\" gridRow=\"#{r0} / #{r1}\" " \
+              "gridTemplateColumns=\"repeat(#{page_cols}, 1fr)\" gridTemplateRows=\"auto\">"]
+    lines << "  <LayoutElement elementId=\"#{logo_id}\" gridColumn=\"1 / 3\" gridRow=\"#{r0} / #{r1}\"/>" if logo_url
+    lines << "  <LayoutElement elementId=\"#{title_id}\" gridColumn=\"#{text_c0} / #{page_cols + 1}\" gridRow=\"#{r0} / #{title_r1}\"/>"
+    if subtitle
+      lines << "  <LayoutElement elementId=\"#{subtitle_id}\" gridColumn=\"#{text_c0} / #{page_cols + 1}\" gridRow=\"#{title_r1} / #{r1}\"/>"
+    end
+    lines << '</GridContainer>'
+
+    { element: elements, layout: lines.join("\n") }
+  end
+
+  # Composes the gradient_card background SVG (live-render fix, user-reported
+  # "can't see the numbers"): same viewBox + gradient-rect technique as
+  # compose_gradient_svg (always motif :none -- a card this small has no room
+  # for a decorative mark), PLUS a second rect layered on top filled with a
+  # vertical black scrim `linearGradient` -- CARD_SCRIM_TOP_OPACITY opacity
+  # at the top (y=0, where the KPI name+value sit) fading to 0 opacity by
+  # the bottom (y=210, where a Styling.sparkline sits) -- so a white KPI
+  # value stays legible on ANY caller gradient, bright or dark, while the
+  # brand gradient still reads through in the lower half (never fully
+  # blacked out). Kept as its own composer (not a compose_gradient_svg
+  # option) so gradient_header's output -- already live-verified without a
+  # scrim -- is untouched.
+  def self.compose_card_svg(gradient)
+    unless gradient.is_a?(Array) && [2, 3].include?(gradient.length)
+      raise ArgumentError, "compose_card_svg: gradient must be an array of 2-3 hex stops (got #{gradient.inspect})"
+    end
+    offsets = gradient.length == 2 ? %w[0 1] : %w[0 0.5 1]
+    stops = gradient.each_with_index.map { |hex, i| "<stop offset=\"#{offsets[i]}\" stop-color=\"#{hex}\"/>" }.join
+    '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1600 210" preserveAspectRatio="xMidYMid slice">' \
+      "<defs><linearGradient id=\"cg\" x1=\"0\" y1=\"0\" x2=\"1\" y2=\"0.45\">#{stops}</linearGradient>" \
+      "<linearGradient id=\"card-scrim\" x1=\"0\" y1=\"0\" x2=\"0\" y2=\"1\">" \
+      "<stop offset=\"0\" stop-color=\"#000000\" stop-opacity=\"#{CARD_SCRIM_TOP_OPACITY}\"/>" \
+      '<stop offset="1" stop-color="#000000" stop-opacity="0"/></linearGradient></defs>' \
+      '<rect width="1600" height="210" fill="url(#cg)"/><rect width="1600" height="210" fill="url(#card-scrim)"/></svg>'
+  end
+
+  # Wraps a caller-built kpi-chart element (a Hash, e.g. from KpiCard.build)
+  # in a gradient backgroundImage CARD container. Decorate-only, like
+  # `section_card`: `kpi_element` is READ ONLY here (its `id` is read to
+  # build `child_layout`) -- it is never mutated, and `kpi_card.rb` is never
+  # touched. Instead this returns a `patch` Hash the caller MERGES (never
+  # replaces) onto their own copy of three top-level keys on the kpi element:
+  #   kpi_element['value'] = kpi_element['value'].merge(patch['value'])
+  #   kpi_element['name']  = kpi_element['name'].merge(patch['name'])
+  #   kpi_element['style'] = (kpi_element['style'] || {}).merge(patch['style'])
+  # A shallow `Hash#merge` is REQUIRED, not a wholesale replace of the
+  # `value`/`name` hashes -- kpi_element['value'] carries `columnId` (and
+  # optionally `fontSize`) that this patch must not clobber; merge overlays
+  # only the `color` key. `patch['style']` (live-render fix): the KpiCard.build
+  # shape never sets a `style` key of its own, so this is additive, but
+  # callers should still merge rather than assign in case a future
+  # kpi_element does carry one. Turning the value + title white is not
+  # enough by itself -- the KPI element still keeps its own opaque
+  # background, so a live render shows white-on-white; `patch['style']` sets
+  # `backgroundColor: 'transparent'` (letting the gradient card behind show
+  # through) and `padding: 'none'` (edge-to-edge) so the white value/title
+  # are actually legible against the gradient. `gradient:` is OPTIONAL --
+  # it defaults to `DEFAULT_THEME[:card_gradient]` (a dark slate pair), so a
+  # caller with no brand gradient in mind still gets a legible dark card;
+  # pass a caller-specific 2-3 hex-stop array to override it (distinct KPI
+  # cards typically carry distinct gradients). The composed background is
+  # now TWO layers (see compose_card_svg): the gradient rect, then a dark
+  # scrim -- this is what makes the white value/title legible on a
+  # bright/medium gradient too, not just a dark one (live-render fix,
+  # user-reported "can't see the numbers"). `child_layout` is only the
+  # inner `<LayoutElement>` fragment positioning `kpi_element`'s id inside
+  # the container at the Composition kpi-band height (rows 1..7, matching
+  # `Composition.bands`' own `:kpi` role height) -- placing the container
+  # itself on the page is the caller's job (same "decorate, don't own
+  # layout" contract as `section_card`), so no outer `<GridContainer>` is
+  # returned here. NO-GO -> `{element:[],child_layout:'',patch:{}}`
+  # (graceful: nothing to merge, nothing to lay out, never a broken/
+  # half-decorated card).
+  def self.gradient_card(id:, kpi_element:, gradient: DEFAULT_THEME[:card_gradient], page_cols: 24, surfaces: SURFACES)
+    return { element: [], child_layout: '', patch: {} } unless surfaces[:gradient_card]
+
+    bg_url = svg_data_uri(compose_card_svg(gradient))
+    container_el = { 'id' => id, 'kind' => 'container', 'style' => { 'borderRadius' => 'round' },
+                      'backgroundImage' => { 'url' => bg_url, 'style' => { 'fit' => 'cover' } } }
+    child_layout = "<LayoutElement elementId=\"#{kpi_element['id']}\" gridColumn=\"1 / #{page_cols + 1}\" gridRow=\"1 / 7\"/>"
+    patch = { 'value' => { 'color' => '#FFFFFF' }, 'name' => { 'color' => '#FFFFFF' },
+              'style' => { 'backgroundColor' => 'transparent', 'padding' => 'none' } }
+    { element: [container_el], child_layout: child_layout, patch: patch }
+  end
+
+  # Composite in-card sparkline: a separate, borderless mini `line-chart`
+  # element meant to sit BELOW a kpi-chart inside the same `gradient_card`
+  # container -- NOT a date column bound inside the kpi-chart itself (that
+  # in-kpi shape is NO-GO; this standalone line-chart is the live-verified
+  # GO pattern). Two columns: a period dimension (`period_ref`'s formula,
+  # formatted `kind:"datetime"`/`period_format`) and a value (`value_formula`'s
+  # formula). Both axes hide their labels/marks so no chrome competes with
+  # the kpi above it; the y-axis scale is `zero:false` (a small trend doesn't
+  # get flattened against a forced-zero baseline) with `hideZeroLine:true`;
+  # `name`/`legend` are hidden (no title, no legend on a sparkline); the line
+  # uses a smooth `monotone` interpolation; the background is transparent so
+  # the chart blends into the gradient card above/around it. NO-GO ->
+  # `{'opt_in'=>true,'id'=>id}` (never a faked/broken chart shape).
+  def self.sparkline(id:, source_element_id:, period_ref:, value_formula:, period_format: '%b %Y', surfaces: SURFACES)
+    return { 'opt_in' => true, 'id' => id } unless surfaces[:sparkline]
+
+    period_col_id = "#{id}-period"
+    value_col_id = "#{id}-value"
+    {
+      'id' => id,
+      'kind' => 'line-chart',
+      'source' => { 'kind' => 'table', 'elementId' => source_element_id },
+      'columns' => [
+        { 'id' => period_col_id, 'formula' => period_ref, 'name' => 'Period',
+          'format' => { 'kind' => 'datetime', 'formatString' => period_format } },
+        { 'id' => value_col_id, 'formula' => value_formula, 'name' => 'Value' }
+      ],
+      'xAxis' => { 'columnId' => period_col_id, 'format' => { 'marks' => 'none', 'labels' => 'hidden' } },
+      'yAxis' => { 'columnIds' => [value_col_id],
+                    'format' => { 'labels' => 'hidden', 'marks' => 'none',
+                                  'scale' => { 'type' => 'linear', 'zero' => false, 'hideZeroLine' => true } } },
+      'name' => { 'visibility' => 'hidden' },
+      'legend' => { 'visibility' => 'hidden' },
+      'lineAreaStyle' => { 'interpolation' => 'monotone' },
+      'style' => { 'backgroundColor' => 'transparent', 'padding' => 'none' }
+    }
   end
 end

--- a/sigma-workbooks/scripts/lib/test_actions.rb
+++ b/sigma-workbooks/scripts/lib/test_actions.rb
@@ -1,0 +1,221 @@
+# frozen_string_literal: true
+# test_actions.rb — run directly: ruby scripts/lib/test_actions.rb (from sigma-workbooks/)
+require 'json'
+require_relative 'actions'
+$failures = 0
+def check(desc); ok = yield; puts(ok ? "[ok] #{desc}" : "[FAIL] #{desc}"); $failures += 1 unless ok; end
+
+# Deep-sort hashes/arrays so twin/golden comparison is key-order-independent.
+def sort_deep(o)
+  case o
+  when Hash then o.keys.sort.each_with_object({}) { |k, h| h[k] = sort_deep(o[k]) }
+  when Array then o.map { |e| sort_deep(e) }
+  else o
+  end
+end
+
+check('SURFACES: all 4 actions surfaces are GO') do
+  expected = %i[button effects input_table_empty input_table_linked]
+  Actions::SURFACES.keys.sort == expected.sort && Actions::SURFACES.values.all? { |v| v == true }
+end
+
+# --- button -------------------------------------------------------------
+
+check('button: default appearance/trigger + default action_id "a-<id>"') do
+  el = Actions.button(id: 'btn-log', text: 'Log note',
+                       effects: [{ 'effect' => 'insert-rows', 'table' => 'annotations', 'values' => {} }])
+  el == {
+    'id' => 'btn-log', 'kind' => 'button', 'text' => 'Log note', 'appearance' => 'filled',
+    'actions' => [{ 'id' => 'a-btn-log', 'trigger' => 'on-click',
+                    'effects' => [{ 'effect' => 'insert-rows', 'table' => 'annotations', 'values' => {} }] }]
+  }
+end
+check('button: custom appearance + trigger are honored') do
+  el = Actions.button(id: 'btn-reset', text: 'Reset filters', appearance: 'outline', trigger: 'on-load', effects: [])
+  el['appearance'] == 'outline' && el['actions'][0]['trigger'] == 'on-load'
+end
+check('button: explicit action_id: overrides the "a-<id>" default') do
+  el = Actions.button(id: 'btn-reset', text: 'Reset filters', action_id: 'a-reset', effects: [])
+  el['actions'][0]['id'] == 'a-reset'
+end
+check('button: effects array is passed through verbatim (caller builds via effect builders)') do
+  effects = [{ 'effect' => 'insert-rows', 'table' => 't', 'values' => { 'c' => 1 } },
+             { 'effect' => 'clear-control', 'scope' => { 'type' => 'page', 'page' => 'pg' }, 'usePublishedValue' => true }]
+  el = Actions.button(id: 'btn-log', text: 'Log note', effects: effects)
+  el['actions'][0]['effects'] == effects && el['actions'][0]['effects'].length == 2
+end
+check('button: id required') do
+  begin; Actions.button(id: '', text: 'x', effects: []); false
+  rescue ArgumentError; true; end
+end
+check('button: text required') do
+  begin; Actions.button(id: 'btn-x', text: '', effects: []); false
+  rescue ArgumentError; true; end
+end
+check('button: NO-GO surface -> opt-in marker') do
+  el = Actions.button(id: 'btn-log', text: 'Log note', effects: [],
+                       surfaces: Actions::SURFACES.merge(button: false))
+  el == { 'opt_in' => true, 'id' => 'btn-log' }
+end
+
+# --- input_table_empty ---------------------------------------------------
+
+ANNOTATION_COLUMNS = [
+  { 'id' => 'an-note', 'type' => 'text', 'name' => 'Review note' },
+  { 'id' => 'CREATED_AT' }, { 'id' => 'CREATED_BY' }
+].freeze
+
+check('input_table_empty: inputMode:"edit" is present (masked-error fix) + source.kind:"empty"') do
+  el = Actions.input_table_empty(id: 'annotations', connection_id: 'write-conn-1', columns: ANNOTATION_COLUMNS)
+  el == {
+    'id' => 'annotations', 'kind' => 'input-table', 'inputMode' => 'edit',
+    'source' => { 'kind' => 'empty', 'connectionId' => 'write-conn-1' },
+    'columns' => ANNOTATION_COLUMNS
+  }
+end
+check('input_table_empty: name: omitted entirely when not given') do
+  el = Actions.input_table_empty(id: 'annotations', connection_id: 'write-conn-1', columns: ANNOTATION_COLUMNS)
+  !el.key?('name')
+end
+check('input_table_empty: name: passed through verbatim when given') do
+  name = { 'text' => 'Review log (append-only)', 'fontWeight' => 'bold', 'fontSize' => 15, 'color' => '#1A1A1A' }
+  el = Actions.input_table_empty(id: 'annotations', connection_id: 'write-conn-1', columns: ANNOTATION_COLUMNS,
+                                  name: name)
+  el['name'] == name
+end
+check('input_table_empty: id required') do
+  begin; Actions.input_table_empty(id: '', connection_id: 'c', columns: ANNOTATION_COLUMNS); false
+  rescue ArgumentError; true; end
+end
+check('input_table_empty: connection_id required') do
+  begin; Actions.input_table_empty(id: 'x', connection_id: '', columns: ANNOTATION_COLUMNS); false
+  rescue ArgumentError; true; end
+end
+check('input_table_empty: columns required (nil)') do
+  begin; Actions.input_table_empty(id: 'x', connection_id: 'c', columns: nil); false
+  rescue ArgumentError; true; end
+end
+check('input_table_empty: columns required (empty array)') do
+  begin; Actions.input_table_empty(id: 'x', connection_id: 'c', columns: []); false
+  rescue ArgumentError; true; end
+end
+check('input_table_empty: NO-GO surface -> opt-in marker') do
+  el = Actions.input_table_empty(id: 'annotations', connection_id: 'write-conn-1', columns: ANNOTATION_COLUMNS,
+                                  surfaces: Actions::SURFACES.merge(input_table_empty: false))
+  el == { 'opt_in' => true, 'id' => 'annotations' }
+end
+
+# --- input_table_linked ---------------------------------------------------
+
+TARGET_COLUMNS = [
+  { 'id' => 'tg-fam', 'key' => 'fp-fam' },
+  { 'id' => 'tg-actual', 'key' => 'fp-rev', 'name' => 'Actual Revenue' },
+  { 'id' => 'tg-target', 'type' => 'number', 'name' => 'Target Revenue' },
+  { 'id' => 'tg-var', 'name' => 'Variance vs Target', 'formula' => '[Actual Revenue] - [Target Revenue]' }
+].freeze
+
+check('input_table_linked: source.kind:"linked" carries from + connectionId') do
+  el = Actions.input_table_linked(id: 'targets', from: 'fam-pivot', connection_id: 'write-conn-1',
+                                   columns: TARGET_COLUMNS)
+  el == {
+    'id' => 'targets', 'kind' => 'input-table', 'inputMode' => 'edit',
+    'source' => { 'kind' => 'linked', 'from' => 'fam-pivot', 'connectionId' => 'write-conn-1' },
+    'columns' => TARGET_COLUMNS
+  }
+end
+check('input_table_linked: id required') do
+  begin; Actions.input_table_linked(id: '', from: 'f', connection_id: 'c', columns: TARGET_COLUMNS); false
+  rescue ArgumentError; true; end
+end
+check('input_table_linked: from required') do
+  begin; Actions.input_table_linked(id: 'x', from: '', connection_id: 'c', columns: TARGET_COLUMNS); false
+  rescue ArgumentError; true; end
+end
+check('input_table_linked: connection_id required') do
+  begin; Actions.input_table_linked(id: 'x', from: 'f', connection_id: '', columns: TARGET_COLUMNS); false
+  rescue ArgumentError; true; end
+end
+check('input_table_linked: columns required (empty array)') do
+  begin; Actions.input_table_linked(id: 'x', from: 'f', connection_id: 'c', columns: []); false
+  rescue ArgumentError; true; end
+end
+check('input_table_linked: NO-GO surface -> opt-in marker') do
+  el = Actions.input_table_linked(id: 'targets', from: 'fam-pivot', connection_id: 'write-conn-1',
+                                   columns: TARGET_COLUMNS,
+                                   surfaces: Actions::SURFACES.merge(input_table_linked: false))
+  el == { 'opt_in' => true, 'id' => 'targets' }
+end
+
+# --- effect builders -------------------------------------------------------
+
+check('insert_rows_effect: {effect, table, values} — values passed through verbatim') do
+  values = { 'an-note' => { 'type' => 'control', 'control' => 'NoteCtl' } }
+  Actions.insert_rows_effect(table: 'annotations', values: values) ==
+    { 'effect' => 'insert-rows', 'table' => 'annotations', 'values' => values }
+end
+check('insert_rows_effect: table required') do
+  begin; Actions.insert_rows_effect(table: '', values: {}); false
+  rescue ArgumentError; true; end
+end
+check('insert_rows_effect: NO-GO surface -> {}') do
+  Actions.insert_rows_effect(table: 'annotations', values: {},
+                              surfaces: Actions::SURFACES.merge(effects: false)) == {}
+end
+
+check('clear_control_effect: {effect, scope:{type:page,page}, usePublishedValue:true}') do
+  Actions.clear_control_effect(page: 'pg') ==
+    { 'effect' => 'clear-control', 'scope' => { 'type' => 'page', 'page' => 'pg' }, 'usePublishedValue' => true }
+end
+check('clear_control_effect: page required') do
+  begin; Actions.clear_control_effect(page: ''); false
+  rescue ArgumentError; true; end
+end
+check('clear_control_effect: NO-GO surface -> {}') do
+  Actions.clear_control_effect(page: 'pg', surfaces: Actions::SURFACES.merge(effects: false)) == {}
+end
+
+check('set_control_value_effect: {effect, control, value:{type:constant,value:{type:text,value}}}') do
+  Actions.set_control_value_effect(control: 'RegionF', text: 'West') ==
+    { 'effect' => 'set-control-value', 'control' => 'RegionF',
+      'value' => { 'type' => 'constant', 'value' => { 'type' => 'text', 'value' => 'West' } } }
+end
+check('set_control_value_effect: control required') do
+  begin; Actions.set_control_value_effect(control: '', text: 'West'); false
+  rescue ArgumentError; true; end
+end
+check('set_control_value_effect: text required') do
+  begin; Actions.set_control_value_effect(control: 'RegionF', text: ''); false
+  rescue ArgumentError; true; end
+end
+check('set_control_value_effect: NO-GO surface -> {}') do
+  Actions.set_control_value_effect(control: 'RegionF', text: 'West',
+                                    surfaces: Actions::SURFACES.merge(effects: false)) == {}
+end
+
+# --- golden ------------------------------------------------------------------
+
+golden = JSON.parse(File.read(File.join(__dir__, 'testdata', 'actions_golden.json')))
+check('helpers match actions_golden.json (sorted-key identical)') do
+  button_effects = [
+    Actions.insert_rows_effect(table: 'annotations',
+                                values: { 'an-note' => { 'type' => 'control', 'control' => 'NoteCtl' } }),
+    Actions.clear_control_effect(page: 'pg')
+  ]
+  actual = {
+    'button' => Actions.button(id: 'btn-log', text: 'Log note', appearance: 'filled', effects: button_effects),
+    'input_table_empty' => Actions.input_table_empty(
+      id: 'annotations', connection_id: 'write-conn-1', columns: ANNOTATION_COLUMNS,
+      name: { 'text' => 'Review log (append-only)', 'fontWeight' => 'bold', 'fontSize' => 15, 'color' => '#1A1A1A' }
+    ),
+    'input_table_linked' => Actions.input_table_linked(id: 'targets', from: 'fam-pivot',
+                                                        connection_id: 'write-conn-1', columns: TARGET_COLUMNS),
+    'insert_rows_effect' => Actions.insert_rows_effect(
+      table: 'annotations', values: { 'an-note' => { 'type' => 'control', 'control' => 'NoteCtl' } }
+    ),
+    'clear_control_effect' => Actions.clear_control_effect(page: 'pg'),
+    'set_control_value_effect' => Actions.set_control_value_effect(control: 'RegionF', text: 'West')
+  }
+  JSON.generate(sort_deep(actual)) == JSON.generate(sort_deep(golden))
+end
+
+exit($failures.zero? ? 0 : 1)

--- a/sigma-workbooks/scripts/lib/test_richness.rb
+++ b/sigma-workbooks/scripts/lib/test_richness.rb
@@ -14,8 +14,8 @@ def sort_deep(o)
   end
 end
 
-check('SURFACES: all 4 richness surfaces are GO') do
-  expected = %i[ai_insight dynamic_grain filter_row wide_pivot]
+check('SURFACES: all 5 richness surfaces are GO') do
+  expected = %i[agent ai_insight dynamic_grain filter_row wide_pivot]
   Richness::SURFACES.keys.sort == expected.sort && Richness::SURFACES.values.all? { |v| v == true }
 end
 
@@ -197,11 +197,80 @@ check('wide_pivot: NO-GO surface -> opt-in marker') do
   piv == { 'opt_in' => true, 'id' => 'piv-1' }
 end
 
+# --- agent / chat -------------------------------------------------------------
+
+AGENT_TOOLS = [
+  { 'toolId' => 't-log-note', 'kind' => 'action', 'name' => 'Log note', 'description' => 'Insert a review note.',
+    'steps' => [{ 'kind' => 'effect', 'effect' => 'insert-rows', 'table' => 'annotations',
+                  'value' => { 'type' => 'agent-input', 'inputName' => 'note' } }] }
+].freeze
+
+check('agent: read-only analyst (tools: []) OMITS the tools key entirely') do
+  el = Richness.agent(id: 'ag-1', name: 'Analyst', instructions: 'Be a helpful retail analyst.',
+                       data_source_ids: ['src'])
+  el == {
+    'id' => 'ag-1', 'name' => 'Analyst', 'instructions' => 'Be a helpful retail analyst.',
+    'dataSources' => [{ 'kind' => 'table', 'elementId' => 'src' }]
+  } && !el.key?('tools')
+end
+check('agent: multiple data_source_ids map to multiple dataSources entries, in order') do
+  el = Richness.agent(id: 'ag-1', name: 'Analyst', instructions: 'x', data_source_ids: %w[src-a src-b])
+  el['dataSources'] == [{ 'kind' => 'table', 'elementId' => 'src-a' }, { 'kind' => 'table', 'elementId' => 'src-b' }]
+end
+check('agent: non-empty tools: is added verbatim') do
+  el = Richness.agent(id: 'ag-2', name: 'Assistant', instructions: 'Act on my behalf.',
+                       data_source_ids: ['src'], tools: AGENT_TOOLS)
+  el['tools'] == AGENT_TOOLS && el.key?('tools')
+end
+check('agent: id required') do
+  begin
+    Richness.agent(id: '', name: 'A', instructions: 'x', data_source_ids: ['src']); false
+  rescue ArgumentError; true; end
+end
+check('agent: name required') do
+  begin
+    Richness.agent(id: 'ag-1', name: '', instructions: 'x', data_source_ids: ['src']); false
+  rescue ArgumentError; true; end
+end
+check('agent: instructions required') do
+  begin
+    Richness.agent(id: 'ag-1', name: 'A', instructions: '', data_source_ids: ['src']); false
+  rescue ArgumentError; true; end
+end
+check('agent: NO-GO surface -> opt-in marker, never a faked agent') do
+  el = Richness.agent(id: 'ag-1', name: 'A', instructions: 'x', data_source_ids: ['src'],
+                       surfaces: Richness::SURFACES.merge(agent: false))
+  el == { 'opt_in' => true, 'id' => 'ag-1' }
+end
+
+check('chat: {id, kind: chat, agentId} shape') do
+  Richness.chat(id: 'chat-1', agent_id: 'ag-1') == { 'id' => 'chat-1', 'kind' => 'chat', 'agentId' => 'ag-1' }
+end
+check('chat: id required') do
+  begin
+    Richness.chat(id: '', agent_id: 'ag-1'); false
+  rescue ArgumentError; true; end
+end
+check('chat: agent_id required') do
+  begin
+    Richness.chat(id: 'chat-1', agent_id: ''); false
+  rescue ArgumentError; true; end
+end
+check('chat: NO-GO surface -> opt-in marker, never a faked chat element') do
+  el = Richness.chat(id: 'chat-1', agent_id: 'ag-1', surfaces: Richness::SURFACES.merge(agent: false))
+  el == { 'opt_in' => true, 'id' => 'chat-1' }
+end
+
 # --- golden ------------------------------------------------------------------
 
 golden = JSON.parse(File.read(File.join(__dir__, 'testdata', 'richness_golden.json')))
 check('helpers match richness_golden.json (sorted-key identical)') do
   actual = {
+    'agent' => Richness.agent(id: 'ag-1', name: 'Analyst', instructions: 'Be a helpful retail analyst.',
+                               data_source_ids: ['src']),
+    'agent_with_tools' => Richness.agent(id: 'ag-2', name: 'Assistant', instructions: 'Act on my behalf.',
+                                          data_source_ids: ['src'], tools: AGENT_TOOLS),
+    'chat' => Richness.chat(id: 'chat-1', agent_id: 'ag-1'),
     'ai_insight' => Richness.ai_insight(id: 'ai-rev', prompt: 'Summarize revenue trends for the period.'),
     'ai_insight_custom_model' => Richness.ai_insight(id: 'ai-rev2', model: 'mistral-large2',
                                                       prompt: 'Say one nice thing about the data.'),

--- a/sigma-workbooks/scripts/lib/test_styling.rb
+++ b/sigma-workbooks/scripts/lib/test_styling.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 # test_styling.rb — run directly: ruby scripts/lib/test_styling.rb (from sigma-workbooks/)
 require 'json'
+require 'base64'
 require_relative 'styling'
 require_relative 'composition'
 $failures = 0
@@ -84,8 +85,9 @@ end
 
 # --- chart_color, kpi_accent, format_for, header, section_card ---
 
-check('SURFACES: all 6 verified surfaces are GO') do
-  expected = %i[categorical_scheme chart_color_by container_style format_string kpi_name_color typography]
+check('SURFACES: all 10 verified surfaces are GO') do
+  expected = %i[categorical_scheme chart_color_by container_style format_string kpi_name_color typography
+                gradient_header motif gradient_card sparkline]
   Styling::SURFACES.keys.sort == expected.sort && Styling::SURFACES.values.all? { |v| v == true }
 end
 
@@ -158,6 +160,231 @@ check('section_card: NO-GO container_style returns bare band render, no containe
   sc[:element].nil? && !sc[:wrap].include?('GridContainer') && sc[:wrap].scan('<LayoutElement').length == 2
 end
 
+# --- Styling::MOTIFS + Styling.gradient_header ---
+
+check('DEFAULT_THEME[:header_gradient] is a neutral 2-3 stop hex gradient, not red') do
+  hg = Styling::DEFAULT_THEME[:header_gradient]
+  hg.is_a?(Array) && [2, 3].include?(hg.length) && hg.all? { |h| h =~ /\A#[0-9A-Fa-f]{6}\z/ } &&
+    !hg.include?('#E4002B') && !hg.include?('#FF0000')
+end
+
+check('MOTIFS: exactly the 6 menu keys') do
+  Styling::MOTIFS.keys.sort == %i[dots glow grid none rings waves].sort
+end
+
+check('MOTIFS: glow/rings/grid/waves/dots each return a non-empty deterministic SVG fragment') do
+  %i[glow rings grid waves dots].all? do |k|
+    frag = Styling::MOTIFS[k].call
+    frag.is_a?(String) && !frag.empty? && frag == Styling::MOTIFS[k].call
+  end
+end
+check('MOTIFS: :none returns an empty string') do
+  Styling::MOTIFS[:none].call == ''
+end
+
+check('gradient_header (default :glow, :right): container has data-URI SVG backgroundImage + title element + GridContainer layout') do
+  h = Styling.gradient_header(id: 'ghdr', title: 'Command Center')
+  bg = h[:element][0]
+  bg['kind'] == 'container' && bg['style'] == { 'borderRadius' => 'round' } &&
+    bg['backgroundImage']['url'].start_with?('data:image/svg+xml;base64,') &&
+    bg['backgroundImage']['style'] == { 'fit' => 'cover' } &&
+    h[:element].any? { |e| e['kind'] == 'text' && e['id'] == 'ghdr-title' } &&
+    h[:layout].include?('<GridContainer') && h[:layout].include?('elementId="ghdr-title"')
+end
+
+check('gradient_header: decoded SVG carries the linearGradient + the requested motif group') do
+  h = Styling.gradient_header(id: 'ghdr', title: 'X', motif: :rings)
+  svg = Base64.decode64(h[:element][0]['backgroundImage']['url'].sub('data:image/svg+xml;base64,', ''))
+  svg.include?('linearGradient') && svg.include?('<circle r="40"/>') && svg.include?('<g transform="translate(1440,86)">')
+end
+
+check('gradient_header motif :none: no motif <g> group in the decoded SVG') do
+  h = Styling.gradient_header(id: 'ghdr', title: 'X', motif: :none)
+  svg = Base64.decode64(h[:element][0]['backgroundImage']['url'].sub('data:image/svg+xml;base64,', ''))
+  !svg.include?('<g transform=')
+end
+
+check('gradient_header motif_side: :left translates the motif group to x=160') do
+  h = Styling.gradient_header(id: 'ghdr', title: 'X', motif: :rings, motif_side: :left)
+  svg = Base64.decode64(h[:element][0]['backgroundImage']['url'].sub('data:image/svg+xml;base64,', ''))
+  svg.include?('translate(160,86)')
+end
+
+check('gradient_header: logo_url present -> logo element + logo/title split layout (logo col 1/3)') do
+  h = Styling.gradient_header(id: 'ghdr', title: 'X', logo_url: 'https://example.com/logo.png')
+  h[:element].length == 3 &&
+    h[:element][1] == { 'id' => 'ghdr-logo', 'kind' => 'image', 'url' => 'https://example.com/logo.png',
+                         'style' => { 'fit' => 'contain' } } &&
+    h[:layout].include?('elementId="ghdr-logo" gridColumn="1 / 3"') &&
+    h[:layout].include?('elementId="ghdr-title" gridColumn="3 / 25"')
+end
+
+check('gradient_header: no logo_url -> title spans full width, no logo element') do
+  h = Styling.gradient_header(id: 'ghdr', title: 'X')
+  h[:element].none? { |e| e['kind'] == 'image' } &&
+    h[:layout].include?('elementId="ghdr-title" gridColumn="1 / 25"')
+end
+
+check('gradient_header: subtitle -> separate subtitle text element + split layout rows') do
+  h = Styling.gradient_header(id: 'ghdr', title: 'X', subtitle: 'Sub')
+  h[:element].length == 3 &&
+    h[:element][2]['kind'] == 'text' && h[:element][2]['id'] == 'ghdr-subtitle' &&
+    h[:element][2]['body'].include?('Sub') &&
+    h[:layout].include?('elementId="ghdr-title" gridColumn="1 / 25" gridRow="1 / 3"') &&
+    h[:layout].include?('elementId="ghdr-subtitle" gridColumn="1 / 25" gridRow="3 / 4"')
+end
+
+check('gradient_header: bring-your-own http(s) URL used verbatim, SVG compose skipped') do
+  h = Styling.gradient_header(id: 'ghdr', title: 'X', motif: 'https://example.com/art.png')
+  h[:element][0]['backgroundImage']['url'] == 'https://example.com/art.png'
+end
+check('gradient_header: bring-your-own data: URL used verbatim') do
+  uri = 'data:image/png;base64,AAAA'
+  h = Styling.gradient_header(id: 'ghdr', title: 'X', motif: uri)
+  h[:element][0]['backgroundImage']['url'] == uri
+end
+
+check('gradient_header: gradient with != 2-3 stops raises ArgumentError') do
+  begin
+    Styling.gradient_header(id: 'ghdr', title: 'X', gradient: ['#111111'])
+    false
+  rescue ArgumentError
+    true
+  end
+end
+
+check('gradient_header: NO-GO gradient_header surface falls back to flat Styling.header output') do
+  surfaces = Styling::SURFACES.merge(gradient_header: false)
+  h = Styling.gradient_header(id: 'ghdr', title: 'X', surfaces: surfaces)
+  expected = Styling.header(id: 'ghdr', title: 'X', theme: Styling::DEFAULT_THEME, surfaces: surfaces)
+  h == expected
+end
+
+check('gradient_header: NO-GO motif surface + menu-key motif falls back to the plain gradient (:none)') do
+  surfaces = Styling::SURFACES.merge(motif: false)
+  h = Styling.gradient_header(id: 'ghdr', title: 'X', motif: :rings, surfaces: surfaces)
+  bg = h[:element][0]['backgroundImage']['url']
+  svg = Base64.decode64(bg.sub('data:image/svg+xml;base64,', ''))
+  bg.start_with?('data:image/svg+xml;base64,') && svg.include?('linearGradient') && !svg.include?('<g transform=')
+end
+
+check('gradient_header: NO-GO motif surface does NOT suppress a bring-your-own URL (honored verbatim)') do
+  surfaces = Styling::SURFACES.merge(motif: false)
+  h = Styling.gradient_header(id: 'ghdr', title: 'X', motif: 'https://example.com/art.png', surfaces: surfaces)
+  h[:element][0]['backgroundImage']['url'] == 'https://example.com/art.png'
+end
+
+check('gradient_header motif_side: :center translates the motif group to x=800 and produces a valid header') do
+  h = Styling.gradient_header(id: 'ghdr', title: 'X', motif: :rings, motif_side: :center)
+  svg = Base64.decode64(h[:element][0]['backgroundImage']['url'].sub('data:image/svg+xml;base64,', ''))
+  svg.include?('translate(800,86)') &&
+    h[:element].any? { |e| e['kind'] == 'text' && e['id'] == 'ghdr-title' } &&
+    h[:layout].include?('<GridContainer') && h[:layout].include?('elementId="ghdr-title"')
+end
+
+check('gradient_header: unrecognized motif symbol raises ArgumentError') do
+  begin
+    Styling.gradient_header(id: 'ghdr', title: 'X', motif: :sparkles)
+    false
+  rescue ArgumentError
+    true
+  end
+end
+
+# --- Styling.gradient_card + Styling.sparkline ---
+
+GC_KPI_EL = { 'id' => 'kpi-rev', 'kind' => 'kpi-chart', 'name' => { 'text' => 'Revenue' },
+              'value' => { 'columnId' => 'rev-cur' } }.freeze
+
+check('gradient_card: GO returns a gradient container + child_layout positioning the kpi + a white-text patch') do
+  gc = Styling.gradient_card(id: 'card-1', kpi_element: GC_KPI_EL, gradient: %w[#0F172A #2563EB])
+  gc[:element].length == 1 &&
+    gc[:element][0]['id'] == 'card-1' && gc[:element][0]['kind'] == 'container' &&
+    gc[:element][0]['style'] == { 'borderRadius' => 'round' } &&
+    gc[:element][0]['backgroundImage']['url'].start_with?('data:image/svg+xml;base64,') &&
+    gc[:element][0]['backgroundImage']['style'] == { 'fit' => 'cover' } &&
+    gc[:child_layout] == '<LayoutElement elementId="kpi-rev" gridColumn="1 / 25" gridRow="1 / 7"/>' &&
+    gc[:patch] == { 'value' => { 'color' => '#FFFFFF' }, 'name' => { 'color' => '#FFFFFF' },
+                    'style' => { 'backgroundColor' => 'transparent', 'padding' => 'none' } }
+end
+
+check('gradient_card: patch style makes the KPI transparent + padding:none so white text is legible on the gradient (live-render fix)') do
+  gc = Styling.gradient_card(id: 'card-1', kpi_element: GC_KPI_EL, gradient: %w[#0F172A #2563EB])
+  gc[:patch]['style'] == { 'backgroundColor' => 'transparent', 'padding' => 'none' }
+end
+
+check('gradient_card: decoded SVG carries the linearGradient stops (motif: :none -- no motif group)') do
+  gc = Styling.gradient_card(id: 'card-1', kpi_element: GC_KPI_EL, gradient: %w[#0F172A #2563EB])
+  svg = Base64.decode64(gc[:element][0]['backgroundImage']['url'].sub('data:image/svg+xml;base64,', ''))
+  svg.include?('linearGradient') && !svg.include?('<g transform=')
+end
+
+check('gradient_card: composed SVG layers a dark scrim (id="card-scrim") over the caller gradient so white ' \
+      'KPI text stays legible on any gradient, bright or dark (live-render fix, user-reported)') do
+  gc = Styling.gradient_card(id: 'card-1', kpi_element: GC_KPI_EL, gradient: %w[#0F172A #2563EB])
+  svg = Base64.decode64(gc[:element][0]['backgroundImage']['url'].sub('data:image/svg+xml;base64,', ''))
+  svg.include?('id="card-scrim"') &&
+    svg.include?("stop-opacity=\"#{Styling::CARD_SCRIM_TOP_OPACITY}\"") &&
+    svg.include?('stop-opacity="0"') &&
+    svg.scan('<rect ').length == 2 # the caller's gradient rect, THEN the scrim rect on top
+end
+
+check('gradient_card: gradient: can be omitted -- defaults to DEFAULT_THEME[:card_gradient] (a dark slate pair)') do
+  gc = Styling.gradient_card(id: 'card-1', kpi_element: GC_KPI_EL)
+  svg = Base64.decode64(gc[:element][0]['backgroundImage']['url'].sub('data:image/svg+xml;base64,', ''))
+  default_gradient = Styling::DEFAULT_THEME[:card_gradient]
+  svg.include?(default_gradient[0]) && svg.include?(default_gradient[1])
+end
+
+check('gradient_card: does NOT mutate the passed kpi_element hash') do
+  kpi_el = { 'id' => 'kpi-rev2', 'kind' => 'kpi-chart', 'name' => { 'text' => 'Revenue' },
+             'value' => { 'columnId' => 'rev-cur', 'fontSize' => 32 } }
+  snapshot = Marshal.load(Marshal.dump(kpi_el))
+  Styling.gradient_card(id: 'card-2', kpi_element: kpi_el, gradient: %w[#0F172A #2563EB])
+  kpi_el == snapshot
+end
+
+check('gradient_card: respects a custom page_cols in child_layout gridColumn span') do
+  gc = Styling.gradient_card(id: 'card-1', kpi_element: GC_KPI_EL, gradient: %w[#0F172A #2563EB], page_cols: 12)
+  gc[:child_layout] == '<LayoutElement elementId="kpi-rev" gridColumn="1 / 13" gridRow="1 / 7"/>'
+end
+
+check('gradient_card: NO-GO gradient_card surface -> empty element/child_layout/patch, no crash') do
+  surfaces = Styling::SURFACES.merge(gradient_card: false)
+  gc = Styling.gradient_card(id: 'card-1', kpi_element: GC_KPI_EL, gradient: %w[#0F172A #2563EB], surfaces: surfaces)
+  gc == { element: [], child_layout: '', patch: {} }
+end
+
+check('sparkline: GO returns a borderless line-chart with hidden axes/legend/name + transparent bg + datetime format') do
+  sp = Styling.sparkline(id: 'spark-rev', source_element_id: 'tbl', period_ref: '[Table/Month]',
+                          value_formula: 'Sum([Table/Revenue])')
+  sp['id'] == 'spark-rev' && sp['kind'] == 'line-chart' &&
+    sp['source'] == { 'kind' => 'table', 'elementId' => 'tbl' } &&
+    sp['columns'].length == 2 &&
+    sp['columns'][0]['formula'] == '[Table/Month]' &&
+    sp['columns'][0]['format'] == { 'kind' => 'datetime', 'formatString' => '%b %Y' } &&
+    sp['columns'][1]['formula'] == 'Sum([Table/Revenue])' &&
+    sp['xAxis']['format'] == { 'marks' => 'none', 'labels' => 'hidden' } &&
+    sp['yAxis']['format']['labels'] == 'hidden' && sp['yAxis']['format']['marks'] == 'none' &&
+    sp['yAxis']['format']['scale'] == { 'type' => 'linear', 'zero' => false, 'hideZeroLine' => true } &&
+    sp['name'] == { 'visibility' => 'hidden' } && sp['legend'] == { 'visibility' => 'hidden' } &&
+    sp['lineAreaStyle'] == { 'interpolation' => 'monotone' } &&
+    sp['style'] == { 'backgroundColor' => 'transparent', 'padding' => 'none' }
+end
+
+check('sparkline: custom period_format flows into the period column format') do
+  sp = Styling.sparkline(id: 'spark-rev', source_element_id: 'tbl', period_ref: '[Table/Month]',
+                          value_formula: 'Sum([Table/Revenue])', period_format: '%Y-%m')
+  sp['columns'][0]['format'] == { 'kind' => 'datetime', 'formatString' => '%Y-%m' }
+end
+
+check('sparkline: NO-GO sparkline surface -> opt_in marker, never a broken chart shape') do
+  surfaces = Styling::SURFACES.merge(sparkline: false)
+  sp = Styling.sparkline(id: 'spark-rev', source_element_id: 'tbl', period_ref: '[Table/Month]',
+                          value_formula: 'Sum([Table/Revenue])', surfaces: surfaces)
+  sp == { 'opt_in' => true, 'id' => 'spark-rev' }
+end
+
 golden = JSON.parse(File.read(File.join(__dir__, 'testdata', 'styling_golden.json')))
 check('helpers match styling_golden.json (sorted-key identical)') do
   theme = Styling::DEFAULT_THEME
@@ -171,7 +398,15 @@ check('helpers match styling_golden.json (sorted-key identical)') do
     'format_for_percent' => Styling.format_for(:percent),
     'format_for_decimal' => Styling.format_for(:decimal),
     'header' => Styling.header(id: 'hdr', title: 'Dashboard', theme: theme),
-    'section_card' => Styling.section_card(id: 'card-1', band: band, theme: theme)
+    'section_card' => Styling.section_card(id: 'card-1', band: band, theme: theme),
+    'gradient_header_glow' => Styling.gradient_header(id: 'ghdr', title: 'Command Center', subtitle: 'Live metrics',
+                                                        logo_url: 'https://example.com/logo.png'),
+    'gradient_header_rings_left' => Styling.gradient_header(id: 'ghdr2', title: 'Ops', motif: :rings, motif_side: :left),
+    'gradient_header_none' => Styling.gradient_header(id: 'ghdr3', title: 'Plain', motif: :none),
+    'gradient_header_byo' => Styling.gradient_header(id: 'ghdr4', title: 'Custom', motif: 'https://example.com/art.png'),
+    'gradient_card' => Styling.gradient_card(id: 'card-1', kpi_element: GC_KPI_EL, gradient: %w[#0F172A #2563EB]),
+    'sparkline' => Styling.sparkline(id: 'spark-rev', source_element_id: 'tbl', period_ref: '[Table/Month]',
+                                      value_formula: 'Sum([Table/Revenue])')
   }
   JSON.generate(sort_deep(actual)) == JSON.generate(sort_deep(golden))
 end

--- a/sigma-workbooks/scripts/lib/testdata/actions_golden.json
+++ b/sigma-workbooks/scripts/lib/testdata/actions_golden.json
@@ -1,0 +1,122 @@
+{
+  "button": {
+    "id": "btn-log",
+    "kind": "button",
+    "text": "Log note",
+    "appearance": "filled",
+    "actions": [
+      {
+        "id": "a-btn-log",
+        "trigger": "on-click",
+        "effects": [
+          {
+            "effect": "insert-rows",
+            "table": "annotations",
+            "values": {
+              "an-note": {
+                "type": "control",
+                "control": "NoteCtl"
+              }
+            }
+          },
+          {
+            "effect": "clear-control",
+            "scope": {
+              "type": "page",
+              "page": "pg"
+            },
+            "usePublishedValue": true
+          }
+        ]
+      }
+    ]
+  },
+  "input_table_empty": {
+    "id": "annotations",
+    "kind": "input-table",
+    "inputMode": "edit",
+    "source": {
+      "kind": "empty",
+      "connectionId": "write-conn-1"
+    },
+    "columns": [
+      {
+        "id": "an-note",
+        "type": "text",
+        "name": "Review note"
+      },
+      {
+        "id": "CREATED_AT"
+      },
+      {
+        "id": "CREATED_BY"
+      }
+    ],
+    "name": {
+      "text": "Review log (append-only)",
+      "fontWeight": "bold",
+      "fontSize": 15,
+      "color": "#1A1A1A"
+    }
+  },
+  "input_table_linked": {
+    "id": "targets",
+    "kind": "input-table",
+    "inputMode": "edit",
+    "source": {
+      "kind": "linked",
+      "from": "fam-pivot",
+      "connectionId": "write-conn-1"
+    },
+    "columns": [
+      {
+        "id": "tg-fam",
+        "key": "fp-fam"
+      },
+      {
+        "id": "tg-actual",
+        "key": "fp-rev",
+        "name": "Actual Revenue"
+      },
+      {
+        "id": "tg-target",
+        "type": "number",
+        "name": "Target Revenue"
+      },
+      {
+        "id": "tg-var",
+        "name": "Variance vs Target",
+        "formula": "[Actual Revenue] - [Target Revenue]"
+      }
+    ]
+  },
+  "insert_rows_effect": {
+    "effect": "insert-rows",
+    "table": "annotations",
+    "values": {
+      "an-note": {
+        "type": "control",
+        "control": "NoteCtl"
+      }
+    }
+  },
+  "clear_control_effect": {
+    "effect": "clear-control",
+    "scope": {
+      "type": "page",
+      "page": "pg"
+    },
+    "usePublishedValue": true
+  },
+  "set_control_value_effect": {
+    "effect": "set-control-value",
+    "control": "RegionF",
+    "value": {
+      "type": "constant",
+      "value": {
+        "type": "text",
+        "value": "West"
+      }
+    }
+  }
+}

--- a/sigma-workbooks/scripts/lib/testdata/richness_golden.json
+++ b/sigma-workbooks/scripts/lib/testdata/richness_golden.json
@@ -1,4 +1,45 @@
 {
+  "agent": {
+    "id": "ag-1",
+    "name": "Analyst",
+    "instructions": "Be a helpful retail analyst.",
+    "dataSources": [
+      {
+        "kind": "table",
+        "elementId": "src"
+      }
+    ]
+  },
+  "agent_with_tools": {
+    "id": "ag-2",
+    "name": "Assistant",
+    "instructions": "Act on my behalf.",
+    "dataSources": [
+      {
+        "kind": "table",
+        "elementId": "src"
+      }
+    ],
+    "tools": [
+      {
+        "toolId": "t-log-note",
+        "kind": "action",
+        "name": "Log note",
+        "description": "Insert a review note.",
+        "steps": [
+          {
+            "kind": "effect",
+            "effect": "insert-rows",
+            "table": "annotations",
+            "value": {
+              "type": "agent-input",
+              "inputName": "note"
+            }
+          }
+        ]
+      }
+    ]
+  },
   "ai_insight": {
     "body": "{{ Replace(CallText(\"SNOWFLAKE.CORTEX.COMPLETE\", \"llama3.1-8b\", \"Summarize revenue trends for the period.\") , '\"', \"\") }}",
     "id": "ai-rev",
@@ -8,6 +49,11 @@
     "body": "{{ Replace(CallText(\"SNOWFLAKE.CORTEX.COMPLETE\", \"mistral-large2\", \"Say one nice thing about the data.\") , '\"', \"\") }}",
     "id": "ai-rev2",
     "kind": "text"
+  },
+  "chat": {
+    "id": "chat-1",
+    "kind": "chat",
+    "agentId": "ag-1"
   },
   "filter_row": [
     {

--- a/sigma-workbooks/scripts/lib/testdata/styling_golden.json
+++ b/sigma-workbooks/scripts/lib/testdata/styling_golden.json
@@ -35,6 +35,146 @@
     "formatString": ".1%",
     "kind": "number"
   },
+  "gradient_card": {
+    "element": [
+      {
+        "id": "card-1",
+        "kind": "container",
+        "style": {
+          "borderRadius": "round"
+        },
+        "backgroundImage": {
+          "url": "data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAxNjAwIDIxMCIgcHJlc2VydmVBc3BlY3RSYXRpbz0ieE1pZFlNaWQgc2xpY2UiPjxkZWZzPjxsaW5lYXJHcmFkaWVudCBpZD0iY2ciIHgxPSIwIiB5MT0iMCIgeDI9IjEiIHkyPSIwLjQ1Ij48c3RvcCBvZmZzZXQ9IjAiIHN0b3AtY29sb3I9IiMwRjE3MkEiLz48c3RvcCBvZmZzZXQ9IjEiIHN0b3AtY29sb3I9IiMyNTYzRUIiLz48L2xpbmVhckdyYWRpZW50PjxsaW5lYXJHcmFkaWVudCBpZD0iY2FyZC1zY3JpbSIgeDE9IjAiIHkxPSIwIiB4Mj0iMCIgeTI9IjEiPjxzdG9wIG9mZnNldD0iMCIgc3RvcC1jb2xvcj0iIzAwMDAwMCIgc3RvcC1vcGFjaXR5PSIwLjU1Ii8+PHN0b3Agb2Zmc2V0PSIxIiBzdG9wLWNvbG9yPSIjMDAwMDAwIiBzdG9wLW9wYWNpdHk9IjAiLz48L2xpbmVhckdyYWRpZW50PjwvZGVmcz48cmVjdCB3aWR0aD0iMTYwMCIgaGVpZ2h0PSIyMTAiIGZpbGw9InVybCgjY2cpIi8+PHJlY3Qgd2lkdGg9IjE2MDAiIGhlaWdodD0iMjEwIiBmaWxsPSJ1cmwoI2NhcmQtc2NyaW0pIi8+PC9zdmc+",
+          "style": {
+            "fit": "cover"
+          }
+        }
+      }
+    ],
+    "child_layout": "<LayoutElement elementId=\"kpi-rev\" gridColumn=\"1 / 25\" gridRow=\"1 / 7\"/>",
+    "patch": {
+      "value": {
+        "color": "#FFFFFF"
+      },
+      "name": {
+        "color": "#FFFFFF"
+      },
+      "style": {
+        "backgroundColor": "transparent",
+        "padding": "none"
+      }
+    }
+  },
+  "gradient_header_byo": {
+    "element": [
+      {
+        "id": "ghdr4-bg",
+        "kind": "container",
+        "style": {
+          "borderRadius": "round"
+        },
+        "backgroundImage": {
+          "url": "https://example.com/art.png",
+          "style": {
+            "fit": "cover"
+          }
+        }
+      },
+      {
+        "id": "ghdr4-title",
+        "kind": "text",
+        "verticalAlign": "middle",
+        "body": "# <span style=\"color: #FFFFFF\">Custom</span>"
+      }
+    ],
+    "layout": "<GridContainer elementId=\"ghdr4-bg\" type=\"grid\" gridColumn=\"1 / 25\" gridRow=\"1 / 4\" gridTemplateColumns=\"repeat(24, 1fr)\" gridTemplateRows=\"auto\">\n  <LayoutElement elementId=\"ghdr4-title\" gridColumn=\"1 / 25\" gridRow=\"1 / 4\"/>\n</GridContainer>"
+  },
+  "gradient_header_glow": {
+    "element": [
+      {
+        "id": "ghdr-bg",
+        "kind": "container",
+        "style": {
+          "borderRadius": "round"
+        },
+        "backgroundImage": {
+          "url": "data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAxNjAwIDIxMCIgcHJlc2VydmVBc3BlY3RSYXRpbz0ieE1pZFlNaWQgc2xpY2UiPjxkZWZzPjxsaW5lYXJHcmFkaWVudCBpZD0iaGciIHgxPSIwIiB5MT0iMCIgeDI9IjEiIHkyPSIwLjQ1Ij48c3RvcCBvZmZzZXQ9IjAiIHN0b3AtY29sb3I9IiMwRjE3MkEiLz48c3RvcCBvZmZzZXQ9IjAuNSIgc3RvcC1jb2xvcj0iIzFFM0E4QSIvPjxzdG9wIG9mZnNldD0iMSIgc3RvcC1jb2xvcj0iIzI1NjNFQiIvPjwvbGluZWFyR3JhZGllbnQ+PC9kZWZzPjxyZWN0IHdpZHRoPSIxNjAwIiBoZWlnaHQ9IjIxMCIgZmlsbD0idXJsKCNoZykiLz48ZyB0cmFuc2Zvcm09InRyYW5zbGF0ZSgxNDQwLDg2KSI+PGRlZnM+PHJhZGlhbEdyYWRpZW50IGlkPSJtb3RpZi1nbG93IiBjeD0iMC41IiBjeT0iMC41IiByPSIwLjYiPjxzdG9wIG9mZnNldD0iMCIgc3RvcC1jb2xvcj0iI0ZGRkZGRiIgc3RvcC1vcGFjaXR5PSIwLjIiLz48c3RvcCBvZmZzZXQ9IjEiIHN0b3AtY29sb3I9IiNGRkZGRkYiIHN0b3Atb3BhY2l0eT0iMCIvPjwvcmFkaWFsR3JhZGllbnQ+PC9kZWZzPjxyZWN0IHg9Ii0yNjAiIHk9Ii0xMDUiIHdpZHRoPSI1MjAiIGhlaWdodD0iMjEwIiBmaWxsPSJ1cmwoI21vdGlmLWdsb3cpIi8+PC9nPjwvc3ZnPg==",
+          "style": {
+            "fit": "cover"
+          }
+        }
+      },
+      {
+        "id": "ghdr-logo",
+        "kind": "image",
+        "url": "https://example.com/logo.png",
+        "style": {
+          "fit": "contain"
+        }
+      },
+      {
+        "id": "ghdr-title",
+        "kind": "text",
+        "verticalAlign": "middle",
+        "body": "# <span style=\"color: #FFFFFF\">Command Center</span>"
+      },
+      {
+        "id": "ghdr-subtitle",
+        "kind": "text",
+        "verticalAlign": "middle",
+        "body": "<span style=\"color: #CBD5E1\">Live metrics</span>"
+      }
+    ],
+    "layout": "<GridContainer elementId=\"ghdr-bg\" type=\"grid\" gridColumn=\"1 / 25\" gridRow=\"1 / 4\" gridTemplateColumns=\"repeat(24, 1fr)\" gridTemplateRows=\"auto\">\n  <LayoutElement elementId=\"ghdr-logo\" gridColumn=\"1 / 3\" gridRow=\"1 / 4\"/>\n  <LayoutElement elementId=\"ghdr-title\" gridColumn=\"3 / 25\" gridRow=\"1 / 3\"/>\n  <LayoutElement elementId=\"ghdr-subtitle\" gridColumn=\"3 / 25\" gridRow=\"3 / 4\"/>\n</GridContainer>"
+  },
+  "gradient_header_none": {
+    "element": [
+      {
+        "id": "ghdr3-bg",
+        "kind": "container",
+        "style": {
+          "borderRadius": "round"
+        },
+        "backgroundImage": {
+          "url": "data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAxNjAwIDIxMCIgcHJlc2VydmVBc3BlY3RSYXRpbz0ieE1pZFlNaWQgc2xpY2UiPjxkZWZzPjxsaW5lYXJHcmFkaWVudCBpZD0iaGciIHgxPSIwIiB5MT0iMCIgeDI9IjEiIHkyPSIwLjQ1Ij48c3RvcCBvZmZzZXQ9IjAiIHN0b3AtY29sb3I9IiMwRjE3MkEiLz48c3RvcCBvZmZzZXQ9IjAuNSIgc3RvcC1jb2xvcj0iIzFFM0E4QSIvPjxzdG9wIG9mZnNldD0iMSIgc3RvcC1jb2xvcj0iIzI1NjNFQiIvPjwvbGluZWFyR3JhZGllbnQ+PC9kZWZzPjxyZWN0IHdpZHRoPSIxNjAwIiBoZWlnaHQ9IjIxMCIgZmlsbD0idXJsKCNoZykiLz48L3N2Zz4=",
+          "style": {
+            "fit": "cover"
+          }
+        }
+      },
+      {
+        "id": "ghdr3-title",
+        "kind": "text",
+        "verticalAlign": "middle",
+        "body": "# <span style=\"color: #FFFFFF\">Plain</span>"
+      }
+    ],
+    "layout": "<GridContainer elementId=\"ghdr3-bg\" type=\"grid\" gridColumn=\"1 / 25\" gridRow=\"1 / 4\" gridTemplateColumns=\"repeat(24, 1fr)\" gridTemplateRows=\"auto\">\n  <LayoutElement elementId=\"ghdr3-title\" gridColumn=\"1 / 25\" gridRow=\"1 / 4\"/>\n</GridContainer>"
+  },
+  "gradient_header_rings_left": {
+    "element": [
+      {
+        "id": "ghdr2-bg",
+        "kind": "container",
+        "style": {
+          "borderRadius": "round"
+        },
+        "backgroundImage": {
+          "url": "data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAxNjAwIDIxMCIgcHJlc2VydmVBc3BlY3RSYXRpbz0ieE1pZFlNaWQgc2xpY2UiPjxkZWZzPjxsaW5lYXJHcmFkaWVudCBpZD0iaGciIHgxPSIwIiB5MT0iMCIgeDI9IjEiIHkyPSIwLjQ1Ij48c3RvcCBvZmZzZXQ9IjAiIHN0b3AtY29sb3I9IiMwRjE3MkEiLz48c3RvcCBvZmZzZXQ9IjAuNSIgc3RvcC1jb2xvcj0iIzFFM0E4QSIvPjxzdG9wIG9mZnNldD0iMSIgc3RvcC1jb2xvcj0iIzI1NjNFQiIvPjwvbGluZWFyR3JhZGllbnQ+PC9kZWZzPjxyZWN0IHdpZHRoPSIxNjAwIiBoZWlnaHQ9IjIxMCIgZmlsbD0idXJsKCNoZykiLz48ZyB0cmFuc2Zvcm09InRyYW5zbGF0ZSgxNjAsODYpIj48ZyBmaWxsPSJub25lIiBzdHJva2U9IiNGRkZGRkYiIHN0cm9rZS1vcGFjaXR5PSIwLjEyIiBzdHJva2Utd2lkdGg9IjEuNCI+PGNpcmNsZSByPSI0MCIvPjxjaXJjbGUgcj0iNzQiLz48Y2lyY2xlIHI9IjEwOCIvPjxsaW5lIHgxPSItMTMwIiB5MT0iMCIgeDI9IjEzMCIgeTI9IjAiLz48bGluZSB4MT0iMCIgeTE9Ii0xMzAiIHgyPSIwIiB5Mj0iMTMwIi8+PC9nPjwvZz48L3N2Zz4=",
+          "style": {
+            "fit": "cover"
+          }
+        }
+      },
+      {
+        "id": "ghdr2-title",
+        "kind": "text",
+        "verticalAlign": "middle",
+        "body": "# <span style=\"color: #FFFFFF\">Ops</span>"
+      }
+    ],
+    "layout": "<GridContainer elementId=\"ghdr2-bg\" type=\"grid\" gridColumn=\"1 / 25\" gridRow=\"1 / 4\" gridTemplateColumns=\"repeat(24, 1fr)\" gridTemplateRows=\"auto\">\n  <LayoutElement elementId=\"ghdr2-title\" gridColumn=\"1 / 25\" gridRow=\"1 / 4\"/>\n</GridContainer>"
+  },
   "header": {
     "element": [
       {
@@ -68,5 +208,63 @@
       }
     },
     "wrap": "<GridContainer elementId=\"card-1\" type=\"grid\" gridColumn=\"1 / 25\" gridRow=\"7 / 13\" gridTemplateColumns=\"repeat(24, 1fr)\" gridTemplateRows=\"auto\">\n  <LayoutElement elementId=\"k1\" gridColumn=\"1 / 9\" gridRow=\"1 / 7\"/>\n  <LayoutElement elementId=\"k2\" gridColumn=\"9 / 17\" gridRow=\"1 / 7\"/>\n  <LayoutElement elementId=\"k3\" gridColumn=\"17 / 25\" gridRow=\"1 / 7\"/>\n</GridContainer>"
+  },
+  "sparkline": {
+    "id": "spark-rev",
+    "kind": "line-chart",
+    "source": {
+      "kind": "table",
+      "elementId": "tbl"
+    },
+    "columns": [
+      {
+        "id": "spark-rev-period",
+        "formula": "[Table/Month]",
+        "name": "Period",
+        "format": {
+          "kind": "datetime",
+          "formatString": "%b %Y"
+        }
+      },
+      {
+        "id": "spark-rev-value",
+        "formula": "Sum([Table/Revenue])",
+        "name": "Value"
+      }
+    ],
+    "xAxis": {
+      "columnId": "spark-rev-period",
+      "format": {
+        "marks": "none",
+        "labels": "hidden"
+      }
+    },
+    "yAxis": {
+      "columnIds": [
+        "spark-rev-value"
+      ],
+      "format": {
+        "labels": "hidden",
+        "marks": "none",
+        "scale": {
+          "type": "linear",
+          "zero": false,
+          "hideZeroLine": true
+        }
+      }
+    },
+    "name": {
+      "visibility": "hidden"
+    },
+    "legend": {
+      "visibility": "hidden"
+    },
+    "lineAreaStyle": {
+      "interpolation": "monotone"
+    },
+    "style": {
+      "backgroundColor": "transparent",
+      "padding": "none"
+    }
   }
 }


### PR DESCRIPTION
Ports the WS4 authoring capabilities into the standalone sigma-workbooks skill (Ruby-only per this repo; canonical byte-identical to sigma-migration-skills #533):

- **Sigma agent** — Richness.agent + chat + agents.md
- **Gradient header/cards** — Styling.gradient_header (motif menu), gradient_card (dark scrim = legible white KPI values on any gradient), sparkline
- **Actions / input tables** — actions.rb (buttons + empty/linked input tables + effect builders) + actions.md + doc gap-fills

Gated SURFACES, golden-fixture tested (ruby). Stacks on the merged WS3 (#24).

🤖 Generated with [Claude Code](https://claude.com/claude-code)