### PR TITLE
feat(ws5): tabbed containers — Composition.tabbed_container + layout docs

### DIFF
--- a/sigma-workbooks/SKILL.md
+++ b/sigma-workbooks/SKILL.md
@@ -244,7 +244,7 @@ The reference is feature-sliced — don't read every file up-front. The index ha
 | `reference/specification/schema.md` | Always — load before drafting any spec. Top-level shape, required fields, response-only fields to strip. |
 | `reference/specification/formulas.md` | Always — load before drafting any spec. Formula syntax, qualification, special characters, the #1 mistake. |
 | `reference/specification/formatting.md` | Format, currency, percentage, date format, decimals — column formatting. |
-| `reference/specification/layout.md` | **Always load for multi-element workbooks.** Layout XML, GridContainer/LayoutElement, container elements, page visibility / background, auto-arrange fallback rules, when to write explicit layout vs. omit. |
+| `reference/specification/layout.md` | **Always load for multi-element workbooks.** Layout XML, GridContainer/LayoutElement, container elements, tabbed containers (pack multiple views into one region — spec-authorable, not UI-only), page visibility / background, auto-arrange fallback rules, when to write explicit layout vs. omit. |
 | `reference/specification/example-full.yaml` | A real multi-page reference spec (KPIs, charts, joins, controls, layout) — copy shapes from when in doubt. |
 | `reference/specification/comparative-kpi-card.yaml` | Minimal clone-able comparative KPI card — `value` + `comparisonColumn` + `comparison:{display:"delta"}`, the house-default comparative shape (see `kpis.md`). |
 

--- a/sigma-workbooks/generated/cline/sigma-workbooks.md
+++ b/sigma-workbooks/generated/cline/sigma-workbooks.md
@@ -217,10 +217,11 @@ The reference is feature-sliced — don't read every file up-front. The index ha
 | `reference/specification/charts.md` | Chart, graph, visualization, line / bar / column / stacked / grouped / combo / donut / pie / scatter / share-of / breakdown. Cartesian axes, color channel, trellis, trendlines, reference marks. |
 | `reference/specification/maps.md` | Map visualizations — `geography-map` (GeoJSON shapes), `point-map` (lat/long bubbles), `region-map` (states / counties / countries). |
 | `reference/specification/kpis.md` | KPI, stat, big number, single value, metric card — including layout / value styling, the comparison Δ badge (`comparisonColumn` + `comparison:{display:"delta"}` — spec-authorable and readback-stable; the house default), and the trend/sparkline block (still UI-bound). |
-| `reference/specification/controls.md` | Filter, dropdown, picker, multi-select, date range, date picker, text filter, number range, slider, segmented, hierarchy. |
+| `reference/specification/controls.md` | Filter, dropdown, picker, multi-select, date range, date picker, text filter, number range, slider, segmented, hierarchy. Also the entry (write) text control shape used with buttons/actions. |
 | `reference/specification/content-elements.md` | The non-data elements — `text` (Markdown + inline styling), `image`, `divider`, `embed` (external URLs). Titles, callouts, logos, rules, embedded content. |
 | `reference/specification/input-tables.md` | Operational supplement for `input-table` (spec shape lives in `tables.md`): write-connection requirement, the publish gate, reading data back via warehouse views, element endpoints for auditing, and migration patterns (Excel/planning models). |
-| `reference/specification/styling.md` | **Load when building a dashboard from scratch.** Design recipe library — vetted color palette, hero header strip, KPI card row, section headers, divider rhythm, categorical chart colors. Turns a default-arrange workbook into a designed-looking one without UI editing. |
+| `reference/specification/styling.md` | **Load when building a dashboard from scratch.** Design recipe library — vetted color palette, hero header strip, gradient header/KPI cards + composite sparkline, KPI card row, section headers, divider rhythm, categorical chart colors. Turns a default-arrange workbook into a designed-looking one without UI editing. |
+| `reference/specification/agents.md` | Workbook AI agent, chat with your data, agent, chatbot, AI assistant. The workbook-top-level `agents:[]` array + page-level `chat` element; read-only analyst vs. write/action agent; org-feature gate + graceful degrade. |
 
 ### Sources
 
@@ -236,7 +237,7 @@ The reference is feature-sliced — don't read every file up-front. The index ha
 | `reference/specification/schema.md` | Always — load before drafting any spec. Top-level shape, required fields, response-only fields to strip. |
 | `reference/specification/formulas.md` | Always — load before drafting any spec. Formula syntax, qualification, special characters, the #1 mistake. |
 | `reference/specification/formatting.md` | Format, currency, percentage, date format, decimals — column formatting. |
-| `reference/specification/layout.md` | **Always load for multi-element workbooks.** Layout XML, GridContainer/LayoutElement, container elements, page visibility / background, auto-arrange fallback rules, when to write explicit layout vs. omit. |
+| `reference/specification/layout.md` | **Always load for multi-element workbooks.** Layout XML, GridContainer/LayoutElement, container elements, tabbed containers (pack multiple views into one region — spec-authorable, not UI-only), page visibility / background, auto-arrange fallback rules, when to write explicit layout vs. omit. |
 | `reference/specification/example-full.yaml` | A real multi-page reference spec (KPIs, charts, joins, controls, layout) — copy shapes from when in doubt. |
 | `reference/specification/comparative-kpi-card.yaml` | Minimal clone-able comparative KPI card — `value` + `comparisonColumn` + `comparison:{display:"delta"}`, the house-default comparative shape (see `kpis.md`). |
 
@@ -246,6 +247,7 @@ The reference is feature-sliced — don't read every file up-front. The index ha
 |------|--------------|
 | `reference/workflows/discover.md` | Finding connections, tables, and column names. Load before composing a new spec. |
 | `reference/workflows/composition.md` | Open-ended design decisions — calibrating workbook complexity to the request, when to ask the user, what to ask, surfacing structural choices in the final summary, and a few safe defaults (hidden source pages, ranked-table sort direction). Load before drafting anything when the prompt leaves significant design choices unmade. |
+| `reference/workflows/actions.md` | Buttons, write-back, insert-rows/clear-control/set-control-value effects, modals (open/close-overlay), the append-only-log pattern, and the masked-error catalog for input-table/control element kinds. Load when the user wants a button, a "log/save/submit" action, or a write-back workflow. |
 | `reference/workflows/crud.md` | POST / GET / PUT against the workbook spec endpoints. Load when creating, retrieving, or updating a workbook. |
 | `reference/workflows/validate.md` | Pre-submit + post-create validation. Load before any POST or PUT. |
 | `reference/workflows/from-image.md` | The user supplied a target image (screenshot, mockup, BI-tool export) to reproduce. Load *before* discovery — it adds explicit observation and validation steps. |

--- a/sigma-workbooks/generated/codex/AGENTS.md
+++ b/sigma-workbooks/generated/codex/AGENTS.md
@@ -217,10 +217,11 @@ The reference is feature-sliced — don't read every file up-front. The index ha
 | `reference/specification/charts.md` | Chart, graph, visualization, line / bar / column / stacked / grouped / combo / donut / pie / scatter / share-of / breakdown. Cartesian axes, color channel, trellis, trendlines, reference marks. |
 | `reference/specification/maps.md` | Map visualizations — `geography-map` (GeoJSON shapes), `point-map` (lat/long bubbles), `region-map` (states / counties / countries). |
 | `reference/specification/kpis.md` | KPI, stat, big number, single value, metric card — including layout / value styling, the comparison Δ badge (`comparisonColumn` + `comparison:{display:"delta"}` — spec-authorable and readback-stable; the house default), and the trend/sparkline block (still UI-bound). |
-| `reference/specification/controls.md` | Filter, dropdown, picker, multi-select, date range, date picker, text filter, number range, slider, segmented, hierarchy. |
+| `reference/specification/controls.md` | Filter, dropdown, picker, multi-select, date range, date picker, text filter, number range, slider, segmented, hierarchy. Also the entry (write) text control shape used with buttons/actions. |
 | `reference/specification/content-elements.md` | The non-data elements — `text` (Markdown + inline styling), `image`, `divider`, `embed` (external URLs). Titles, callouts, logos, rules, embedded content. |
 | `reference/specification/input-tables.md` | Operational supplement for `input-table` (spec shape lives in `tables.md`): write-connection requirement, the publish gate, reading data back via warehouse views, element endpoints for auditing, and migration patterns (Excel/planning models). |
-| `reference/specification/styling.md` | **Load when building a dashboard from scratch.** Design recipe library — vetted color palette, hero header strip, KPI card row, section headers, divider rhythm, categorical chart colors. Turns a default-arrange workbook into a designed-looking one without UI editing. |
+| `reference/specification/styling.md` | **Load when building a dashboard from scratch.** Design recipe library — vetted color palette, hero header strip, gradient header/KPI cards + composite sparkline, KPI card row, section headers, divider rhythm, categorical chart colors. Turns a default-arrange workbook into a designed-looking one without UI editing. |
+| `reference/specification/agents.md` | Workbook AI agent, chat with your data, agent, chatbot, AI assistant. The workbook-top-level `agents:[]` array + page-level `chat` element; read-only analyst vs. write/action agent; org-feature gate + graceful degrade. |
 
 ### Sources
 
@@ -236,7 +237,7 @@ The reference is feature-sliced — don't read every file up-front. The index ha
 | `reference/specification/schema.md` | Always — load before drafting any spec. Top-level shape, required fields, response-only fields to strip. |
 | `reference/specification/formulas.md` | Always — load before drafting any spec. Formula syntax, qualification, special characters, the #1 mistake. |
 | `reference/specification/formatting.md` | Format, currency, percentage, date format, decimals — column formatting. |
-| `reference/specification/layout.md` | **Always load for multi-element workbooks.** Layout XML, GridContainer/LayoutElement, container elements, page visibility / background, auto-arrange fallback rules, when to write explicit layout vs. omit. |
+| `reference/specification/layout.md` | **Always load for multi-element workbooks.** Layout XML, GridContainer/LayoutElement, container elements, tabbed containers (pack multiple views into one region — spec-authorable, not UI-only), page visibility / background, auto-arrange fallback rules, when to write explicit layout vs. omit. |
 | `reference/specification/example-full.yaml` | A real multi-page reference spec (KPIs, charts, joins, controls, layout) — copy shapes from when in doubt. |
 | `reference/specification/comparative-kpi-card.yaml` | Minimal clone-able comparative KPI card — `value` + `comparisonColumn` + `comparison:{display:"delta"}`, the house-default comparative shape (see `kpis.md`). |
 
@@ -246,6 +247,7 @@ The reference is feature-sliced — don't read every file up-front. The index ha
 |------|--------------|
 | `reference/workflows/discover.md` | Finding connections, tables, and column names. Load before composing a new spec. |
 | `reference/workflows/composition.md` | Open-ended design decisions — calibrating workbook complexity to the request, when to ask the user, what to ask, surfacing structural choices in the final summary, and a few safe defaults (hidden source pages, ranked-table sort direction). Load before drafting anything when the prompt leaves significant design choices unmade. |
+| `reference/workflows/actions.md` | Buttons, write-back, insert-rows/clear-control/set-control-value effects, modals (open/close-overlay), the append-only-log pattern, and the masked-error catalog for input-table/control element kinds. Load when the user wants a button, a "log/save/submit" action, or a write-back workflow. |
 | `reference/workflows/crud.md` | POST / GET / PUT against the workbook spec endpoints. Load when creating, retrieving, or updating a workbook. |
 | `reference/workflows/validate.md` | Pre-submit + post-create validation. Load before any POST or PUT. |
 | `reference/workflows/from-image.md` | The user supplied a target image (screenshot, mockup, BI-tool export) to reproduce. Load *before* discovery — it adds explicit observation and validation steps. |

--- a/sigma-workbooks/generated/continue/sigma-workbooks.md
+++ b/sigma-workbooks/generated/continue/sigma-workbooks.md
@@ -217,10 +217,11 @@ The reference is feature-sliced — don't read every file up-front. The index ha
 | `reference/specification/charts.md` | Chart, graph, visualization, line / bar / column / stacked / grouped / combo / donut / pie / scatter / share-of / breakdown. Cartesian axes, color channel, trellis, trendlines, reference marks. |
 | `reference/specification/maps.md` | Map visualizations — `geography-map` (GeoJSON shapes), `point-map` (lat/long bubbles), `region-map` (states / counties / countries). |
 | `reference/specification/kpis.md` | KPI, stat, big number, single value, metric card — including layout / value styling, the comparison Δ badge (`comparisonColumn` + `comparison:{display:"delta"}` — spec-authorable and readback-stable; the house default), and the trend/sparkline block (still UI-bound). |
-| `reference/specification/controls.md` | Filter, dropdown, picker, multi-select, date range, date picker, text filter, number range, slider, segmented, hierarchy. |
+| `reference/specification/controls.md` | Filter, dropdown, picker, multi-select, date range, date picker, text filter, number range, slider, segmented, hierarchy. Also the entry (write) text control shape used with buttons/actions. |
 | `reference/specification/content-elements.md` | The non-data elements — `text` (Markdown + inline styling), `image`, `divider`, `embed` (external URLs). Titles, callouts, logos, rules, embedded content. |
 | `reference/specification/input-tables.md` | Operational supplement for `input-table` (spec shape lives in `tables.md`): write-connection requirement, the publish gate, reading data back via warehouse views, element endpoints for auditing, and migration patterns (Excel/planning models). |
-| `reference/specification/styling.md` | **Load when building a dashboard from scratch.** Design recipe library — vetted color palette, hero header strip, KPI card row, section headers, divider rhythm, categorical chart colors. Turns a default-arrange workbook into a designed-looking one without UI editing. |
+| `reference/specification/styling.md` | **Load when building a dashboard from scratch.** Design recipe library — vetted color palette, hero header strip, gradient header/KPI cards + composite sparkline, KPI card row, section headers, divider rhythm, categorical chart colors. Turns a default-arrange workbook into a designed-looking one without UI editing. |
+| `reference/specification/agents.md` | Workbook AI agent, chat with your data, agent, chatbot, AI assistant. The workbook-top-level `agents:[]` array + page-level `chat` element; read-only analyst vs. write/action agent; org-feature gate + graceful degrade. |
 
 ### Sources
 
@@ -236,7 +237,7 @@ The reference is feature-sliced — don't read every file up-front. The index ha
 | `reference/specification/schema.md` | Always — load before drafting any spec. Top-level shape, required fields, response-only fields to strip. |
 | `reference/specification/formulas.md` | Always — load before drafting any spec. Formula syntax, qualification, special characters, the #1 mistake. |
 | `reference/specification/formatting.md` | Format, currency, percentage, date format, decimals — column formatting. |
-| `reference/specification/layout.md` | **Always load for multi-element workbooks.** Layout XML, GridContainer/LayoutElement, container elements, page visibility / background, auto-arrange fallback rules, when to write explicit layout vs. omit. |
+| `reference/specification/layout.md` | **Always load for multi-element workbooks.** Layout XML, GridContainer/LayoutElement, container elements, tabbed containers (pack multiple views into one region — spec-authorable, not UI-only), page visibility / background, auto-arrange fallback rules, when to write explicit layout vs. omit. |
 | `reference/specification/example-full.yaml` | A real multi-page reference spec (KPIs, charts, joins, controls, layout) — copy shapes from when in doubt. |
 | `reference/specification/comparative-kpi-card.yaml` | Minimal clone-able comparative KPI card — `value` + `comparisonColumn` + `comparison:{display:"delta"}`, the house-default comparative shape (see `kpis.md`). |
 
@@ -246,6 +247,7 @@ The reference is feature-sliced — don't read every file up-front. The index ha
 |------|--------------|
 | `reference/workflows/discover.md` | Finding connections, tables, and column names. Load before composing a new spec. |
 | `reference/workflows/composition.md` | Open-ended design decisions — calibrating workbook complexity to the request, when to ask the user, what to ask, surfacing structural choices in the final summary, and a few safe defaults (hidden source pages, ranked-table sort direction). Load before drafting anything when the prompt leaves significant design choices unmade. |
+| `reference/workflows/actions.md` | Buttons, write-back, insert-rows/clear-control/set-control-value effects, modals (open/close-overlay), the append-only-log pattern, and the masked-error catalog for input-table/control element kinds. Load when the user wants a button, a "log/save/submit" action, or a write-back workflow. |
 | `reference/workflows/crud.md` | POST / GET / PUT against the workbook spec endpoints. Load when creating, retrieving, or updating a workbook. |
 | `reference/workflows/validate.md` | Pre-submit + post-create validation. Load before any POST or PUT. |
 | `reference/workflows/from-image.md` | The user supplied a target image (screenshot, mockup, BI-tool export) to reproduce. Load *before* discovery — it adds explicit observation and validation steps. |

--- a/sigma-workbooks/generated/cursor/rules/sigma-workbooks.mdc
+++ b/sigma-workbooks/generated/cursor/rules/sigma-workbooks.mdc
@@ -222,10 +222,11 @@ The reference is feature-sliced — don't read every file up-front. The index ha
 | `reference/specification/charts.md` | Chart, graph, visualization, line / bar / column / stacked / grouped / combo / donut / pie / scatter / share-of / breakdown. Cartesian axes, color channel, trellis, trendlines, reference marks. |
 | `reference/specification/maps.md` | Map visualizations — `geography-map` (GeoJSON shapes), `point-map` (lat/long bubbles), `region-map` (states / counties / countries). |
 | `reference/specification/kpis.md` | KPI, stat, big number, single value, metric card — including layout / value styling, the comparison Δ badge (`comparisonColumn` + `comparison:{display:"delta"}` — spec-authorable and readback-stable; the house default), and the trend/sparkline block (still UI-bound). |
-| `reference/specification/controls.md` | Filter, dropdown, picker, multi-select, date range, date picker, text filter, number range, slider, segmented, hierarchy. |
+| `reference/specification/controls.md` | Filter, dropdown, picker, multi-select, date range, date picker, text filter, number range, slider, segmented, hierarchy. Also the entry (write) text control shape used with buttons/actions. |
 | `reference/specification/content-elements.md` | The non-data elements — `text` (Markdown + inline styling), `image`, `divider`, `embed` (external URLs). Titles, callouts, logos, rules, embedded content. |
 | `reference/specification/input-tables.md` | Operational supplement for `input-table` (spec shape lives in `tables.md`): write-connection requirement, the publish gate, reading data back via warehouse views, element endpoints for auditing, and migration patterns (Excel/planning models). |
-| `reference/specification/styling.md` | **Load when building a dashboard from scratch.** Design recipe library — vetted color palette, hero header strip, KPI card row, section headers, divider rhythm, categorical chart colors. Turns a default-arrange workbook into a designed-looking one without UI editing. |
+| `reference/specification/styling.md` | **Load when building a dashboard from scratch.** Design recipe library — vetted color palette, hero header strip, gradient header/KPI cards + composite sparkline, KPI card row, section headers, divider rhythm, categorical chart colors. Turns a default-arrange workbook into a designed-looking one without UI editing. |
+| `reference/specification/agents.md` | Workbook AI agent, chat with your data, agent, chatbot, AI assistant. The workbook-top-level `agents:[]` array + page-level `chat` element; read-only analyst vs. write/action agent; org-feature gate + graceful degrade. |
 
 ### Sources
 
@@ -241,7 +242,7 @@ The reference is feature-sliced — don't read every file up-front. The index ha
 | `reference/specification/schema.md` | Always — load before drafting any spec. Top-level shape, required fields, response-only fields to strip. |
 | `reference/specification/formulas.md` | Always — load before drafting any spec. Formula syntax, qualification, special characters, the #1 mistake. |
 | `reference/specification/formatting.md` | Format, currency, percentage, date format, decimals — column formatting. |
-| `reference/specification/layout.md` | **Always load for multi-element workbooks.** Layout XML, GridContainer/LayoutElement, container elements, page visibility / background, auto-arrange fallback rules, when to write explicit layout vs. omit. |
+| `reference/specification/layout.md` | **Always load for multi-element workbooks.** Layout XML, GridContainer/LayoutElement, container elements, tabbed containers (pack multiple views into one region — spec-authorable, not UI-only), page visibility / background, auto-arrange fallback rules, when to write explicit layout vs. omit. |
 | `reference/specification/example-full.yaml` | A real multi-page reference spec (KPIs, charts, joins, controls, layout) — copy shapes from when in doubt. |
 | `reference/specification/comparative-kpi-card.yaml` | Minimal clone-able comparative KPI card — `value` + `comparisonColumn` + `comparison:{display:"delta"}`, the house-default comparative shape (see `kpis.md`). |
 
@@ -251,6 +252,7 @@ The reference is feature-sliced — don't read every file up-front. The index ha
 |------|--------------|
 | `reference/workflows/discover.md` | Finding connections, tables, and column names. Load before composing a new spec. |
 | `reference/workflows/composition.md` | Open-ended design decisions — calibrating workbook complexity to the request, when to ask the user, what to ask, surfacing structural choices in the final summary, and a few safe defaults (hidden source pages, ranked-table sort direction). Load before drafting anything when the prompt leaves significant design choices unmade. |
+| `reference/workflows/actions.md` | Buttons, write-back, insert-rows/clear-control/set-control-value effects, modals (open/close-overlay), the append-only-log pattern, and the masked-error catalog for input-table/control element kinds. Load when the user wants a button, a "log/save/submit" action, or a write-back workflow. |
 | `reference/workflows/crud.md` | POST / GET / PUT against the workbook spec endpoints. Load when creating, retrieving, or updating a workbook. |
 | `reference/workflows/validate.md` | Pre-submit + post-create validation. Load before any POST or PUT. |
 | `reference/workflows/from-image.md` | The user supplied a target image (screenshot, mockup, BI-tool export) to reproduce. Load *before* discovery — it adds explicit observation and validation steps. |

--- a/sigma-workbooks/reference/specification/layout.md
+++ b/sigma-workbooks/reference/specification/layout.md
@@ -60,6 +60,45 @@ jq --arg k container 'first(.. | objects | select((.allOf? and any(.allOf[]?; .p
 - **Element on a background image:** to place an element *on top of* a container's `backgroundImage`, make it a **child** of that container in the layout XML — the background spans the container and the child sits on top.
 - **When to skip:** with no shared background or logical grouping, position elements directly with `<LayoutElement>`. A container around a single element is usually overkill.
 
+## Tabbed containers
+
+A `kind: "tabbed-container"` element packs several views into one region — switchable tabs instead of a long vertical scroll or extra pages. Unlike the `kind: "container"` placeholder above, it's a real element with its own JSON shape, not a bare grouping wrapper.
+
+**It IS spec-authorable** — verified working end-to-end via spec `POST`/`PUT`, not the UI-only construct a stale note elsewhere may claim.
+
+**JSON element** (`pages[].elements[]`) — `tabs[]` entries are **labels only**, no children:
+
+```yaml
+- id: tc
+  kind: tabbed-container
+  tabs:
+    - name: Overview
+    - name: Detail
+  tabBar:
+    alignment: start
+```
+
+The actual content for each tab is ordinary elements declared elsewhere in `pages[].elements[]` — the layout XML below is what places them into a tab.
+
+**Layout XML** — a `<TabbedContainer>` wraps one `<Tab>` per label. `<Tab>` children map to `tabs[]` **by position** (1st `<Tab>` = 1st label; `<Tab>` carries no `name` attribute):
+
+```xml
+<TabbedContainer elementId="tc" type="tabbed-container" gridColumn="1 / 25" gridRow="7 / 60">
+  <Tab gridTemplateColumns="repeat(24, 1fr)" gridTemplateRows="auto">
+    <LayoutElement elementId="overview-chart" gridColumn="1 / 25" gridRow="1 / 12"/>
+  </Tab>
+  <Tab gridTemplateColumns="repeat(24, 1fr)" gridTemplateRows="auto">
+    <LayoutElement elementId="detail-table" gridColumn="1 / 25" gridRow="1 / 12"/>
+  </Tab>
+</TabbedContainer>
+```
+
+Two `<Tab>`s, two elements (`overview-chart`, `detail-table`) each declared once in `pages[].elements[]`; `<Tab>` order alone ties them to the "Overview" / "Detail" labels above.
+
+- **Gotcha (verified):** inside a `<Tab>`, use **bare `<LayoutElement>` children only** — never nest a `<GridContainer>` inside a `<Tab>`. A `<Tab>` is already a mini-grid (its own `gridTemplateColumns` / `gridTemplateRows`), so elements position directly in it; a nested `<GridContainer>` scrambles tab render order.
+- **When to use it:** several views that are alternates of each other (a summary + a detail table, one view per region/segment) rather than sequential reading — pack them into one region instead of a long scroll or extra pages.
+- **Building it:** hand-authoring the position-mapped `<Tab>` block is error-prone. Use `Composition.tabbed_container(id:, tabs:, grid_column:, grid_row:, tab_bar_alignment: 'start')` in `scripts/lib/composition.rb` — `tabs:` is `[{name:, inner:}]`, where `inner` is the tab's bare-`<LayoutElement>` XML (built with `Composition.band`/`Composition.le` or by hand). It returns `{element:, layout:}`, ready to splice into `pages[].elements[]` and the workbook-level `layout` string.
+
 ## `gridTemplateRows`: always `"auto"`
 
 Row tracks are always `"auto"` — write `gridTemplateRows="auto"`. Height comes from the children, not from the row track.

--- a/sigma-workbooks/scripts/lib/composition.rb
+++ b/sigma-workbooks/scripts/lib/composition.rb
@@ -133,4 +133,46 @@ module Composition
     else raise ArgumentError, "compose: unknown pattern #{pattern.inspect}"
     end
   end
+
+  # tabbed_container: a Sigma {kind:"tabbed-container"} page element + its
+  # <TabbedContainer> layout XML. Per the live-verified shape: tabs[] in the
+  # JSON element are LABELS ONLY (no children); the <Tab> children in the
+  # layout map to tabs[] BY POSITION (1st <Tab> = 1st label).
+  #
+  # GOTCHA (verified): inside a <Tab>, callers pass BARE <LayoutElement>
+  # children only -- a nested <GridContainer> inside a <Tab> scrambles tab
+  # render order. The <Tab> is itself a mini-grid (gridTemplateColumns /
+  # gridTemplateRows), so elements position directly within it; no inner
+  # GridContainer is needed.
+  def self.tabbed_container(id:, tabs:, grid_column:, grid_row:, tab_bar_alignment: 'start')
+    raise ArgumentError, 'tabbed_container: id required' if id.to_s.empty?
+    raise ArgumentError, 'tabbed_container: tabs required' if tabs.nil? || tabs.empty?
+    tabs.each do |t|
+      raise ArgumentError, 'tabbed_container: every tab requires a non-empty name' if t[:name].to_s.empty?
+    end
+    element = {
+      'id' => id,
+      'kind' => 'tabbed-container',
+      'tabs' => tabs.map { |t| { 'name' => t[:name] } },
+      'tabBar' => { 'alignment' => tab_bar_alignment }
+    }
+    tab_blocks = tabs.map do |t|
+      "  <Tab gridTemplateColumns=\"repeat(24, 1fr)\" gridTemplateRows=\"auto\">\n" \
+      "#{indent(t[:inner])}\n" \
+      '  </Tab>'
+    end
+    layout = "<TabbedContainer elementId=\"#{id}\" type=\"tabbed-container\" " \
+             "gridColumn=\"#{grid_column}\" gridRow=\"#{grid_row}\">\n" \
+             "#{tab_blocks.join("\n")}\n" \
+             '</TabbedContainer>'
+    { element: element, layout: layout }
+  end
+
+  # indent: prepend one indent level (2 spaces, this file's per-level unit)
+  # to every line of a multi-line XML fragment -- used to nest a tab's bare
+  # <LayoutElement> lines (already 2-space indented by le()) one level
+  # deeper inside a <Tab> (-> 4 spaces total, matching the verified shape).
+  def self.indent(text)
+    text.to_s.split("\n").map { |line| "  #{line}" }.join("\n")
+  end
 end

--- a/sigma-workbooks/scripts/lib/test_composition.rb
+++ b/sigma-workbooks/scripts/lib/test_composition.rb
@@ -140,4 +140,71 @@ end
 check('regression: :master_detail golden still matches after adding :overview') do
   Composition.compose(md_els, pattern: :master_detail).strip == md_golden
 end
+
+# tabbed_container — labels-only element; <Tab> children map to tabs[] by
+# position; bare <LayoutElement> children only inside a <Tab> (a nested
+# GridContainer scrambles tab render order).
+require 'json'
+tabbed_golden = JSON.parse(File.read(File.join(__dir__, 'testdata', 'composition_tabbed_golden.json')))
+tabbed_tabs = [
+  { name: 'Overview', inner: Composition.le('a1', 1, 25, 1, 7) },
+  { name: 'Details', inner: Composition.le('b1', 1, 25, 1, 7) }
+]
+check('tabbed_container: element + layout match golden') do
+  out = Composition.tabbed_container(id: 'tc', tabs: tabbed_tabs, grid_column: '1 / 25', grid_row: '7 / 60')
+  out[:element] == tabbed_golden['element'] && out[:layout] == tabbed_golden['layout']
+end
+check('tabbed_container: element tabs are labels-only, in order, with tabBar.alignment') do
+  out = Composition.tabbed_container(id: 'tc', tabs: tabbed_tabs, grid_column: '1 / 25', grid_row: '7 / 60')
+  out[:element]['tabs'] == [{ 'name' => 'Overview' }, { 'name' => 'Details' }] &&
+    out[:element]['tabBar'] == { 'alignment' => 'start' }
+end
+check('tabbed_container: non-default tab_bar_alignment is honored (not hardcoded to start)') do
+  out = Composition.tabbed_container(
+    id: 'tc', tabs: tabbed_tabs, grid_column: '1 / 25', grid_row: '7 / 60', tab_bar_alignment: 'center'
+  )
+  out[:element]['tabBar'] == { 'alignment' => 'center' }
+end
+check('tabbed_container: layout has exactly 2 ordered <Tab> blocks, each wrapping its inner') do
+  out = Composition.tabbed_container(id: 'tc', tabs: tabbed_tabs, grid_column: '1 / 25', grid_row: '7 / 60')
+  out[:layout].scan('<Tab ').size == 2 &&
+    out[:layout].index('elementId="a1"') < out[:layout].index('elementId="b1"') &&
+    out[:layout].start_with?(
+      '<TabbedContainer elementId="tc" type="tabbed-container" gridColumn="1 / 25" gridRow="7 / 60">'
+    ) &&
+    out[:layout].end_with?('</TabbedContainer>')
+end
+check('tabbed_container: empty id raises ArgumentError') do
+  begin
+    Composition.tabbed_container(id: '', tabs: tabbed_tabs, grid_column: '1 / 25', grid_row: '7 / 60')
+    false
+  rescue ArgumentError
+    true
+  end
+end
+check('tabbed_container: empty tabs raises ArgumentError') do
+  begin
+    Composition.tabbed_container(id: 'tc', tabs: [], grid_column: '1 / 25', grid_row: '7 / 60')
+    false
+  rescue ArgumentError
+    true
+  end
+end
+check('tabbed_container: a tab missing a name raises ArgumentError') do
+  begin
+    Composition.tabbed_container(id: 'tc', tabs: [{ name: '', inner: 'x' }], grid_column: '1 / 25', grid_row: '7 / 60')
+    false
+  rescue ArgumentError
+    true
+  end
+end
+check('tabbed_container: a tab with a missing (nil) name raises ArgumentError') do
+  begin
+    Composition.tabbed_container(id: 'tc', tabs: [{ inner: 'x' }], grid_column: '1 / 25', grid_row: '7 / 60')
+    false
+  rescue ArgumentError
+    true
+  end
+end
+
 exit($failures.zero? ? 0 : 1)

--- a/sigma-workbooks/scripts/lib/testdata/composition_tabbed_golden.json
+++ b/sigma-workbooks/scripts/lib/testdata/composition_tabbed_golden.json
@@ -1,0 +1,12 @@
+{
+  "element": {
+    "id": "tc",
+    "kind": "tabbed-container",
+    "tabs": [
+      { "name": "Overview" },
+      { "name": "Details" }
+    ],
+    "tabBar": { "alignment": "start" }
+  },
+  "layout": "<TabbedContainer elementId=\"tc\" type=\"tabbed-container\" gridColumn=\"1 / 25\" gridRow=\"7 / 60\">\n  <Tab gridTemplateColumns=\"repeat(24, 1fr)\" gridTemplateRows=\"auto\">\n    <LayoutElement elementId=\"a1\" gridColumn=\"1 / 25\" gridRow=\"1 / 7\"/>\n  </Tab>\n  <Tab gridTemplateColumns=\"repeat(24, 1fr)\" gridTemplateRows=\"auto\">\n    <LayoutElement elementId=\"b1\" gridColumn=\"1 / 25\" gridRow=\"1 / 7\"/>\n  </Tab>\n</TabbedContainer>"
+}


### PR DESCRIPTION
Ports tabbed-container authoring into the standalone sigma-workbooks skill (Ruby-only; canonical byte-identical to sigma-migration-skills). Composition.tabbed_container + layout.md "Tabbed containers" section. Golden-tested. Stacks on merged WS3 (#24).

🤖 Generated with [Claude Code](https://claude.com/claude-code)