### PR TITLE
docs(sigma-data-models): mandate Lookup() for cross-element refs — the bare form silently returns NULL

### DIFF
--- a/sigma-data-models/reference/calc-columns.md
+++ b/sigma-data-models/reference/calc-columns.md
@@ -17,10 +17,49 @@ A calc column has no warehouse-column ID prefix — its `id` is a generated shor
 ## Formula references
 
 - **Within the same element** — bare `[Column Name]` (case-sensitive, must match a column's `name` field on the same element).
-- **Cross-element** — `[Element Name/Column Name]`. The element name is the source element's `name`.
+- **Cross-element** — **use `Lookup()`. Do not use the bare `[Element Name/Column Name]` form.**
+  See the warning immediately below: the bare form is accepted at PUT, reports a
+  clean type, and then returns NULL for every row.
 - **From a warehouse-table source** — `[TABLE_NAME/Column Display Name]` where `TABLE_NAME` is the last segment of the source's `path` (uppercase, as it appears in the warehouse).
 
 A calc column **cannot reference itself**, even transitively — the server rejects circular references.
+
+### ⚠️ Cross-element refs: `Lookup()` only — the bare form silently returns NULL
+
+A bare cross-element reference in a DM calc column — `[Other Element/Column]` —
+**compiles clean and then evaluates to NULL for every row.** It is accepted at
+PUT, `/columns` reports a normal type with `error: null`, and nothing surfaces a
+problem at any layer you can inspect. The dashboard just quietly shows nothing.
+
+Measured 2026-08-06 on a two-element model with a defined relationship, 906 fact
+rows, two calc columns identical in intent:
+
+| Formula | Non-null rows |
+|---|---|
+| `[Customer Dim/Region]` (bare) | **0 / 906** |
+| `Lookup([Customer Dim/Region], [Customer Key], [Customer Dim/Customer Key])` | **872 / 906** |
+
+Both reported `type: text`, `error: null`. Always write:
+
+```
+Lookup(<value from the other element>, <local key>, <other element's key>)
+```
+
+The local key column must already exist on this element.
+
+Two caveats that matter at scale:
+
+1. **Orphan rows return NULL.** The 34-row gap above is genuine — fact rows whose
+   key is absent from the dimension. If you are porting logic from a tool whose
+   `ELSE` branch swallowed NULLs (Tableau does: `NULL >= 5000` falls through),
+   wrap it: `Coalesce(Lookup(...), "Bronze")`. Otherwise you get a NULL bucket
+   where the source had a default.
+2. **`Lookup()` returns ONE ARBITRARY match per key.** On a non-unique join key
+   the pick is nondeterministic and silent. Confirm the target key is unique
+   before relying on it.
+
+There is no supported bare-reference form to fall back to. If `Lookup()` cannot
+express what you need, push the join into a `sql` source instead.
 
 ## The `*Over` window functions don't work — but the native family does
 


### PR DESCRIPTION
`calc-columns.md` documented bare `[Element Name/Column Name]` as a supported
cross-element reference in a DM calc column, with no caveat. That pattern
**silently returns NULL for every row**.

## Measured

Two-element model with a defined relationship, 906 fact rows, two calc columns
identical in intent:

| Formula | Non-null rows |
|---|---|
| `[Customer Dim/Region]` (bare) | **0 / 906** |
| `Lookup([Customer Dim/Region], [Customer Key], [Customer Dim/Customer Key])` | **872 / 906** |

Both reported `type: text`, `error: null`. `spec/verify`, the PUT and `/columns`
all pass. There is no layer a user can inspect that shows a problem — the
dashboard just quietly shows nothing.

In the migration that surfaced this, the documented pattern produced **228 such
refs**: every dimension attribute came through empty, and a bucketing calc
classified 100% of stores into a single bucket with zero errors raised.

## What changed

- The bullet now points at `Lookup()` and away from the bare form.
- A new warning section carries the measurement, the correct signature, and the
  two caveats that bite at scale:
  - **orphan rows return NULL** (the 34-row gap above) — wrap in `Coalesce` when
    porting logic whose `ELSE` branch swallowed NULLs, as Tableau's does;
  - **`Lookup()` returns one arbitrary match per key** on a non-unique join key,
    silently.

## Deliberately not changed

`custom-sql-to-data-model/SKILL.md:208` also shows `[DM Element Name/Column Name]`,
but its column is headed *"Formula in workbook referencing the DM"* — a **workbook**
element sourcing a DM element. That form is verified working (it returned data in
the same probe run). Different context, correct as written.

Docs only. Re-vendor into `sigma-migration-skills`' `sigma-authoring` plugin per
`SYNC.md` after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)