### PR TITLE
docs(styling): finish the theme relocation — settings.theme, not the removed flat pair

### DIFF
--- a/sigma-workbooks/reference/specification/styling.md
+++ b/sigma-workbooks/reference/specification/styling.md
@@ -51,20 +51,7 @@ never an override of a user's stated branding or a migration's source fidelity.*
 
 ---
 
-## Workbook theme (2026-06-18 release; `themeOverrides` schema documented 2026-06-25)
-
-> **⚠ Relocated (confirmed 2026-08-05).** The flat `themeName` / `themeOverrides` keys shown throughout this section are **no longer `document`-level**. Theming now lives under **`document.settings.theme`**, as `{ name, overrides }`:
->
-> ```yaml
-> document:
->   settings:
->     theme:
->       name: Dark        # was `themeName`      — Light | Dark | Surface, or an org theme UUID
->       overrides: { }    # was `themeOverrides` — same field set, same semantics
->     navigation: { }     # page headers / sidebars / tabs
-> ```
->
-> The **field semantics below are unchanged** — only the path moved, plus the `themeName`→`name` and `themeOverrides`→`overrides` rename. Mentally prefix every `themeName` / `themeOverrides` in the rest of this section with `document.settings.theme`. (Verify against the current spec asset before relying on the old flat form; see `SKILL.md` → *Fetching the compiled asset*.)
+## Workbook theme (2026-06-18 release; `settings.theme.overrides` schema documented 2026-06-25)
 
 A workbook carries a theme under `document.settings`, alongside `pages` and `layout`:
 
@@ -84,15 +71,21 @@ document:
           surface: "#101826"
 ```
 
+> **The theme moved.** It was once a top-level `themeName` + `themeOverrides` pair; both
+> were **removed from the API** and are now `settings.theme.name` and
+> `settings.theme.overrides` — inside `document`, alongside `pages`/`layout`. The individual
+> override keys below are unchanged; only the container moved. A spec that still writes the
+> old pair loses its whole theme **silently** (no error, just an unthemed workbook).
+
 The **full overrides schema is in the public OpenAPI** (`.../spec` POST/PUT request body and GET response). The OpenAPI is the source of truth for every field; the list below is the verified summary.
 
-### `themeName`
+### `settings.theme.name`
 
 - Accepts a **built-in** name (`Light` / `Dark` / `Surface`) or an **org theme id** (a UUID). All round-trip. Only the **format** is checked, not existence: a malformed value 400s, but a well-formed but nonexistent UUID is accepted as-is and renders broken (like a bad `pluginId`) — so a clean POST is not proof the theme exists.
 - **There is no API to discover theme names.** Built-ins are the three above; an org theme id can only be learned by reading a workbook spec that already uses it (admin Branding Settings shows names, not ids). So the theme id has to come from somewhere external — an agent cannot enumerate them from a single call.
-- **Use the per-org theme registry instead of asking blind.** `harvest-theme-registry.py` (in `sigma-migration-skills/shared/scripts/`) scans an org's workbook specs once and writes `~/.sigma-migration/theme-registry.yaml`, keyed by API host, with each `themeName` and how many workbooks use it. Read it to suggest the org's themes ranked by frequency — **the most-used org-UUID is almost always the org default.** If the registry is missing or stale, run the harvester (a full scan is ~20–40s and persists), then fall back to asking the user only if no org themes are found. Singletons are often test/transient junk — prefer the high-count entries.
+- **Use the per-org theme registry instead of asking blind.** `harvest-theme-registry.py` (in `sigma-migration-skills/shared/scripts/`) scans an org's workbook specs once and writes `~/.sigma-migration/theme-registry.yaml`, keyed by API host, with each `settings.theme.name` and how many workbooks use it. Read it to suggest the org's themes ranked by frequency — **the most-used org-UUID is almost always the org default.** If the registry is missing or stale, run the harvester (a full scan is ~20–40s and persists), then fall back to asking the user only if no org themes are found. Singletons are often test/transient junk — prefer the high-count entries.
 
-### `themeOverrides` — one-off tweaks stacked on the base theme
+### `settings.theme.overrides` — one-off tweaks stacked on the base theme
 
 Every field below **round-trips and renders** — verified live 2026-06-26 (POST → GET round-trip with 0 dropped fields, + PNG export showing the override applied; a 14-key override on a `Light` base produced a dark canvas, pill cards, cyan headers, row banding, and a monospace data font).
 
@@ -117,7 +110,7 @@ Every field below **round-trips and renders** — verified live 2026-06-26 (POST
 
 **Gotchas:**
 - The server **lowercases hex** on save (`#0F172A` → `#0f172a`) — cosmetic, not a drop; don't treat it as a failed round-trip.
-- `themeOverrides` is the spec path to **donut/pie slice colors** — set `categoricalScheme` here (the per-element `color.scheme` is still silently dropped on donut/pie — see Recipe 5). This supersedes the old "set the theme in the UI" workaround.
+- `settings.theme.overrides` is the spec path to **donut/pie slice colors** — set `categoricalScheme` here (the per-element `color.scheme` is still silently dropped on donut/pie — see Recipe 5). This supersedes the old "set the theme in the UI" workaround.
 - `titleFont` sets every element's title **by default**, but a per-element `name:{fontSize,color}` (live-verified 2026-07-28 — see *Things that are NOT designable via spec* below, now corrected) **wins over** `titleFont` for that one element when both are set. Use `titleFont` for a workbook-wide title style and per-element `name` only where one title needs to stand out.
 - Theme vs. the recipes below: a theme is the global skin (selected, org-managed). The recipes here style individual elements from spec fields and **stack on top of** whatever theme is set. For a migration, prefer the source dashboard's look; reach for a theme only when the user asks to apply one.
 
@@ -309,7 +302,7 @@ For bar / line / area / combo charts, pin slice colors to the vetted palette:
 
 `scheme` is positional — pin colors to category sort order, not to category names. Sort by the value descending to get "biggest bar = primary blue, smaller = warning amber/red."
 
-> **Donut and pie do NOT accept `scheme`.** The field is silently stripped on those chart kinds. To customize donut/pie slice colors from spec, set `themeOverrides.categoricalScheme` at the workbook level (see *Workbook theme* above) — that path is now spec-authorable and verified. See `charts.md` donut section for the verified gotchas.
+> **Donut and pie do NOT accept `scheme`.** The field is silently stripped on those chart kinds. To customize donut/pie slice colors from spec, set `settings.theme.overrides.categoricalScheme` at the workbook level (see *Workbook theme* above) — that path is now spec-authorable and verified. See `charts.md` donut section for the verified gotchas.
 
 ---
 
@@ -571,7 +564,9 @@ migration's source fidelity or a user's own branding always overrides this.
 
 - Single-series (default): `{ "color": { "by": "single", "value": theme[:categorical][0] } }` —
   merge onto a bar/line/area/combo element (Recipe 5's single-hue case).
-- Categorical (`categorical: true`): `{ "themeOverrides": { "categoricalScheme": theme[:categorical] } }`
+- Categorical (`categorical: true`): `{ "settings": { "theme": { "overrides": { "categoricalScheme": theme[:categorical] } } } }`
+  — **deep-merge** at the workbook level (inside `document`, a sibling of `pages`/`layout`), not per-element.
+  Deep-merge, not shallow: a shallow merge of `settings` clobbers `navigation`.
   — merge at the **workbook** level (a sibling of `pages`/`layout`), not per-element. This is the
   verified path for donut/pie slice colors too (per-element `color.scheme` is still silently
   dropped there — see Recipe 5 / *Workbook theme* above).
@@ -740,10 +735,10 @@ Don't waste a round-trip trying to set these — the spec API silently drops the
 
 - **Chart tooltip customization** (spec-findings #10)
 - **Trellis / small-multiples layout** (spec-findings #11)
-- **Donut / pie slice colors** (spec-findings #22, per-element `color.scheme`; use workbook-level `themeOverrides.categoricalScheme` instead — see *Workbook theme* above)
+- **Donut / pie slice colors** (spec-findings #22, per-element `color.scheme`; use workbook-level `settings.theme.overrides.categoricalScheme` instead — see *Workbook theme* above)
 - ~~**KPI title color or "hide title" toggle** — `name` always renders as a black title~~ — **RESOLVED, live-verified 2026-07-28**: `name` on a `kpi-chart` (or any element) *is* colorable — `{ "name": { "text": "Revenue", "color": "#2563EB" } }` survives readback and renders the title in that color. This supersedes the "`name` always renders as a black title" claim this doc carried until now — for *this exact shape only*: there is still no `showTitle: false` / "hide title" toggle, so the `name: ' '` (single-space) workaround in Recipe 2 above still stands for suppressing a duplicate title.
-- ~~**Element title font size / font family** — the `name` field has no `style` sibling.~~ — **PARTIALLY RESOLVED, live-verified 2026-07-28**: a per-element `name` object also takes `fontSize` — `{ "name": { "text": "Category Detail", "fontSize": 22, "color": "#DC2626" } }` on a non-KPI element (e.g. a table) survives readback and renders both a visibly larger size and a distinct color, **overriding the workbook-wide `titleFont`** (see *Workbook theme* above) for that one element when both are set. This supersedes the "the `name` field has no `style` sibling" claim this doc carried until now. Font *family* per title remains untested — only `fontSize`/`color` were probed; `themeOverrides.fonts.textFont` (*Workbook theme* above) is still the only verified lever for text font family, and it's global, not per-title.
-- ~~**Workbook-level palette / theme** via spec~~ — **RESOLVED**: now spec-authorable via top-level `themeName` + `themeOverrides` (see *Workbook theme* above).
+- ~~**Element title font size / font family** — the `name` field has no `style` sibling.~~ — **PARTIALLY RESOLVED, live-verified 2026-07-28**: a per-element `name` object also takes `fontSize` — `{ "name": { "text": "Category Detail", "fontSize": 22, "color": "#DC2626" } }` on a non-KPI element (e.g. a table) survives readback and renders both a visibly larger size and a distinct color, **overriding the workbook-wide `titleFont`** (see *Workbook theme* above) for that one element when both are set. This supersedes the "the `name` field has no `style` sibling" claim this doc carried until now. Font *family* per title remains untested — only `fontSize`/`color` were probed; `settings.theme.overrides.fonts.textFont` (*Workbook theme* above) is still the only verified lever for text font family, and it's global, not per-title.
+- ~~**Workbook-level palette / theme** via spec~~ — **RESOLVED**: now spec-authorable via `settings.theme.name` + `settings.theme.overrides` (see *Workbook theme* above).
 - **Chart `tooltip` / `trellis*` fields** (UI-only)
 
 If a customer needs slice color branding on donut/pie, set the workbook theme in the UI after the spec is posted.

--- a/sigma-workbooks/scripts/lib/styling.rb
+++ b/sigma-workbooks/scripts/lib/styling.rb
@@ -135,7 +135,10 @@ module Styling
   def self.chart_color(theme, categorical: false, surfaces: SURFACES)
     if categorical
       return {} unless surfaces[:categorical_scheme]
-      # theming moved: document.settings.theme.overrides (themeOverrides was REMOVED)
+      # Workbook-level palette patch at settings.theme.overrides (the removed
+      # top-level themeOverrides key is silently dropped by the API).
+      # NOTE for callers: this is a NESTED patch, so deep-merge it into the spec;
+      # a shallow merge of `settings` would clobber sibling settings (navigation).
       { 'settings' => { 'theme' => { 'overrides' => { 'categoricalScheme' => theme[:categorical] } } } }
     else
       return {} unless surfaces[:chart_color_by]


### PR DESCRIPTION
Neither #31 (code) nor #32 (docs) covered this. `styling.md` carried the **removed** `themeName`/`themeOverrides` names in **14 places**, held together by a transitional callout telling the reader to *"mentally prefix every `themeName` / `themeOverrides` with `document.settings.theme`"*.

That's a standing invitation to write a spec that loses its theme silently — the API removed both keys (zero occurrences in the published OpenAPI) and ignores them without erroring.

**Changes**
- All 14 renamed to `settings.theme.name` / `settings.theme.overrides`
- Transitional callout dropped, replaced by one short historical note after the YAML example — now the only surviving mention of the old names (14 → 1)
- Line 574 corrected: it documented `chart_color(categorical: true)` as returning the **flat** patch while `scripts/lib/styling.rb:142` has long emitted the **nested** one. The doc contradicted the code it describes. Added the deep-merge warning — a shallow merge of `settings` clobbers `navigation`.
- `styling.rb` is **comment-only**; its emitted shape was already correct.

**The YAML example is deliberately unchanged** — main's is already `document`-wrapped. Worth flagging for the upcoming re-vendor: the vendored copy of this file in `sigma-migration-skills` has the theme rename but a **flat** example with no `document:` key. Do not port that one back; upstream is ahead here, and that flat example is the regression this note exists to prevent.

Verified: `themeName|themeOverrides` count 14 → 1 (the historical note); example still `document`-wrapped; doc and code now agree on the nested shape; `test_styling.rb` green; `ruby -c` clean; `generated/*` regenerated via `sync-targets.rb`.

⚠️ No CI in this repo — all gates run locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)