### PR TITLE
ci: add first GitHub Actions workflow to run the Ruby test suite

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -29,20 +29,33 @@ jobs:
       - name: Run every test-*.rb / test_*.rb (glob, aggregate failures)
         run: |
           set -uo pipefail
+          dirs=(sigma-workbooks custom-sql-to-data-model sigma-plugin-authoring)
+          # Each directory must exist on its own — an aggregate count alone
+          # would let one moved/renamed directory silently vanish from the
+          # glob while the other two still supply enough matches to pass.
+          for d in "${dirs[@]}"; do
+            [ -d "$d" ] || { echo "::error::expected test directory '$d' not found (moved/renamed?)"; exit 1; }
+          done
           tests=()
           while IFS= read -r -d '' f; do
             tests+=("$f")
-          done < <(find sigma-workbooks custom-sql-to-data-model sigma-plugin-authoring -type f \( -name 'test-*.rb' -o -name 'test_*.rb' \) -print0 | sort -z)
-          # A moved/renamed directory must FAIL here, never vacuously pass.
+          done < <(find "${dirs[@]}" -type f \( -name 'test-*.rb' -o -name 'test_*.rb' \) -print0 | sort -z)
+          # Belt-and-suspenders: a directory can exist but have every test
+          # file deleted from it. A moved/renamed directory (caught above) or
+          # an emptied one (caught here) must FAIL, never vacuously pass.
           [ "${#tests[@]}" -gt 0 ] || { echo "::error::glob matched no test files under sigma-workbooks/, custom-sql-to-data-model/, sigma-plugin-authoring/"; exit 1; }
           fail=0; ran=0
           for t in "${tests[@]}"; do
-            case "$(basename "$t")" in
-              # The ONLY exclusion. test-verify.rb hits the live Sigma API and
-              # needs SIGMA_BASE_URL/SIGMA_API_TOKEN; verified it does NOT skip
-              # cleanly without them (exits 2, not 0), so keep this workflow
-              # creds-free by never running it here rather than adding secrets.
-              test-verify.rb) echo "SKIP $t (needs live Sigma creds; does not skip cleanly without them)"; continue ;;
+            case "$t" in
+              # The ONLY exclusion — matched by full relative PATH, not
+              # basename, so an unrelated file elsewhere that happens to
+              # share this name is never silently skipped.
+              # sigma-workbooks/scripts/test-verify.rb hits the live Sigma API
+              # and needs SIGMA_BASE_URL/SIGMA_API_TOKEN; verified it does NOT
+              # skip cleanly without them (exits 2, not 0), so keep this
+              # workflow creds-free by never running it here rather than
+              # adding secrets.
+              sigma-workbooks/scripts/test-verify.rb) echo "SKIP $t (needs live Sigma creds; does not skip cleanly without them)"; continue ;;
             esac
             echo "::group::$t"
             if ruby "$t"; then

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,58 @@
+# First CI for this repo (previously zero automated testing — every PR
+# required manual local verification). Creds-free by design: no secrets are
+# referenced anywhere, and the one test that needs live Sigma credentials
+# (sigma-workbooks/scripts/test-verify.rb) is explicitly excluded below
+# rather than making this workflow need any.
+#
+# Pinned to ubuntu-24.04 (not -latest) and ruby 3.3 via ruby/setup-ruby@v1 —
+# mirrors the sibling sigma-migration-skills repo's CI convention — so a
+# runner-image rollover or Ruby-version drift can't silently change what
+# these tests execute against. System Ruby 2.6 fails outright (`filter_map`
+# is 2.7+).
+name: tests
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+jobs:
+  ruby-tests:
+    name: ruby unit tests (creds-free, globbed)
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '3.3'
+      - name: Run every test-*.rb / test_*.rb (glob, aggregate failures)
+        run: |
+          set -uo pipefail
+          tests=()
+          while IFS= read -r -d '' f; do
+            tests+=("$f")
+          done < <(find sigma-workbooks custom-sql-to-data-model sigma-plugin-authoring -type f \( -name 'test-*.rb' -o -name 'test_*.rb' \) -print0 | sort -z)
+          # A moved/renamed directory must FAIL here, never vacuously pass.
+          [ "${#tests[@]}" -gt 0 ] || { echo "::error::glob matched no test files under sigma-workbooks/, custom-sql-to-data-model/, sigma-plugin-authoring/"; exit 1; }
+          fail=0; ran=0
+          for t in "${tests[@]}"; do
+            case "$(basename "$t")" in
+              # The ONLY exclusion. test-verify.rb hits the live Sigma API and
+              # needs SIGMA_BASE_URL/SIGMA_API_TOKEN; verified it does NOT skip
+              # cleanly without them (exits 2, not 0), so keep this workflow
+              # creds-free by never running it here rather than adding secrets.
+              test-verify.rb) echo "SKIP $t (needs live Sigma creds; does not skip cleanly without them)"; continue ;;
+            esac
+            echo "::group::$t"
+            if ruby "$t"; then
+              echo "OK $t"
+            else
+              echo "::error file=$t::test failed"
+              fail=1
+            fi
+            echo "::endgroup::"
+            ran=$((ran+1))
+          done
+          echo "ran $ran ruby test file(s)"
+          exit $fail


### PR DESCRIPTION
This repo had zero automated testing, so every PR required manual local
verification. Add a minimal, creds-free workflow that runs on every PR
and push to main: pins ubuntu-24.04 and Ruby 3.3 (via ruby/setup-ruby@v1,
mirroring sigma-migration-skills' CI convention — system Ruby 2.6 fails
on filter_map), discovers test-*.rb/test_*.rb files under
sigma-workbooks/, custom-sql-to-data-model/, and sigma-plugin-authoring/
by find rather than a hardcoded list, fails loudly if that glob ever
matches nothing (verified locally against a nonexistent-directory probe),
and runs every discovered file to aggregate failures instead of stopping
at the first one.

sigma-workbooks/scripts/test-verify.rb is excluded from the glob with an
inline comment: it needs live Sigma credentials and was verified to exit
2 (not a clean skip) when SIGMA_BASE_URL/SIGMA_API_TOKEN are absent, so
excluding it keeps this workflow secret-free rather than requiring
SIGMA_* secrets.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
