### PR TITLE
docs(sigma-workbooks): document panel headers/sidebars and report kind; fix stale navigation example

### DIFF
--- a/sigma-workbooks/reference/specification/layout.md
+++ b/sigma-workbooks/reference/specification/layout.md
@@ -277,15 +277,92 @@ errors.
 
 ## Panels, headers, sidebars, and navigation
 
-`document.panels` stores panel metadata; panel content is placed by a
-`<Page id="<panel-id>">` layout block just like overlay content. Preserve panel
-metadata from readback and consult the live `panels` schema for the current
-header/sidebar variants.
+> **Derived from the OpenAPI only — NOT live-confirmed.** Every shape below
+> matches `components.schemas.WorkbookSpec` → `document.panels` /
+> `document.settings.navigation` in the compiled OpenAPI, but no probe has
+> gotten a panel to actually render. Live-probed 2026-08-08 against the AWS
+> API host <!-- pragma: allowlist secret --> (an otherwise normal org): any spec that
+> includes `document.settings.navigation` at all — even one that is
+> spec-valid and otherwise unremarkable — is rejected with:
+>
+> ```
+> 400 settings.navigation: workbook navigation settings are not enabled for this workspace.
+> ```
+>
+> The identical spec with `settings.navigation` omitted returns 200. That
+> reads as a **per-workspace entitlement gate**, not a payload error — if you
+> hit this exact message, recognize it as "this org lacks the feature," not a
+> spec mistake to debug. Treat everything in this section as spec-valid and
+> schema-accurate, but unverified end-to-end, until it's been created and
+> rendered on an org where the workspace setting is enabled.
 
-Workbook chrome is configured separately under `document.settings.navigation`.
-It controls built-in page headers, page tabs, and sidebar navigation; the
-`kind: navigation` canvas element is an independent in-layout menu. Use
-settings navigation for workbook-wide chrome and a navigation element when the
-menu must occupy a grid region or provide curated destinations.
+`document.panels[]` holds page **headers** and page **sidebars** — chrome
+that sits outside the scrolling page grid. Each entry is a `oneOf` of two
+variants, discriminated by `type`:
+
+| | `PageHeader` (`type: "header"`) | `PageSidebar` (`type: "sidebar"`) |
+|---|---|---|
+| Required | `id`, `type` | `id`, `type` |
+| `title` | name shown in the workbook's manage-headers list | name shown in the manage-sidebars list |
+| `pages[]` | page ids this panel applies to; omit when defined but unassigned | same |
+| `config.scroll` | `sticky` (default) \| `none` | `sticky` (default) \| `none` |
+| `config.borderStyle` | `line` \| `shadow` \| `none` — **`shadow` requires a sticky header** | `line` \| `none` |
+| `config.backgroundColor` | hex; omit to follow the theme | hex; omit to follow the theme |
+| `width` | — (headers have no width) | `small` (200px) \| `medium` (260px, default) \| `large` (400px) |
+
+Constraint from the OpenAPI (`pages[]` description): **a page may have at
+most one header and one sidebar, and only normal pages can carry panels —
+not modals or drawers.**
+
+```yaml
+document:
+  panels:
+    - id: main-header
+      type: header
+      title: Main Header
+      pages: [overview, detail]
+      config:
+        scroll: sticky
+        borderStyle: shadow
+    - id: nav-sidebar
+      type: sidebar
+      title: Navigation
+      pages: [overview, detail]
+      width: medium
+      config:
+        borderStyle: line
+```
+
+Panel *content* is placed exactly like overlay content: a layout
+`<Page id="<panel-id>">` block whose `id` matches the panel's `id` assigns
+elements to it (see "Each `<Page id>` matches a `document.pages[].id`,
+`document.overlays[].id`, or `document.panels[].id`" above). Preserve panel
+metadata from readback and re-check the live `panels` schema before adding
+fields not shown here — panel variants evolve.
+
+### `document.settings.navigation` — the on/off switch
+
+A panel renders **only** when its corresponding setting is `enabled`.
+Defining a panel in `document.panels[]` without enabling it here is inert,
+not an error — the panel is saved but never shown.
+
+```yaml
+document:
+  settings:
+    navigation:
+      pageHeader: enabled          # enabled | disabled
+      pageSidebar: enabled         # enabled | disabled
+      primary: sidebar             # sidebar (default) | header — which one
+                                    # owns the top corner when a page has both
+      pageTabsInViewMode: shown    # shown (default) | hidden — viewers only;
+                                    # editors always see page tabs
+```
+
+This is workbook-wide, always-on chrome — distinct from the `kind:
+navigation` canvas *element*, which is an independent in-layout menu that
+occupies a grid region and can carry curated destinations. Use
+`settings.navigation` + `document.panels` for built-in header/sidebar chrome;
+use a `navigation` element when the menu needs to live inside the page grid
+alongside other content.
 
 To study real grid-container idioms, fetch an existing multi-page workbook's spec (`GET /v2/workbooks/{id}/spec`, see SKILL.md Steps 1–2). The OpenAPI doesn't model the `layout` XML string, so a live spec is the way to see production layout.

--- a/sigma-workbooks/reference/specification/schema.md
+++ b/sigma-workbooks/reference/specification/schema.md
@@ -50,10 +50,19 @@ settings:
     overrides:
       categoricalScheme: ["#2563EB", "#F97316", "#10B981"]
   navigation:
-    position: side
-    pageHeader:
-      visibility: shown
+    pageHeader: enabled          # enabled | disabled
+    pageSidebar: enabled         # enabled | disabled
+    primary: sidebar             # sidebar (default) | header
+    pageTabsInViewMode: shown    # shown (default) | hidden
 ```
+
+> The `navigation` shape above (`pageHeader`/`pageSidebar`/`primary`/
+> `pageTabsInViewMode`, all enabled/disabled or shown/hidden enums) replaces a
+> stale `{position, pageHeader: {visibility}}` example this doc previously
+> showed — that shape does not exist in the live OpenAPI. See `layout.md`
+> §"Panels, headers, sidebars, and navigation" for the full field reference,
+> the matching `document.panels[]` shapes, and an important workspace-gating
+> caveat before you rely on any of it.
 
 Theme and navigation sub-fields evolve; inspect `CreateWorkbookSpec` before
 using an unfamiliar option. See `styling.md` for the richer theme recipes and
@@ -151,6 +160,41 @@ They are not part of a PUT body.
 - Every layout `elementId` must match a flat `document.elements[].id`.
 - Every element must be placed exactly where intended in layout. Do not infer
   ownership from array adjacency.
+
+## Related: `kind: "report"` documents are a separate resource, not a workbook variant
+
+The compiled OpenAPI also defines a `report` document (`document.kind:
+"report"`), but it is **not** something you set on a `/v2/workbooks/spec`
+payload — it's a sibling top-level resource with its own endpoint family:
+`POST /v2/reports/spec`, `POST /v2/reports/spec/verify`, `GET`/`PUT
+/v2/reports/{reportId}/spec`, plus a full set of `/v2/reports/{reportId}/...`
+routes (`elements`, `pages`, `schedules`, `send`, `export`, …). A workbook
+becomes a report via `POST /v2/workbooks/{workbookId}/convertToReport`, not
+by changing `document.kind` in place.
+
+Reports use **pixel** layout, not grid layout. The OpenAPI's `layout`
+description for a report document reads:
+
+> Pixel layout as XML. Top-level Page and Panel roots; Element children use
+> absolute x/y/width/height in pixels. Panel roots require type="header" or
+> type="footer".
+
+Key differences from the workbook shapes documented in this skill:
+
+- **Absolute pixel placement** (`x`/`y`/`width`/`height`) instead of
+  `gridColumn`/`gridRow` grid-line syntax.
+- **Report panels are `header`/`footer`** (top/bottom of a printed page),
+  each with `config: {height, backgroundColor}` (height in pixels) and a
+  `pages[]` assignment list — not `header`/`sidebar` like workbook panels
+  (see `layout.md`). Same vocabulary (`panels`, `type`, `config`), different
+  enum values, different resource — don't conflate the two.
+- `document.config` on a report carries `margin`, `pageHeight`, and
+  `pageWidth`, all in pixels — a report-level print/page-size block with no
+  workbook equivalent.
+
+This skill targets `/v2/workbooks/spec`; report authoring is out of scope
+here beyond this pointer. To build a report, start from the `/v2/reports/*`
+OpenAPI paths directly rather than reusing workbook layout recipes.
 
 ## Minimal working example
 


### PR DESCRIPTION
- Add full document.panels[] (PageHeader/PageSidebar) field reference to
  layout.md, sourced from the compiled OpenAPI: required id/type, title,
  pages[], config.scroll/borderStyle/backgroundColor, sidebar width presets,
  and the "one header + one sidebar per normal page" constraint.
- Flag the feature as workspace-gated: any spec containing
  document.settings.navigation is rejected with a 400
  ("workbook navigation settings are not enabled for this workspace") on an
  otherwise normal org, so the panel/navigation shapes are schema-derived and
  NOT live-confirmed end to end. Document the exact error text so the next
  reader recognizes an entitlement gap instead of debugging their payload.
- Document document.settings.navigation's real shape
  (pageHeader/pageSidebar/primary/pageTabsInViewMode) and fix schema.md's
  stale {position, pageHeader: {visibility}} example, which does not exist
  in the live OpenAPI.
- Add a schema.md section on kind: "report" documents, correcting the
  assumption that this is a workbook document-kind variant: it's a separate
  resource under /v2/reports/*, with pixel (x/y/width/height) layout and
  header/footer (not header/sidebar) panels.
- Verified the existing layout XML docs already use elementId= (not id=) and
  never show a <Document> wrapper throughout the repo — no correction needed
  there.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
