### PR TITLE
feat(sigma-workbooks): recognize live &lt;Panel&gt;/&lt;Overlay&gt; layout region tags

### DIFF
--- a/sigma-workbooks/reference/specification/layout.md
+++ b/sigma-workbooks/reference/specification/layout.md
@@ -277,24 +277,25 @@ errors.
 
 ## Panels, headers, sidebars, and navigation
 
-> **Derived from the OpenAPI only — NOT live-confirmed.** Every shape below
-> matches `components.schemas.WorkbookSpec` → `document.panels` /
-> `document.settings.navigation` in the compiled OpenAPI, but no probe has
-> gotten a panel to actually render. Live-probed 2026-08-08 against the AWS
-> API host <!-- pragma: allowlist secret --> (an otherwise normal org): any spec that
-> includes `document.settings.navigation` at all — even one that is
-> spec-valid and otherwise unremarkable — is rejected with:
+> **LIVE-CONFIRMED 2026-08-10** on a workspace with navigation enabled: a
+> workbook with a header panel and a sidebar panel round-trips through
+> `GET /v2/workbooks/{id}/spec` with both `document.panels[]` entries, the
+> `document.settings.navigation` block, and `<Panel>` layout nodes intact, and
+> the panels render. The shapes below match `components.schemas.WorkbookSpec`
+> → `document.panels` / `document.settings.navigation`.
+>
+> **Workspace entitlement gate (still applies).** `document.settings.navigation`
+> is rejected on a workspace where the feature is **not** enabled:
 >
 > ```
 > 400 settings.navigation: workbook navigation settings are not enabled for this workspace.
 > ```
 >
-> The identical spec with `settings.navigation` omitted returns 200. That
-> reads as a **per-workspace entitlement gate**, not a payload error — if you
-> hit this exact message, recognize it as "this org lacks the feature," not a
-> spec mistake to debug. Treat everything in this section as spec-valid and
-> schema-accurate, but unverified end-to-end, until it's been created and
-> rendered on an org where the workspace setting is enabled.
+> The identical spec with `settings.navigation` omitted returns 200. That is a
+> **per-workspace entitlement gate**, not a payload error — if you hit this
+> exact message, recognize it as "this org lacks the feature," not a spec
+> mistake to debug. Panels only render on an org where the workspace setting is
+> enabled.
 
 `document.panels[]` holds page **headers** and page **sidebars** — chrome
 that sits outside the scrolling page grid. Each entry is a `oneOf` of two
@@ -333,12 +334,29 @@ document:
         borderStyle: line
 ```
 
-Panel *content* is placed exactly like overlay content: a layout
-`<Page id="<panel-id>">` block whose `id` matches the panel's `id` assigns
-elements to it (see "Each `<Page id>` matches a `document.pages[].id`,
-`document.overlays[].id`, or `document.panels[].id`" above). Preserve panel
-metadata from readback and re-check the live `panels` schema before adding
-fields not shown here — panel variants evolve.
+Panel *content* is placed by a dedicated layout **`<Panel>`** block whose
+`id` matches the panel's `id` (NOT a `<Page>` block — that was the pre-2026-08
+guess; live readback uses its own `<Panel>` tag). The block carries the same
+`type="grid"` / `gridTemplateColumns` / `gridTemplateRows` attributes as a
+`<Page>` and holds `<Element>` children the same way. Live-confirmed shape
+(`GET /v2/workbooks/{id}/spec`, 2026-08-10):
+
+```xml
+<Page type="grid" gridTemplateColumns="repeat(24, 1fr)" gridTemplateRows="auto" id="kchtzPvp2c"/>
+<Panel type="grid" gridTemplateColumns="repeat(24, 1fr)" gridTemplateRows="auto" id="main-header">
+  <Element elementId="header-text" gridColumn="3 / 15" gridRow="1 / 3"/>
+</Panel>
+<Panel type="grid" gridTemplateColumns="repeat(6, 1fr)" gridTemplateRows="auto" id="nav-sidebar">
+  <Element elementId="sidebar-text" gridColumn="3 / 6" gridRow="5 / 11"/>
+</Panel>
+```
+
+Every `<Panel id>` must match a `document.panels[].id`, and every element it
+places must exist in the flat `document.elements` array (same
+place-each-element-exactly-once rule as pages/overlays). A sidebar panel's grid
+is commonly narrower (`repeat(6, 1fr)`) than the 24-column page grid. Preserve
+panel metadata from readback and re-check the live `panels` schema before
+adding fields not shown here — panel variants evolve.
 
 ### `document.settings.navigation` — the on/off switch
 

--- a/sigma-workbooks/reference/specification/schema.md
+++ b/sigma-workbooks/reference/specification/schema.md
@@ -137,10 +137,14 @@ Overlay actions and open/close effects are in `reference/workflows/actions.md`.
 ## Panels
 
 `document.panels` is the metadata collection for workbook panels such as
-header/sidebar surfaces. Panel content is also selected by layout placement,
-not a nested element list. Panel variants have different configuration fields;
-read the live `panels` property before authoring one and preserve unknown panel
-metadata on round trip.
+header/sidebar surfaces (live-confirmed 2026-08-10 on a navigation-enabled
+workspace). Each entry is discriminated by `type` (`"header"` | `"sidebar"`).
+Panel content is selected by layout placement — a dedicated `<Panel id="...">`
+block in the `layout` XML (its own tag, not `<Page>`), not a nested element
+list. See `layout.md` §"Panels, headers, sidebars, and navigation" for the
+full field reference, the `<Panel>` layout shape, the
+`document.settings.navigation` on/off switch, and the workspace-entitlement
+gate. Preserve unknown panel metadata on round trip.
 
 ## Response-only fields
 

--- a/sigma-workbooks/scripts/lib/code_rep.rb
+++ b/sigma-workbooks/scripts/lib/code_rep.rb
@@ -86,19 +86,25 @@ module Sigma
         elements.is_a?(Array) ? elements.select { |element| element.is_a?(Hash) } : []
       end
 
-      # { page_id => [element_id, ...] }, in layout order.
-      # Current GET specs use <Element> leaves, <Container> nested grids, and
-      # <TabbedContainer> tab groups. Keep the two pre-release aliases readable
-      # for old snapshots, but do not treat arbitrary XML tags carrying an
-      # elementId as workbook ownership.
+      # { region_id => [element_id, ...] }, in layout order. A "region" is a
+      # page, an overlay, or a **panel** (header/sidebar) — each owns a
+      # top-level layout block keyed by id. Live GET specs emit a distinct
+      # <Panel> tag for header/sidebar panels (live-confirmed 2026-08-10), and
+      # <Overlay> for overlay chrome, alongside <Page> for normal pages; all
+      # three carry <Element> leaves, <Container> nested grids, and
+      # <TabbedContainer> tab groups the same way. Match on the opening tag and
+      # its own closing tag via a backreference so a <Panel> body is never
+      # mis-attributed to the preceding <Page>. Keep the two pre-release aliases
+      # readable for old snapshots, but do not treat arbitrary XML tags carrying
+      # an elementId as workbook ownership.
       def workbook_page_element_ids(spec)
         document(spec)['layout'].to_s
-                       .scan(%r{<Page\b[^>]*\bid="([^"]*)"[^>]*>(.*?)</Page>}m)
-                       .each_with_object({}) do |(page_id, body), out|
+                       .scan(%r{<(Page|Panel|Overlay)\b[^>]*\bid="([^"]*)"[^>]*>(.*?)</\1>}m)
+                       .each_with_object({}) do |(_tag, region_id, body), out|
           nodes = body.scan(
             %r{<(?:#{LAYOUT_NODE_TAG_PATTERN})\b[^>]*\belementId="([^"]*)"}m
           )
-          out[page_id] = nodes.flatten.uniq
+          out[region_id] = nodes.flatten.uniq
         end
       end
 

--- a/sigma-workbooks/scripts/lib/test_code_rep.rb
+++ b/sigma-workbooks/scripts/lib/test_code_rep.rb
@@ -147,6 +147,21 @@ check('ownership parser ignores unknown tags with elementId attributes') do
   Sigma::CodeRep.workbook_page_element_ids(spec) == { 'p1' => ['owned'] }
 end
 
+check('ownership parser attributes <Panel>/<Overlay> region blocks by their own id') do
+  # Live GET specs emit distinct <Panel> (header/sidebar) and <Overlay> tags,
+  # not <Page id="panel-id"> — a panel body must be owned by the panel, never
+  # folded into the preceding page (live-confirmed 2026-08-10).
+  spec = Marshal.load(Marshal.dump(NESTED_RESPONSE))
+  spec['document']['layout'] = <<~XML
+    <Page id="p1"><Element elementId="page-el"/></Page>
+    <Panel id="hdr"><Element elementId="header-el"/></Panel>
+    <Overlay id="ov"><Element elementId="overlay-el"/></Overlay>
+  XML
+  Sigma::CodeRep.workbook_page_element_ids(spec) == {
+    'p1' => ['page-el'], 'hdr' => ['header-el'], 'ov' => ['overlay-el']
+  }
+end
+
 check('wrap migrates legacy page-nested elements to the current API shape') do
   legacy = {
     'schemaVersion' => 1,

--- a/sigma-workbooks/scripts/test-representation.rb
+++ b/sigma-workbooks/scripts/test-representation.rb
@@ -29,12 +29,12 @@ layout = <<~XML
       <Element elementId="title" gridColumn="1 / 25" gridRow="1 / 5"/>
     </Container>
   </Page>
-  <Page type="grid" gridTemplateColumns="repeat(24, 1fr)" gridTemplateRows="auto" id="overlay-detail">
+  <Overlay type="grid" gridTemplateColumns="repeat(24, 1fr)" gridTemplateRows="auto" id="overlay-detail">
     <Element elementId="detail" gridColumn="1 / 25" gridRow="1 / 8"/>
-  </Page>
-  <Page type="grid" gridTemplateColumns="repeat(24, 1fr)" gridTemplateRows="auto" id="panel-filter">
-    <Element elementId="filter-copy" gridColumn="1 / 25" gridRow="1 / 4"/>
-  </Page>
+  </Overlay>
+  <Panel type="grid" gridTemplateColumns="repeat(6, 1fr)" gridTemplateRows="auto" id="panel-filter">
+    <Element elementId="filter-copy" gridColumn="1 / 6" gridRow="1 / 4"/>
+  </Panel>
 XML
 
 spec = {

--- a/sigma-workbooks/scripts/validate-spec.sh
+++ b/sigma-workbooks/scripts/validate-spec.sh
@@ -141,7 +141,7 @@ LAYOUT_ISSUES=$(printf '%s' "$SPEC_JSON" | jq -r '
   ($placed_all | unique) as $placed |
   ([($d.pages // [])[], ($d.overlays // [])[], ($d.panels // [])[]] |
     map(.id) | map(select(. != null)) | unique) as $declared_regions |
-  ([($d.layout // "") | scan("<Page[^>]*\\bid=\"([^\"]+)\"") | .[0]] | unique) as $placed_regions |
+  ([($d.layout // "") | scan("<(?:Page|Overlay|Panel)[^>]*\\bid=\"([^\"]+)\"") | .[0]] | unique) as $placed_regions |
   (($d.elements // []) | map(select(.kind == "page-break") | .id)) as $page_break_ids |
   ([($d.layout // "") |
     scan("<(?:Element|LayoutElement)\\b[^>]*\\belementId=\"([^\"]+)\"[^>]*\\bgridRow=\"\\s*([0-9]+)\\s*/\\s*([0-9]+)\"")]) as $leaf_rows |

--- a/sigma-workbooks/scripts/wb-rep.rb
+++ b/sigma-workbooks/scripts/wb-rep.rb
@@ -112,17 +112,23 @@ end
 
 # Split the top-level layout XML into [preamble, { page_id => chunk }].
 # Chunks are verbatim byte slices so an untouched rep reassembles identically.
+# A layout region block opens with <Page>, <Overlay>, or <Panel> (header/
+# sidebar). Live GET specs emit a distinct <Panel> tag for header/sidebar
+# panels (live-confirmed 2026-08-10) and <Overlay> for overlays, alongside
+# <Page>; each is a top-level, id-keyed chunk. Splitting on all three keeps a
+# panel/overlay body from being folded into the preceding page chunk.
+LAYOUT_REGION_TAGS = %w[Page Overlay Panel].freeze
 def split_layout(layout)
   return [XML_PROLOG, {}] if layout.nil? || layout.empty?
   starts = []
-  layout.scan(/<Page[\s>]/) { starts << Regexp.last_match.begin(0) }
+  layout.scan(/<(?:#{LAYOUT_REGION_TAGS.join('|')})[\s>]/) { starts << Regexp.last_match.begin(0) }
   return [layout, {}] if starts.empty?
   preamble = layout[0...starts.first]
   chunks = {}
   starts.each_with_index do |s, i|
     chunk = layout[s...(starts[i + 1] || layout.length)]
-    id = chunk[/\A<Page[^>]*\bid="([^"]*)"/, 1]
-    warn "wb-rep: warning — layout <Page> block without an id attribute; it will be appended last" unless id
+    id = chunk[/\A<(?:#{LAYOUT_REGION_TAGS.join('|')})[^>]*\bid="([^"]*)"/, 1]
+    warn "wb-rep: warning — layout region block without an id attribute; it will be appended last" unless id
     chunks[id || "_orphan#{i}"] = chunk
   end
   [preamble, chunks]
@@ -167,7 +173,7 @@ def explode(spec, dir, raw_yaml:, manifest_extra: {})
     File.write(File.join(dir, 'elements', format('%03d-%s.yaml', (index + 1) * 10, base)), YAML.dump(el))
   end
   layout_chunks.each_key do |k|
-    warn "wb-rep: warning — layout <Page id=\"#{k}\"> matches no page, overlay, or panel; chunk dropped"
+    warn "wb-rep: warning — layout region block id=\"#{k}\" matches no page, overlay, or panel; chunk dropped"
   end
 
   File.write(File.join(dir, '.sigma', 'snapshot.yaml'), YAML.dump(canonical_spec(YAML.load(raw_yaml))))
@@ -294,7 +300,7 @@ def lint_layout_coverage(spec)
   referenced = referenced_all.uniq
   regions = COLLECTIONS.keys.flat_map { |collection| Array(doc[collection]) }
   declared_region_ids = regions.filter_map { |region| region['id'] }.uniq
-  referenced_region_ids = layout.scan(/<Page\b[^>]*\bid="([^"]+)"/).flatten.uniq
+  referenced_region_ids = layout.scan(/<(?:Page|Overlay|Panel)\b[^>]*\bid="([^"]+)"/).flatten.uniq
   issues = []
 
   elements.group_by { |element| element['id'] }.each do |id, grouped|


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

A live workbook with a page **header** and **sidebar** panel now round-trips through `GET /v2/workbooks/{id}/spec` with `document.panels[]` (`type: header` / `type: sidebar`), the `document.settings.navigation` block, and distinct `<Panel>` layout nodes — confirming the header/sidebar code representation is real (previously OpenAPI-only and believed workspace-gated end-to-end).

The docs and tooling assumed panels were placed via `<Page id="panel-id">` blocks. Live readback uses a dedicated `<Panel>` tag (and `<Overlay>` for overlays). This aligns both.

### Docs
- `reference/specification/layout.md`: flip the panel section from "NOT live-confirmed" to **live-confirmed 2026-08-10** (workspace entitlement gate still noted), and correct placement to a `<Panel id="...">` layout block with the observed shape.
- `reference/specification/schema.md`: panels are `type`-discriminated and placed by a `<Panel>` layout block, not `<Page>`.

### Tooling (backward-compatible, additive)
- `scripts/lib/code_rep.rb`: `workbook_page_element_ids` attributes `<Page>`, `<Panel>`, and `<Overlay>` region blocks by their own id (backreferenced closing tag so a panel body is never folded into the preceding page).
- `scripts/wb-rep.rb`: `split_layout` chunks on `<Page|Overlay|Panel>`; region-reference scan recognizes all three.
- `scripts/validate-spec.sh`: placed-region scan recognizes `<Page|Overlay|Panel>`.
- Existing `<Page id="overlay-id">`/`<Page id="panel-id">` snapshots still validate.

## Verification
- `scripts/lib/test_code_rep.rb` — new assertion pins `<Panel>`/`<Overlay>` attribution; all checks pass.
- `scripts/test-representation.rb` — fixture updated to use live `<Overlay>`/`<Panel>` tags; import/assemble round-trip + validator all pass.
- Full workbook suite (composition, richness, styling, actions, kpi_card, composition_lint, verify, openapi-contract) — green.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0cbc37cb-28b5-421e-83f3-06b636db66eb?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0cbc37cb-28b5-421e-83f3-06b636db66eb&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

