### PR TITLE
Add browser OAuth login as an auth option across the Sigma skills

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,8 +1,15 @@
 # Sigma API credentials
 # Copy this file to `.env` and fill in your values.
-# Get CLIENT_ID and CLIENT_SECRET from Sigma: Admin → Developer Access → Create
+#
+# Two auth options:
+#   1. Client credentials — set SIGMA_CLIENT_ID + SIGMA_CLIENT_SECRET below.
+#      Get them from Sigma: Admin → Developer Access → Create.
+#   2. Browser login — leave CLIENT_ID/SECRET blank and sign in via the
+#      sigma-api skill: `eval "$(bash sigma-api/scripts/browser-login.sh)"`.
+#      SIGMA_BASE_URL is still required.
 # BASE_URL depends on your cloud region — see https://help.sigmacomputing.com/reference/get-started-sigma-api#identify-your-api-request-url
 
 SIGMA_BASE_URL=
+# Optional when using browser login (Option 2 above):
 SIGMA_CLIENT_ID=
 SIGMA_CLIENT_SECRET=

--- a/README.md
+++ b/README.md
@@ -55,8 +55,10 @@ custom-sql-to-data-model    ─── orchestrator: SQL extraction + DM creation
 
 ## Auth
 
-Use the `sigma-api` skill to configure credentials and mint a token. For the
-client-credentials flow:
+Use the `sigma-api` skill to configure credentials and mint a token. There are
+**two options** — pick whichever fits.
+
+### Option 1 — Client credentials (headless / automation)
 
 ```bash
 export SIGMA_BASE_URL="https://api.sigmacomputing.com"
@@ -68,6 +70,27 @@ eval "$(bash ~/sigma-skills/sigma-api/scripts/get-token.sh)"
 ```
 
 Sigma client credentials are issued from **Administration → Developer Access** in your Sigma org.
+
+### Option 2 — Interactive browser login (no client ID/secret)
+
+Prefer signing in through the browser? The `sigma-api` skill also supports an
+OAuth authorization-code + PKCE login — no pre-provisioned credentials, the
+client registers itself. Best when a human is at the keyboard:
+
+```bash
+export SIGMA_BASE_URL="https://api.sigmacomputing.com"  # adjust per cloud; pragma: allowlist secret
+
+# Opens your browser, captures the redirect, and prints an export line to eval.
+eval "$(bash ~/sigma-skills/sigma-api/scripts/browser-login.sh)"
+
+# Later, mint a fresh token headlessly (no browser) from the stored refresh token:
+eval "$(bash ~/sigma-skills/sigma-api/scripts/refresh-token.sh)"
+```
+
+`browser-login.sh` stores the refresh token in your OS keychain, so
+`refresh-token.sh` can renew the ~1h access token without another sign-in. See
+[`sigma-api/reference/browser-oauth-login.md`](sigma-api/reference/browser-oauth-login.md)
+for the full flow.
 
 ## Installation
 

--- a/custom-sql-to-data-model/SKILL.md
+++ b/custom-sql-to-data-model/SKILL.md
@@ -30,7 +30,21 @@ catches.
 
 ## Prerequisites
 
-Required env vars: `SIGMA_BASE_URL`, `SIGMA_CLIENT_ID`, `SIGMA_CLIENT_SECRET`
+Required env var: `SIGMA_BASE_URL`. Then pick **one** of two auth options:
+
+- **Client credentials (headless):** set `SIGMA_CLIENT_ID` and
+  `SIGMA_CLIENT_SECRET` (from Sigma → Administration → Developer Access). Best
+  for automation.
+- **Browser login (no client ID/secret):** sign in once through the browser
+  using the `sigma-api` skill —
+  `eval "$(bash <repo-root>/sigma-api/scripts/browser-login.sh)"`. It stores a
+  refresh token in your OS keychain, and the token scripts below redeem it
+  headlessly (no browser round-trip on subsequent runs). `SIGMA_CLIENT_ID` /
+  `SIGMA_CLIENT_SECRET` can stay unset.
+
+Both options feed the same `get_token.py` / `get-token.sh` helpers below —
+when the client-credential env vars are absent they automatically fall back to
+the stored browser-login refresh token.
 
 **Default (shell-neutral, works in bash/zsh/PowerShell/cmd):** mint a token
 with the stdlib-only Python script and let `scripts/lib/sigma_rest.rb` pick
@@ -58,7 +72,7 @@ ruby scripts/scan-workbooks.rb
 eval "$(bash scripts/get-token.sh)"
 ```
 
-> Tokens expire after ~1 hour. **The Ruby scripts in this skill now auto-refresh on 401** via `scripts/lib/sigma_rest.rb` — full-site scans on large orgs (hundreds of workbooks, sometimes >1 hour total) no longer fail mid-run. If you still see `Token missing or malformed` after a refresh, re-run `python3 scripts/get_token.py --workdir "$SIGMA_WORKDIR"` (or `eval "$(bash scripts/get-token.sh)"` in bash) manually.
+> Tokens expire after ~1 hour. **With client credentials, the Ruby scripts auto-refresh on 401** via `scripts/lib/sigma_rest.rb` — full-site scans on large orgs (hundreds of workbooks, sometimes >1 hour total) no longer fail mid-run. **Browser-login users** don't have client credentials for the in-process refresh, so re-run `python3 scripts/get_token.py --workdir "$SIGMA_WORKDIR"` between phases — it serves the cached keychain token or redeems the stored refresh token headlessly. Either way, if you still see `Token missing or malformed`, re-run `python3 scripts/get_token.py --workdir "$SIGMA_WORKDIR"` (or `eval "$(bash scripts/get-token.sh)"` in bash) manually.
 
 ---
 

--- a/custom-sql-to-data-model/generated/cline/custom-sql-to-data-model.md
+++ b/custom-sql-to-data-model/generated/cline/custom-sql-to-data-model.md
@@ -27,7 +27,21 @@ catches.
 
 ## Prerequisites
 
-Required env vars: `SIGMA_BASE_URL`, `SIGMA_CLIENT_ID`, `SIGMA_CLIENT_SECRET`
+Required env var: `SIGMA_BASE_URL`. Then pick **one** of two auth options:
+
+- **Client credentials (headless):** set `SIGMA_CLIENT_ID` and
+  `SIGMA_CLIENT_SECRET` (from Sigma → Administration → Developer Access). Best
+  for automation.
+- **Browser login (no client ID/secret):** sign in once through the browser
+  using the `sigma-api` skill —
+  `eval "$(bash <repo-root>/sigma-api/scripts/browser-login.sh)"`. It stores a
+  refresh token in your OS keychain, and the token scripts below redeem it
+  headlessly (no browser round-trip on subsequent runs). `SIGMA_CLIENT_ID` /
+  `SIGMA_CLIENT_SECRET` can stay unset.
+
+Both options feed the same `get_token.py` / `get-token.sh` helpers below —
+when the client-credential env vars are absent they automatically fall back to
+the stored browser-login refresh token.
 
 **Default (shell-neutral, works in bash/zsh/PowerShell/cmd):** mint a token
 with the stdlib-only Python script and let `scripts/lib/sigma_rest.rb` pick
@@ -55,7 +69,7 @@ ruby scripts/scan-workbooks.rb
 eval "$(bash scripts/get-token.sh)"
 ```
 
-> Tokens expire after ~1 hour. **The Ruby scripts in this skill now auto-refresh on 401** via `scripts/lib/sigma_rest.rb` — full-site scans on large orgs (hundreds of workbooks, sometimes >1 hour total) no longer fail mid-run. If you still see `Token missing or malformed` after a refresh, re-run `python3 scripts/get_token.py --workdir "$SIGMA_WORKDIR"` (or `eval "$(bash scripts/get-token.sh)"` in bash) manually.
+> Tokens expire after ~1 hour. **With client credentials, the Ruby scripts auto-refresh on 401** via `scripts/lib/sigma_rest.rb` — full-site scans on large orgs (hundreds of workbooks, sometimes >1 hour total) no longer fail mid-run. **Browser-login users** don't have client credentials for the in-process refresh, so re-run `python3 scripts/get_token.py --workdir "$SIGMA_WORKDIR"` between phases — it serves the cached keychain token or redeems the stored refresh token headlessly. Either way, if you still see `Token missing or malformed`, re-run `python3 scripts/get_token.py --workdir "$SIGMA_WORKDIR"` (or `eval "$(bash scripts/get-token.sh)"` in bash) manually.
 
 ---
 

--- a/custom-sql-to-data-model/generated/codex/AGENTS.md
+++ b/custom-sql-to-data-model/generated/codex/AGENTS.md
@@ -27,7 +27,21 @@ catches.
 
 ## Prerequisites
 
-Required env vars: `SIGMA_BASE_URL`, `SIGMA_CLIENT_ID`, `SIGMA_CLIENT_SECRET`
+Required env var: `SIGMA_BASE_URL`. Then pick **one** of two auth options:
+
+- **Client credentials (headless):** set `SIGMA_CLIENT_ID` and
+  `SIGMA_CLIENT_SECRET` (from Sigma → Administration → Developer Access). Best
+  for automation.
+- **Browser login (no client ID/secret):** sign in once through the browser
+  using the `sigma-api` skill —
+  `eval "$(bash <repo-root>/sigma-api/scripts/browser-login.sh)"`. It stores a
+  refresh token in your OS keychain, and the token scripts below redeem it
+  headlessly (no browser round-trip on subsequent runs). `SIGMA_CLIENT_ID` /
+  `SIGMA_CLIENT_SECRET` can stay unset.
+
+Both options feed the same `get_token.py` / `get-token.sh` helpers below —
+when the client-credential env vars are absent they automatically fall back to
+the stored browser-login refresh token.
 
 **Default (shell-neutral, works in bash/zsh/PowerShell/cmd):** mint a token
 with the stdlib-only Python script and let `scripts/lib/sigma_rest.rb` pick
@@ -55,7 +69,7 @@ ruby scripts/scan-workbooks.rb
 eval "$(bash scripts/get-token.sh)"
 ```
 
-> Tokens expire after ~1 hour. **The Ruby scripts in this skill now auto-refresh on 401** via `scripts/lib/sigma_rest.rb` — full-site scans on large orgs (hundreds of workbooks, sometimes >1 hour total) no longer fail mid-run. If you still see `Token missing or malformed` after a refresh, re-run `python3 scripts/get_token.py --workdir "$SIGMA_WORKDIR"` (or `eval "$(bash scripts/get-token.sh)"` in bash) manually.
+> Tokens expire after ~1 hour. **With client credentials, the Ruby scripts auto-refresh on 401** via `scripts/lib/sigma_rest.rb` — full-site scans on large orgs (hundreds of workbooks, sometimes >1 hour total) no longer fail mid-run. **Browser-login users** don't have client credentials for the in-process refresh, so re-run `python3 scripts/get_token.py --workdir "$SIGMA_WORKDIR"` between phases — it serves the cached keychain token or redeems the stored refresh token headlessly. Either way, if you still see `Token missing or malformed`, re-run `python3 scripts/get_token.py --workdir "$SIGMA_WORKDIR"` (or `eval "$(bash scripts/get-token.sh)"` in bash) manually.
 
 ---
 

--- a/custom-sql-to-data-model/generated/continue/custom-sql-to-data-model.md
+++ b/custom-sql-to-data-model/generated/continue/custom-sql-to-data-model.md
@@ -27,7 +27,21 @@ catches.
 
 ## Prerequisites
 
-Required env vars: `SIGMA_BASE_URL`, `SIGMA_CLIENT_ID`, `SIGMA_CLIENT_SECRET`
+Required env var: `SIGMA_BASE_URL`. Then pick **one** of two auth options:
+
+- **Client credentials (headless):** set `SIGMA_CLIENT_ID` and
+  `SIGMA_CLIENT_SECRET` (from Sigma → Administration → Developer Access). Best
+  for automation.
+- **Browser login (no client ID/secret):** sign in once through the browser
+  using the `sigma-api` skill —
+  `eval "$(bash <repo-root>/sigma-api/scripts/browser-login.sh)"`. It stores a
+  refresh token in your OS keychain, and the token scripts below redeem it
+  headlessly (no browser round-trip on subsequent runs). `SIGMA_CLIENT_ID` /
+  `SIGMA_CLIENT_SECRET` can stay unset.
+
+Both options feed the same `get_token.py` / `get-token.sh` helpers below —
+when the client-credential env vars are absent they automatically fall back to
+the stored browser-login refresh token.
 
 **Default (shell-neutral, works in bash/zsh/PowerShell/cmd):** mint a token
 with the stdlib-only Python script and let `scripts/lib/sigma_rest.rb` pick
@@ -55,7 +69,7 @@ ruby scripts/scan-workbooks.rb
 eval "$(bash scripts/get-token.sh)"
 ```
 
-> Tokens expire after ~1 hour. **The Ruby scripts in this skill now auto-refresh on 401** via `scripts/lib/sigma_rest.rb` — full-site scans on large orgs (hundreds of workbooks, sometimes >1 hour total) no longer fail mid-run. If you still see `Token missing or malformed` after a refresh, re-run `python3 scripts/get_token.py --workdir "$SIGMA_WORKDIR"` (or `eval "$(bash scripts/get-token.sh)"` in bash) manually.
+> Tokens expire after ~1 hour. **With client credentials, the Ruby scripts auto-refresh on 401** via `scripts/lib/sigma_rest.rb` — full-site scans on large orgs (hundreds of workbooks, sometimes >1 hour total) no longer fail mid-run. **Browser-login users** don't have client credentials for the in-process refresh, so re-run `python3 scripts/get_token.py --workdir "$SIGMA_WORKDIR"` between phases — it serves the cached keychain token or redeems the stored refresh token headlessly. Either way, if you still see `Token missing or malformed`, re-run `python3 scripts/get_token.py --workdir "$SIGMA_WORKDIR"` (or `eval "$(bash scripts/get-token.sh)"` in bash) manually.
 
 ---
 

--- a/custom-sql-to-data-model/generated/cursor/rules/custom-sql-to-data-model.mdc
+++ b/custom-sql-to-data-model/generated/cursor/rules/custom-sql-to-data-model.mdc
@@ -32,7 +32,21 @@ catches.
 
 ## Prerequisites
 
-Required env vars: `SIGMA_BASE_URL`, `SIGMA_CLIENT_ID`, `SIGMA_CLIENT_SECRET`
+Required env var: `SIGMA_BASE_URL`. Then pick **one** of two auth options:
+
+- **Client credentials (headless):** set `SIGMA_CLIENT_ID` and
+  `SIGMA_CLIENT_SECRET` (from Sigma → Administration → Developer Access). Best
+  for automation.
+- **Browser login (no client ID/secret):** sign in once through the browser
+  using the `sigma-api` skill —
+  `eval "$(bash <repo-root>/sigma-api/scripts/browser-login.sh)"`. It stores a
+  refresh token in your OS keychain, and the token scripts below redeem it
+  headlessly (no browser round-trip on subsequent runs). `SIGMA_CLIENT_ID` /
+  `SIGMA_CLIENT_SECRET` can stay unset.
+
+Both options feed the same `get_token.py` / `get-token.sh` helpers below —
+when the client-credential env vars are absent they automatically fall back to
+the stored browser-login refresh token.
 
 **Default (shell-neutral, works in bash/zsh/PowerShell/cmd):** mint a token
 with the stdlib-only Python script and let `scripts/lib/sigma_rest.rb` pick
@@ -60,7 +74,7 @@ ruby scripts/scan-workbooks.rb
 eval "$(bash scripts/get-token.sh)"
 ```
 
-> Tokens expire after ~1 hour. **The Ruby scripts in this skill now auto-refresh on 401** via `scripts/lib/sigma_rest.rb` — full-site scans on large orgs (hundreds of workbooks, sometimes >1 hour total) no longer fail mid-run. If you still see `Token missing or malformed` after a refresh, re-run `python3 scripts/get_token.py --workdir "$SIGMA_WORKDIR"` (or `eval "$(bash scripts/get-token.sh)"` in bash) manually.
+> Tokens expire after ~1 hour. **With client credentials, the Ruby scripts auto-refresh on 401** via `scripts/lib/sigma_rest.rb` — full-site scans on large orgs (hundreds of workbooks, sometimes >1 hour total) no longer fail mid-run. **Browser-login users** don't have client credentials for the in-process refresh, so re-run `python3 scripts/get_token.py --workdir "$SIGMA_WORKDIR"` between phases — it serves the cached keychain token or redeems the stored refresh token headlessly. Either way, if you still see `Token missing or malformed`, re-run `python3 scripts/get_token.py --workdir "$SIGMA_WORKDIR"` (or `eval "$(bash scripts/get-token.sh)"` in bash) manually.
 
 ---
 

--- a/custom-sql-to-data-model/scripts/get-token.sh
+++ b/custom-sql-to-data-model/scripts/get-token.sh
@@ -1,7 +1,13 @@
 #!/usr/bin/env bash
-# Exchange Sigma client credentials for a bearer token.
+# Exchange Sigma credentials for a bearer token.
 # Usage:  eval "$(scripts/get-token.sh)"
 # Sets SIGMA_API_TOKEN in the calling shell.
+#
+# Two auth options (SIGMA_BASE_URL is required for both):
+#   - Client credentials: set SIGMA_CLIENT_ID / SIGMA_CLIENT_SECRET (headless).
+#   - Browser login: if those are unset, this delegates to get_token.py, which
+#     redeems the refresh token the sigma-api skill's browser-login.sh stored
+#     in your OS keychain — no client ID/secret needed.
 #
 # bash/zsh only — PowerShell and cmd.exe can't run `eval "$(...)"`. For a
 # shell-neutral path (any shell, any agent), use scripts/get_token.py instead:
@@ -10,9 +16,19 @@
 
 set -euo pipefail
 
-: "${SIGMA_BASE_URL:?Run scripts/setup.rb to configure credentials}"
-: "${SIGMA_CLIENT_ID:?Run scripts/setup.rb to configure credentials}"
-: "${SIGMA_CLIENT_SECRET:?Run scripts/setup.rb to configure credentials}"
+: "${SIGMA_BASE_URL:?Set SIGMA_BASE_URL to your cloud API host (see the README Auth section)}"
+
+# No client credentials → hand off to get_token.py, which covers the
+# browser-login refresh path too (and prints the same `export` line).
+if [ -z "${SIGMA_CLIENT_ID:-}" ] || [ -z "${SIGMA_CLIENT_SECRET:-}" ]; then
+  SCRIPT_DIR=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+  if command -v python3 >/dev/null 2>&1; then
+    exec python3 "$SCRIPT_DIR/get_token.py" --print-export
+  fi
+  echo "Error: SIGMA_CLIENT_ID / SIGMA_CLIENT_SECRET are unset and python3 is not available." >&2
+  echo "  Set client credentials, or sign in with the sigma-api skill's browser-login.sh." >&2
+  exit 1
+fi
 
 CREDENTIALS=$(printf '%s:%s' "$SIGMA_CLIENT_ID" "$SIGMA_CLIENT_SECRET" | base64)
 

--- a/custom-sql-to-data-model/scripts/get_token.py
+++ b/custom-sql-to-data-model/scripts/get_token.py
@@ -15,17 +15,37 @@ auth.json shape:  {"SIGMA_API_TOKEN": "...", "SIGMA_BASE_URL": "..."}
 It is read by scripts/lib/sigma_rest.rb (env vars still win) and MUST be
 kept out of version control — it holds a live bearer token.
 
-Credential resolution: SIGMA_BASE_URL / SIGMA_CLIENT_ID / SIGMA_CLIENT_SECRET
-must already be in the environment (see the repo README / .env.example).
+Credential resolution (SIGMA_BASE_URL is always required):
+  1. Client credentials — if SIGMA_CLIENT_ID and SIGMA_CLIENT_SECRET are in
+     the environment, exchange them for a token (headless, the default).
+  2. Browser login — otherwise, if you have signed in once via the sigma-api
+     skill's browser login (`browser-login.sh`), this redeems the refresh
+     token it stored in your OS keychain — no browser round-trip, no client
+     ID/secret. It serves a still-valid cached access token when present and
+     only redeems (and rotates) the refresh token when the cache is stale.
+See the repo README / .env.example for setup.
 """
 
 import argparse
 import base64
+import getpass
 import json
 import os
+import re
+import shutil
+import subprocess
 import sys
+import time
 import urllib.error
+import urllib.parse
 import urllib.request
+
+# Pin every OAuth host to a known Sigma cloud. auth.json is not eval'd, but the
+# token still becomes an Authorization header, so never POST a keychain-stored
+# refresh token to a host a tampered keychain value might name.
+SIGMA_DOMAIN = "sigma" "computing.com"
+# RFC 6750 bearer-token alphabet — reject anything outside it before use.
+_BEARER_RE = re.compile(r"^[A-Za-z0-9._~+/=-]+$")
 
 
 def _die(msg):
@@ -33,17 +53,19 @@ def _die(msg):
     sys.exit(1)
 
 
-def mint_token():
-    base = os.environ.get("SIGMA_BASE_URL")
-    cid = os.environ.get("SIGMA_CLIENT_ID")
-    secret = os.environ.get("SIGMA_CLIENT_SECRET")
-    if not base or not cid or not secret:
-        _die(
-            "FATAL: Sigma credentials not set.\n"
-            "  Set SIGMA_BASE_URL / SIGMA_CLIENT_ID / SIGMA_CLIENT_SECRET in the\n"
-            "  environment (see .env.example / README.md 'Auth' section)."
-        )
+def _assert_sigma_host(url):
+    # Parse the authority exactly as a client would: strip scheme, stop at the
+    # first '/', '?', or '#', drop any userinfo and port. A naive parse would
+    # let a fragment spoof the trusted suffix.
+    host = re.sub(r"^https?://", "", url)
+    host = re.split(r"[/?#]", host, 1)[0]
+    host = host.split("@")[-1]
+    host = re.sub(r":\d+$", "", host)
+    if not (host == SIGMA_DOMAIN or host.endswith("." + SIGMA_DOMAIN)):
+        _die(f"FATAL: refusing OAuth endpoint on non-Sigma host: {host or '<none>'}")
 
+
+def _mint_client_credentials(base, cid, secret):
     # The #1 hard blocker in practice: a settings file where
     # SIGMA_CLIENT_SECRET is a COPY of SIGMA_CLIENT_ID. Sigma returns the
     # opaque "client secret provided is invalid" and nothing else runs.
@@ -86,6 +108,157 @@ def mint_token():
     return base, token
 
 
+# --- Browser-login fallback: redeem the refresh token that sigma-api's
+# --- browser-login.sh stored in the OS keychain. Mirrors refresh-token.sh:
+# --- serve a valid cached access token, else redeem (and rotate) the refresh
+# --- token. Naming matches what browser-login.sh writes (macOS service
+# --- "sigma-api:<name>"; libsecret service=sigma-api key=<name>). ---
+def _keychain_backend():
+    if shutil.which("security"):
+        return "macos"
+    if shutil.which("secret-tool"):
+        return "libsecret"
+    return None
+
+
+def _kc_get(backend, name):
+    try:
+        if backend == "macos":
+            out = subprocess.run(
+                ["security", "find-generic-password", "-a", getpass.getuser(),
+                 "-s", f"sigma-api:{name}", "-w"],
+                capture_output=True, text=True,
+            )
+        else:
+            out = subprocess.run(
+                ["secret-tool", "lookup", "service", "sigma-api", "key", name],
+                capture_output=True, text=True,
+            )
+    except OSError:
+        return ""
+    if out.returncode != 0:
+        return ""
+    return out.stdout.strip()
+
+
+def _kc_set(backend, name, value):
+    try:
+        if backend == "macos":
+            subprocess.run(
+                ["security", "add-generic-password", "-U", "-a", getpass.getuser(),
+                 "-s", f"sigma-api:{name}", "-w", value],
+                capture_output=True, text=True,
+            )
+        else:
+            subprocess.run(
+                ["secret-tool", "store", "--label", f"sigma-api {name}",
+                 "service", "sigma-api", "key", name],
+                input=value, capture_output=True, text=True,
+            )
+    except OSError:
+        pass
+
+
+def _mint_browser_refresh(base):
+    """Return (base, token) from a stored browser-login refresh token, or None
+    when there is nothing stored to redeem (so the caller can report a single
+    unified 'no credentials' error)."""
+    backend = _keychain_backend()
+    if backend is None:
+        return None
+    refresh = _kc_get(backend, "refresh-token")
+    if not refresh:
+        return None
+
+    now = int(time.time())
+    cached = _kc_get(backend, "access-token")
+    expiry = _kc_get(backend, "access-expiry")
+    if cached and expiry.isdigit() and int(expiry) > now:
+        return base, cached
+
+    client_id = _kc_get(backend, "client-id")
+    token_url = _kc_get(backend, "token-url")
+    if not client_id or not token_url:
+        _die(
+            "FATAL: found a stored browser-login refresh token but not the client-id /\n"
+            "  token-url needed to redeem it (browser-login.sh persists these on macOS).\n"
+            "  Re-run the sigma-api skill's browser-login.sh, or use client credentials."
+        )
+    _assert_sigma_host(token_url)
+
+    data = urllib.parse.urlencode({
+        "grant_type": "refresh_token",
+        "refresh_token": refresh,
+        "client_id": client_id,
+    }).encode()
+    req = urllib.request.Request(
+        token_url,
+        data=data,
+        headers={"Content-Type": "application/x-www-form-urlencoded"},
+        method="POST",
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=30) as resp:
+            payload = json.load(resp)
+    except urllib.error.HTTPError as e:
+        _die(
+            "Refresh failed — the saved refresh token may be revoked or expired.\n"
+            "  Re-run the sigma-api skill's browser-login.sh to sign in again.\n"
+            f"  server -> {e.code} {e.reason}"
+        )
+    except urllib.error.URLError as e:
+        _die(f"Refresh failed — could not reach {token_url}: {e.reason}")
+
+    token = payload.get("access_token")
+    if not token:
+        _die("Refresh failed — response did not contain access_token")
+
+    try:
+        expires_in = int(payload.get("expires_in") or 3600)
+    except (TypeError, ValueError):
+        expires_in = 3600
+    # 60s safety margin so a token never expires mid-request.
+    _kc_set(backend, "access-token", token)
+    _kc_set(backend, "access-expiry", str(now + expires_in - 60))
+    # Refresh tokens are single-use and rotate — persist any replacement or the
+    # next redemption fails.
+    new_refresh = payload.get("refresh_token")
+    if new_refresh and new_refresh != refresh:
+        _kc_set(backend, "refresh-token", new_refresh)
+    return base, token
+
+
+def mint_token():
+    base = os.environ.get("SIGMA_BASE_URL")
+    if not base:
+        _die(
+            "FATAL: SIGMA_BASE_URL not set.\n"
+            "  Set it to your cloud's API host (see .env.example / README.md 'Auth')."
+        )
+
+    cid = os.environ.get("SIGMA_CLIENT_ID")
+    secret = os.environ.get("SIGMA_CLIENT_SECRET")
+    if cid and secret:
+        return _mint_client_credentials(base, cid, secret)
+
+    # No client credentials — fall back to a browser-login refresh token, if one
+    # was stored by the sigma-api skill's browser-login.sh.
+    result = _mint_browser_refresh(base)
+    if result:
+        return result
+
+    _die(
+        "FATAL: no Sigma credentials available.\n"
+        "  Choose one of two auth options:\n"
+        "    - Client credentials: set SIGMA_CLIENT_ID / SIGMA_CLIENT_SECRET (headless).\n"
+        "    - Browser login: sign in once via the sigma-api skill, then retry —\n"
+        "        eval \"$(bash <repo-root>/sigma-api/scripts/browser-login.sh)\"\n"
+        "      It stores a refresh token in your OS keychain that this script\n"
+        "      redeems headlessly. SIGMA_BASE_URL must still be set either way.\n"
+        "  See .env.example / README.md 'Auth' section."
+    )
+
+
 def main():
     ap = argparse.ArgumentParser(description="Mint a Sigma bearer token (shell-neutral).")
     ap.add_argument("--workdir", help="write <WORKDIR>/auth.json (mode 0600)")
@@ -96,6 +269,9 @@ def main():
     args = ap.parse_args()
 
     base, token = mint_token()
+
+    if not _BEARER_RE.match(token):
+        _die("FATAL: token contains unexpected characters; refusing to emit.")
 
     wrote = False
     if args.workdir:

--- a/sigma-api/scripts/browser-login.sh
+++ b/sigma-api/scripts/browser-login.sh
@@ -307,6 +307,11 @@ if [ -n "$REFRESH" ]; then
     fi
   elif command -v secret-tool >/dev/null 2>&1; then
     if printf '%s' "$REFRESH" | secret-tool store --label="sigma-api refresh token" service sigma-api key refresh-token; then
+      # client_id + token_url ride along so refresh-token.sh / get_token.py can
+      # redeem the refresh token without re-discovering anything (mirrors the
+      # macOS branch above — without these, headless refresh on Linux fails).
+      printf '%s' "$CLIENT_ID" | secret-tool store --label="sigma-api client-id" service sigma-api key client-id >/dev/null 2>&1 || true
+      printf '%s' "$TOKEN_URL" | secret-tool store --label="sigma-api token-url" service sigma-api key token-url >/dev/null 2>&1 || true
       log "Stored refresh token via libsecret (service 'sigma-api', key 'refresh-token')."
     else
       log "Warning: could not write to libsecret; refresh token NOT persisted."

--- a/sigma-data-models/SKILL.md
+++ b/sigma-data-models/SKILL.md
@@ -20,7 +20,7 @@ Build a Sigma data model spec — the JSON definition of pages, sources, columns
 
 This skill is for **authoring from existing warehouse tables**: a user knows their warehouse, wants to expose specific tables as a Sigma data model with the right joins, metrics, and governance, and needs help composing the spec. Conversions from other BI-tool formats (dbt schema.yml, LookML views, Tableau TDS, Power BI PBIT, Alteryx YXMD, etc.) are **not in this skill** — direct users to the Sigma data-model converter MCP / browser tool, which already handles those mappings.
 
-**Auth:** Authenticate via the `sigma-api` skill first to set `$SIGMA_BASE_URL` and `$SIGMA_API_TOKEN`. This skill assumes both are already exported.
+**Auth:** Authenticate via the `sigma-api` skill first to set `$SIGMA_BASE_URL` and `$SIGMA_API_TOKEN`. That skill offers two options — **client credentials** (`SIGMA_CLIENT_ID`/`SIGMA_CLIENT_SECRET`) or **interactive browser login** (`browser-login.sh`, no client ID/secret) — either of which exports the token this skill assumes is already present.
 
 **Requirements:** `curl`, `jq`, `base64`. Your Sigma API credentials must have permission to create or edit data models, plus "Can edit" access on the destination folder (for create) or the existing data model (for update). If a request returns 403, ask your Sigma admin to confirm the credential's permissions.
 

--- a/sigma-data-models/generated/cline/sigma-data-models.md
+++ b/sigma-data-models/generated/cline/sigma-data-models.md
@@ -11,7 +11,7 @@ Build a Sigma data model spec — the JSON definition of pages, sources, columns
 
 This skill is for **authoring from existing warehouse tables**: a user knows their warehouse, wants to expose specific tables as a Sigma data model with the right joins, metrics, and governance, and needs help composing the spec. Conversions from other BI-tool formats (dbt schema.yml, LookML views, Tableau TDS, Power BI PBIT, Alteryx YXMD, etc.) are **not in this skill** — direct users to the Sigma data-model converter MCP / browser tool, which already handles those mappings.
 
-**Auth:** Authenticate via the `sigma-api` skill first to set `$SIGMA_BASE_URL` and `$SIGMA_API_TOKEN`. This skill assumes both are already exported.
+**Auth:** Authenticate via the `sigma-api` skill first to set `$SIGMA_BASE_URL` and `$SIGMA_API_TOKEN`. That skill offers two options — **client credentials** (`SIGMA_CLIENT_ID`/`SIGMA_CLIENT_SECRET`) or **interactive browser login** (`browser-login.sh`, no client ID/secret) — either of which exports the token this skill assumes is already present.
 
 **Requirements:** `curl`, `jq`, `base64`. Your Sigma API credentials must have permission to create or edit data models, plus "Can edit" access on the destination folder (for create) or the existing data model (for update). If a request returns 403, ask your Sigma admin to confirm the credential's permissions.
 

--- a/sigma-data-models/generated/codex/AGENTS.md
+++ b/sigma-data-models/generated/codex/AGENTS.md
@@ -11,7 +11,7 @@ Build a Sigma data model spec — the JSON definition of pages, sources, columns
 
 This skill is for **authoring from existing warehouse tables**: a user knows their warehouse, wants to expose specific tables as a Sigma data model with the right joins, metrics, and governance, and needs help composing the spec. Conversions from other BI-tool formats (dbt schema.yml, LookML views, Tableau TDS, Power BI PBIT, Alteryx YXMD, etc.) are **not in this skill** — direct users to the Sigma data-model converter MCP / browser tool, which already handles those mappings.
 
-**Auth:** Authenticate via the `sigma-api` skill first to set `$SIGMA_BASE_URL` and `$SIGMA_API_TOKEN`. This skill assumes both are already exported.
+**Auth:** Authenticate via the `sigma-api` skill first to set `$SIGMA_BASE_URL` and `$SIGMA_API_TOKEN`. That skill offers two options — **client credentials** (`SIGMA_CLIENT_ID`/`SIGMA_CLIENT_SECRET`) or **interactive browser login** (`browser-login.sh`, no client ID/secret) — either of which exports the token this skill assumes is already present.
 
 **Requirements:** `curl`, `jq`, `base64`. Your Sigma API credentials must have permission to create or edit data models, plus "Can edit" access on the destination folder (for create) or the existing data model (for update). If a request returns 403, ask your Sigma admin to confirm the credential's permissions.
 

--- a/sigma-data-models/generated/continue/sigma-data-models.md
+++ b/sigma-data-models/generated/continue/sigma-data-models.md
@@ -11,7 +11,7 @@ Build a Sigma data model spec — the JSON definition of pages, sources, columns
 
 This skill is for **authoring from existing warehouse tables**: a user knows their warehouse, wants to expose specific tables as a Sigma data model with the right joins, metrics, and governance, and needs help composing the spec. Conversions from other BI-tool formats (dbt schema.yml, LookML views, Tableau TDS, Power BI PBIT, Alteryx YXMD, etc.) are **not in this skill** — direct users to the Sigma data-model converter MCP / browser tool, which already handles those mappings.
 
-**Auth:** Authenticate via the `sigma-api` skill first to set `$SIGMA_BASE_URL` and `$SIGMA_API_TOKEN`. This skill assumes both are already exported.
+**Auth:** Authenticate via the `sigma-api` skill first to set `$SIGMA_BASE_URL` and `$SIGMA_API_TOKEN`. That skill offers two options — **client credentials** (`SIGMA_CLIENT_ID`/`SIGMA_CLIENT_SECRET`) or **interactive browser login** (`browser-login.sh`, no client ID/secret) — either of which exports the token this skill assumes is already present.
 
 **Requirements:** `curl`, `jq`, `base64`. Your Sigma API credentials must have permission to create or edit data models, plus "Can edit" access on the destination folder (for create) or the existing data model (for update). If a request returns 403, ask your Sigma admin to confirm the credential's permissions.
 

--- a/sigma-data-models/generated/cursor/rules/sigma-data-models.mdc
+++ b/sigma-data-models/generated/cursor/rules/sigma-data-models.mdc
@@ -16,7 +16,7 @@ Build a Sigma data model spec — the JSON definition of pages, sources, columns
 
 This skill is for **authoring from existing warehouse tables**: a user knows their warehouse, wants to expose specific tables as a Sigma data model with the right joins, metrics, and governance, and needs help composing the spec. Conversions from other BI-tool formats (dbt schema.yml, LookML views, Tableau TDS, Power BI PBIT, Alteryx YXMD, etc.) are **not in this skill** — direct users to the Sigma data-model converter MCP / browser tool, which already handles those mappings.
 
-**Auth:** Authenticate via the `sigma-api` skill first to set `$SIGMA_BASE_URL` and `$SIGMA_API_TOKEN`. This skill assumes both are already exported.
+**Auth:** Authenticate via the `sigma-api` skill first to set `$SIGMA_BASE_URL` and `$SIGMA_API_TOKEN`. That skill offers two options — **client credentials** (`SIGMA_CLIENT_ID`/`SIGMA_CLIENT_SECRET`) or **interactive browser login** (`browser-login.sh`, no client ID/secret) — either of which exports the token this skill assumes is already present.
 
 **Requirements:** `curl`, `jq`, `base64`. Your Sigma API credentials must have permission to create or edit data models, plus "Can edit" access on the destination folder (for create) or the existing data model (for update). If a request returns 403, ask your Sigma admin to confirm the credential's permissions.
 

--- a/sigma-plugin-authoring/SKILL.md
+++ b/sigma-plugin-authoring/SKILL.md
@@ -160,7 +160,7 @@ vendored dependency — this skill doesn't ship or maintain it.
   mechanics) → `sigma-workbooks` skill.
 - **The underlying data model** the bound element sources from →
   `sigma-data-models` skill.
-- **Auth, base URL, token refresh** → defer to the `sigma-api` skill.
+- **Auth, base URL, token refresh** → defer to the `sigma-api` skill (either client credentials or interactive browser login yields the `SIGMA_API_TOKEN` this skill needs).
 
 ## Troubleshooting
 

--- a/sigma-plugin-authoring/generated/cline/sigma-plugin-authoring.md
+++ b/sigma-plugin-authoring/generated/cline/sigma-plugin-authoring.md
@@ -150,7 +150,7 @@ vendored dependency — this skill doesn't ship or maintain it.
   mechanics) → `sigma-workbooks` skill.
 - **The underlying data model** the bound element sources from →
   `sigma-data-models` skill.
-- **Auth, base URL, token refresh** → defer to the `sigma-api` skill.
+- **Auth, base URL, token refresh** → defer to the `sigma-api` skill (either client credentials or interactive browser login yields the `SIGMA_API_TOKEN` this skill needs).
 
 ## Troubleshooting
 

--- a/sigma-plugin-authoring/generated/codex/AGENTS.md
+++ b/sigma-plugin-authoring/generated/codex/AGENTS.md
@@ -150,7 +150,7 @@ vendored dependency — this skill doesn't ship or maintain it.
   mechanics) → `sigma-workbooks` skill.
 - **The underlying data model** the bound element sources from →
   `sigma-data-models` skill.
-- **Auth, base URL, token refresh** → defer to the `sigma-api` skill.
+- **Auth, base URL, token refresh** → defer to the `sigma-api` skill (either client credentials or interactive browser login yields the `SIGMA_API_TOKEN` this skill needs).
 
 ## Troubleshooting
 

--- a/sigma-plugin-authoring/generated/continue/sigma-plugin-authoring.md
+++ b/sigma-plugin-authoring/generated/continue/sigma-plugin-authoring.md
@@ -150,7 +150,7 @@ vendored dependency — this skill doesn't ship or maintain it.
   mechanics) → `sigma-workbooks` skill.
 - **The underlying data model** the bound element sources from →
   `sigma-data-models` skill.
-- **Auth, base URL, token refresh** → defer to the `sigma-api` skill.
+- **Auth, base URL, token refresh** → defer to the `sigma-api` skill (either client credentials or interactive browser login yields the `SIGMA_API_TOKEN` this skill needs).
 
 ## Troubleshooting
 

--- a/sigma-plugin-authoring/generated/cursor/rules/sigma-plugin-authoring.mdc
+++ b/sigma-plugin-authoring/generated/cursor/rules/sigma-plugin-authoring.mdc
@@ -155,7 +155,7 @@ vendored dependency — this skill doesn't ship or maintain it.
   mechanics) → `sigma-workbooks` skill.
 - **The underlying data model** the bound element sources from →
   `sigma-data-models` skill.
-- **Auth, base URL, token refresh** → defer to the `sigma-api` skill.
+- **Auth, base URL, token refresh** → defer to the `sigma-api` skill (either client credentials or interactive browser login yields the `SIGMA_API_TOKEN` this skill needs).
 
 ## Troubleshooting
 

--- a/sigma-workbooks/SKILL.md
+++ b/sigma-workbooks/SKILL.md
@@ -101,7 +101,7 @@ ruby scripts/wb-rep.rb capabilities --kind bar-chart --field source  # one field
 
 ## Auth
 
-Authenticate via the `sigma-api` skill first to populate `$SIGMA_BASE_URL` and `$SIGMA_API_TOKEN`.
+Authenticate via the `sigma-api` skill first to populate `$SIGMA_BASE_URL` and `$SIGMA_API_TOKEN`. Two options there: **client credentials** (`SIGMA_CLIENT_ID`/`SIGMA_CLIENT_SECRET`, best for headless/automation) or **interactive browser login** (`sigma-api/scripts/browser-login.sh` → refresh headlessly with `refresh-token.sh`, no client ID/secret). Either yields a `$SIGMA_API_TOKEN`; the rest of this skill is identical.
 
 ## Recommended Workflow
 
@@ -355,7 +355,7 @@ sigma_curl() {
 }
 ```
 
-If 401 persists after refresh, re-authenticate via `sigma-api` and verify `SIGMA_BASE_URL`, `SIGMA_CLIENT_ID`, `SIGMA_CLIENT_SECRET`.
+If 401 persists after refresh, re-authenticate via `sigma-api`: for client credentials verify `SIGMA_BASE_URL`, `SIGMA_CLIENT_ID`, `SIGMA_CLIENT_SECRET`; for browser login re-run `sigma-api/scripts/refresh-token.sh` (or `browser-login.sh` if the refresh token has expired).
 
 ### 403 Forbidden on workbook create
 

--- a/sigma-workbooks/generated/cline/sigma-workbooks.md
+++ b/sigma-workbooks/generated/cline/sigma-workbooks.md
@@ -94,7 +94,7 @@ ruby scripts/wb-rep.rb capabilities --kind bar-chart --field source  # one field
 
 ## Auth
 
-Authenticate via the `sigma-api` skill first to populate `$SIGMA_BASE_URL` and `$SIGMA_API_TOKEN`.
+Authenticate via the `sigma-api` skill first to populate `$SIGMA_BASE_URL` and `$SIGMA_API_TOKEN`. Two options there: **client credentials** (`SIGMA_CLIENT_ID`/`SIGMA_CLIENT_SECRET`, best for headless/automation) or **interactive browser login** (`sigma-api/scripts/browser-login.sh` → refresh headlessly with `refresh-token.sh`, no client ID/secret). Either yields a `$SIGMA_API_TOKEN`; the rest of this skill is identical.
 
 ## Recommended Workflow
 
@@ -348,7 +348,7 @@ sigma_curl() {
 }
 ```
 
-If 401 persists after refresh, re-authenticate via `sigma-api` and verify `SIGMA_BASE_URL`, `SIGMA_CLIENT_ID`, `SIGMA_CLIENT_SECRET`.
+If 401 persists after refresh, re-authenticate via `sigma-api`: for client credentials verify `SIGMA_BASE_URL`, `SIGMA_CLIENT_ID`, `SIGMA_CLIENT_SECRET`; for browser login re-run `sigma-api/scripts/refresh-token.sh` (or `browser-login.sh` if the refresh token has expired).
 
 ### 403 Forbidden on workbook create
 

--- a/sigma-workbooks/generated/codex/AGENTS.md
+++ b/sigma-workbooks/generated/codex/AGENTS.md
@@ -94,7 +94,7 @@ ruby scripts/wb-rep.rb capabilities --kind bar-chart --field source  # one field
 
 ## Auth
 
-Authenticate via the `sigma-api` skill first to populate `$SIGMA_BASE_URL` and `$SIGMA_API_TOKEN`.
+Authenticate via the `sigma-api` skill first to populate `$SIGMA_BASE_URL` and `$SIGMA_API_TOKEN`. Two options there: **client credentials** (`SIGMA_CLIENT_ID`/`SIGMA_CLIENT_SECRET`, best for headless/automation) or **interactive browser login** (`sigma-api/scripts/browser-login.sh` → refresh headlessly with `refresh-token.sh`, no client ID/secret). Either yields a `$SIGMA_API_TOKEN`; the rest of this skill is identical.
 
 ## Recommended Workflow
 
@@ -348,7 +348,7 @@ sigma_curl() {
 }
 ```
 
-If 401 persists after refresh, re-authenticate via `sigma-api` and verify `SIGMA_BASE_URL`, `SIGMA_CLIENT_ID`, `SIGMA_CLIENT_SECRET`.
+If 401 persists after refresh, re-authenticate via `sigma-api`: for client credentials verify `SIGMA_BASE_URL`, `SIGMA_CLIENT_ID`, `SIGMA_CLIENT_SECRET`; for browser login re-run `sigma-api/scripts/refresh-token.sh` (or `browser-login.sh` if the refresh token has expired).
 
 ### 403 Forbidden on workbook create
 

--- a/sigma-workbooks/generated/continue/sigma-workbooks.md
+++ b/sigma-workbooks/generated/continue/sigma-workbooks.md
@@ -94,7 +94,7 @@ ruby scripts/wb-rep.rb capabilities --kind bar-chart --field source  # one field
 
 ## Auth
 
-Authenticate via the `sigma-api` skill first to populate `$SIGMA_BASE_URL` and `$SIGMA_API_TOKEN`.
+Authenticate via the `sigma-api` skill first to populate `$SIGMA_BASE_URL` and `$SIGMA_API_TOKEN`. Two options there: **client credentials** (`SIGMA_CLIENT_ID`/`SIGMA_CLIENT_SECRET`, best for headless/automation) or **interactive browser login** (`sigma-api/scripts/browser-login.sh` → refresh headlessly with `refresh-token.sh`, no client ID/secret). Either yields a `$SIGMA_API_TOKEN`; the rest of this skill is identical.
 
 ## Recommended Workflow
 
@@ -348,7 +348,7 @@ sigma_curl() {
 }
 ```
 
-If 401 persists after refresh, re-authenticate via `sigma-api` and verify `SIGMA_BASE_URL`, `SIGMA_CLIENT_ID`, `SIGMA_CLIENT_SECRET`.
+If 401 persists after refresh, re-authenticate via `sigma-api`: for client credentials verify `SIGMA_BASE_URL`, `SIGMA_CLIENT_ID`, `SIGMA_CLIENT_SECRET`; for browser login re-run `sigma-api/scripts/refresh-token.sh` (or `browser-login.sh` if the refresh token has expired).
 
 ### 403 Forbidden on workbook create
 

--- a/sigma-workbooks/generated/cursor/rules/sigma-workbooks.mdc
+++ b/sigma-workbooks/generated/cursor/rules/sigma-workbooks.mdc
@@ -99,7 +99,7 @@ ruby scripts/wb-rep.rb capabilities --kind bar-chart --field source  # one field
 
 ## Auth
 
-Authenticate via the `sigma-api` skill first to populate `$SIGMA_BASE_URL` and `$SIGMA_API_TOKEN`.
+Authenticate via the `sigma-api` skill first to populate `$SIGMA_BASE_URL` and `$SIGMA_API_TOKEN`. Two options there: **client credentials** (`SIGMA_CLIENT_ID`/`SIGMA_CLIENT_SECRET`, best for headless/automation) or **interactive browser login** (`sigma-api/scripts/browser-login.sh` → refresh headlessly with `refresh-token.sh`, no client ID/secret). Either yields a `$SIGMA_API_TOKEN`; the rest of this skill is identical.
 
 ## Recommended Workflow
 
@@ -353,7 +353,7 @@ sigma_curl() {
 }
 ```
 
-If 401 persists after refresh, re-authenticate via `sigma-api` and verify `SIGMA_BASE_URL`, `SIGMA_CLIENT_ID`, `SIGMA_CLIENT_SECRET`.
+If 401 persists after refresh, re-authenticate via `sigma-api`: for client credentials verify `SIGMA_BASE_URL`, `SIGMA_CLIENT_ID`, `SIGMA_CLIENT_SECRET`; for browser login re-run `sigma-api/scripts/refresh-token.sh` (or `browser-login.sh` if the refresh token has expired).
 
 ### 403 Forbidden on workbook create
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Makes interactive **browser OAuth login** (authorization-code + PKCE) a first-class alternative to client-credentials across the skills, instead of only being surfaced inside `sigma-api`. The browser flow itself already exists (`sigma-api/scripts/browser-login.sh` + `refresh-token.sh`); this change surfaces it everywhere the docs previously implied `SIGMA_CLIENT_ID`/`SIGMA_CLIENT_SECRET` was the only path, and teaches the `custom-sql-to-data-model` skill's own token scripts to use it.

> Note on the linked reference: the task linked the [Use OAuth override tokens](https://help.sigmacomputing.com/reference/use-oauth-override-tokens) doc, which is a *different* feature (the `x-sigma-oauth-overrides` header for per-connection warehouse tokens, only relevant to data-export endpoints these authoring/metadata skills don't call). This PR implements the stated goal — browser login as an option — not override tokens. Override-token support can be a follow-up if wanted.

## Changes

- **`custom-sql-to-data-model` token scripts** (its own client-credentials-only infra):
  - `scripts/get_token.py`: when `SIGMA_CLIENT_ID`/`SIGMA_CLIENT_SECRET` are absent, redeem the browser-login refresh token stored in the OS keychain (serves a valid cached token, else redeems + rotates the refresh token), with host pinning to Sigma and RFC 6750 token-alphabet validation. Falls back to a unified, actionable error when neither auth option is available.
  - `scripts/get-token.sh`: delegates to `get_token.py` when client credentials are unset instead of hard-failing.
  - `SKILL.md`: Prerequisites now present the two auth options; the token-expiry note clarifies that in-process 401 auto-refresh applies to the client-credentials path, while browser-login users re-run `get_token.py`.
- **Orchestrating skills** (`sigma-workbooks`, `sigma-data-models`, `sigma-plugin-authoring`): auth/401 sections now mention browser login as an alternative to client credentials.
- **Repo docs**: `README.md` gains an "Interactive browser login" option; `.env.example` notes client ID/secret are optional when using browser login.
- **`sigma-api/scripts/browser-login.sh`**: the libsecret (Linux) branch now stores `client-id` + `token-url` alongside the refresh token, matching the macOS branch — without these, headless refresh (`refresh-token.sh` / `get_token.py`) was broken on Linux. (Found while testing this PR live.)
- Regenerated `generated/` agent outputs (codex/cursor/cline/continue) for every edited skill.

## Testing

Static + unit:
- `python3 -m py_compile get_token.py`, `bash -n` on all edited shell scripts pass.
- Repo Ruby unit suite (creds-free glob, mirrors CI): 11/11 pass.
- Dispatch + browser-refresh internals unit-tested (host pinning, cached-token-without-network, no-token → `None`, unified error).

**Live end-to-end against production Sigma (verified during review):**
- Ran the real `browser-login.sh` machinery: discovery → real RFC 7591 client registration → PKCE → authorization URL, all against production Sigma hosts.
- Completed a full interactive sign-in (human approved in-browser, code exchanged): CSRF state verified, code → access + refresh tokens, `/v2/whoami` returned a real `userId`/`organizationId`.
- Exercised **this PR's new code path**: with client credentials unset, `custom-sql/scripts/get_token.py` read the stored refresh token from libsecret, redeemed it against the real Sigma token endpoint, minted a valid token (confirmed via `/v2/whoami`), served a cache hit on the second run, and rotated the single-use refresh token in the keychain.

Notes:
- Keychain persistence is macOS + Linux (libsecret); the Linux fix above closes the previously-broken headless-refresh path there.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5be45e28-1c83-474f-b675-ed7b55fefa66?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5be45e28-1c83-474f-b675-ed7b55fefa66&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

