### PR TITLE
feat(sigma-reports): add fixed-layout report authoring skill

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -29,10 +29,10 @@ jobs:
       - name: Run every test-*.rb / test_*.rb (glob, aggregate failures)
         run: |
           set -uo pipefail
-          dirs=(sigma-workbooks custom-sql-to-data-model sigma-plugin-authoring)
+          dirs=(sigma-workbooks sigma-reports custom-sql-to-data-model sigma-plugin-authoring)
           # Each directory must exist on its own — an aggregate count alone
           # would let one moved/renamed directory silently vanish from the
-          # glob while the other two still supply enough matches to pass.
+          # glob while the other directories still supply enough matches to pass.
           for d in "${dirs[@]}"; do
             [ -d "$d" ] || { echo "::error::expected test directory '$d' not found (moved/renamed?)"; exit 1; }
           done
@@ -43,7 +43,7 @@ jobs:
           # Belt-and-suspenders: a directory can exist but have every test
           # file deleted from it. A moved/renamed directory (caught above) or
           # an emptied one (caught here) must FAIL, never vacuously pass.
-          [ "${#tests[@]}" -gt 0 ] || { echo "::error::glob matched no test files under sigma-workbooks/, custom-sql-to-data-model/, sigma-plugin-authoring/"; exit 1; }
+          [ "${#tests[@]}" -gt 0 ] || { echo "::error::glob matched no test files under sigma-workbooks/, sigma-reports/, custom-sql-to-data-model/, sigma-plugin-authoring/"; exit 1; }
           fail=0; ran=0
           for t in "${tests[@]}"; do
             case "$t" in

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Skills for building and maintaining analytics in Sigma Computing from any AI coding agent.
 
-The skills split along the surfaces of the Sigma REST API — one for data models, one for workbooks, plus utility skills that orchestrate them. Each skill is a self-contained directory.
+The skills split along the surfaces of the Sigma REST API: data models, responsive workbooks, fixed-layout reports, and utility skills that orchestrate them. Each skill is a self-contained directory.
 
 **Supported agents** (`generated/` outputs per skill, install via `scripts/install-into-project.sh`):
 
@@ -24,6 +24,7 @@ See [Installation](#installation) below for the install helper.
 | [`sigma-api`](sigma-api/) | Configure Sigma API credentials and mint short-lived bearer tokens with client credentials or interactive browser OAuth. Prerequisite for skills that call the REST API. |
 | [`sigma-data-models`](sigma-data-models/) | Author Sigma data models from existing warehouse tables — sources, columns, metrics, relationships, filters, calc columns, CLS. Covers spec shape, discovery, CRUD, validation, and authoring judgment calls. **Out of scope: converting from another BI tool's format** (use the converter MCP / browser tool). |
 | [`sigma-workbooks`](sigma-workbooks/) | Build, edit, and iterate on Sigma workbook specs — pages, layout, controls, charts (line/bar/area/combo/donut), KPIs, tables, pivot tables, formulas, sources. Canonical reference for the workbook spec; other skills cross-link here for spec shape. |
+| [`sigma-reports`](sigma-reports/) | Build, validate, and safely update private-beta Sigma report code representations: fixed pixel pages, header/footer panels, common elements, PDF-oriented validation, and workbook-to-report conversion. Use for invoices, statements, regulatory documents, and other pixel-perfect output, not responsive dashboards. |
 | [`sigma-plugin-authoring`](sigma-plugin-authoring/) | Recreate a source viz that has no native Sigma equivalent — a radial gauge, custom heatmap, sankey — as a bespoke `@sigmacomputing/plugin`: build, register, host, embed, bind, verify. Includes a worked gauge example. |
 | [`custom-sql-to-data-model`](custom-sql-to-data-model/) | Scan Sigma workbooks for custom SQL elements, dedupe across workbooks, build or reuse data models, then repoint via the v3alpha `:swapSources` endpoint. Handles many workbooks pointing at one shared model. |
 
@@ -39,6 +40,8 @@ See [Installation](#installation) below for the install helper.
 | "Convert this dbt / LookML / Tableau / Power BI / Alteryx model to Sigma" | The **converter MCP** or the **browser converter tool** — *not* a skill. The skills cover authoring, not source-format parsing. |
 | "Build me a sales dashboard / workbook from this data model" | `sigma-workbooks` |
 | "Add a KPI / chart / control to an existing workbook" | `sigma-workbooks` |
+| "Build a pixel-perfect invoice / statement / printable report" | `sigma-reports` |
+| "Convert this workbook to a fixed-layout report" | `sigma-reports` |
 | "There's custom SQL in this workbook — promote it to a model" | `custom-sql-to-data-model` |
 
 ## Architecture
@@ -47,11 +50,12 @@ See [Installation](#installation) below for the install helper.
 sigma-data-models     ──┐
                         ├── building blocks (load on demand)
 sigma-workbooks       ──┘
+sigma-reports         ─── fixed-layout report authoring and delivery
 
 custom-sql-to-data-model    ─── orchestrator: SQL extraction + DM creation
 ```
 
-`sigma-data-models` and `sigma-workbooks` are the building blocks meant to be loaded by any Sigma authoring task. `custom-sql-to-data-model` is a higher-level pipeline that depends on them.
+`sigma-data-models`, `sigma-workbooks`, and `sigma-reports` are authoring building blocks. Workbooks are responsive and exploratory; reports use fixed physical pages. `custom-sql-to-data-model` is a higher-level pipeline that depends on the data-model and workbook skills.
 
 ## Auth
 
@@ -115,6 +119,7 @@ Each skill ships pre-built outputs in `generated/`. Use the install helper to dr
 # Project-local install
 ~/sigma-skills/scripts/install-into-project.sh tableau-to-sigma codex ~/work/myproject
 ~/sigma-skills/scripts/install-into-project.sh sigma-workbooks   cursor ~/work/myproject
+~/sigma-skills/scripts/install-into-project.sh sigma-reports     all    ~/work/myproject
 ~/sigma-skills/scripts/install-into-project.sh sigma-workbooks   all    ~/work/myproject
 
 # User-global install

--- a/scripts/install-into-project.sh
+++ b/scripts/install-into-project.sh
@@ -4,7 +4,8 @@
 # Usage:
 #   install-into-project.sh <skill-name> <target> [<dest-dir>]
 #
-#   <skill-name>   sigma-workbooks | sigma-data-models | custom-sql-to-data-model
+#   <skill-name>   sigma-workbooks | sigma-reports | sigma-data-models
+#                  | custom-sql-to-data-model
 #                  | tableau-to-sigma | tableau-vds-to-snowflake
 #   <target>       codex | cursor | cline | continue | cortex | all
 #   <dest-dir>     project directory (default: $PWD)
@@ -13,6 +14,7 @@
 # Examples:
 #   install-into-project.sh tableau-to-sigma codex ~/work/myproject
 #   install-into-project.sh sigma-workbooks all ~/work/myproject
+#   install-into-project.sh sigma-reports all ~/work/myproject
 #   install-into-project.sh sigma-workbooks codex --global   # → ~/.codex/AGENTS.md (concat)
 #
 # Cortex Code reads Claude's SKILL.md format natively — for `cortex`, this

--- a/sigma-reports/SKILL.md
+++ b/sigma-reports/SKILL.md
@@ -1,0 +1,233 @@
+---
+name: sigma-reports
+description: >-
+  Build, validate, retrieve, and safely update Sigma report code
+  representations through /v2/reports/spec. Use for fixed-layout or
+  pixel-perfect reports, invoices, statements, regulatory documents, and PDF
+  delivery. Covers report pages, absolute pixel layout, header/footer panels,
+  common elements, verification, full-document replacement, and workbook
+  conversion to reports. Do not use for responsive dashboards; use
+  sigma-workbooks instead. Requires SIGMA_API_TOKEN from the sigma-api skill.
+---
+
+# Sigma Reports (Code Representation via REST API)
+
+Use this skill for Sigma **reports**, the fixed-page authoring surface exposed
+by `/v2/reports/spec`. Reports are a private-beta resource. They share common
+element shapes with workbooks but have a different resource lifecycle and a
+different layout language.
+
+## Choose the correct resource
+
+Use a report for invoices, statements, regulatory packets, printable forms,
+branded documents, and other outputs whose physical page size matters. Use
+`sigma-workbooks` for responsive dashboards, exploratory analysis, application
+workflows, containers, tabs, modals, drawers, or workbook navigation.
+
+Never create a report by sending `kind: report` to a workbook endpoint. The
+resource families are separate:
+
+- Reports: `/v2/reports/spec`, `/v2/reports/{reportId}/spec`
+- Workbooks: `/v2/workbooks/spec`, `/v2/workbooks/{workbookId}/spec`
+- Conversion: `/v2/workbooks/{workbookId}/convertToReport`
+
+## Source of truth
+
+Use the current compiled OpenAPI for endpoint envelopes and published shapes:
+
+```
+https://assets.sigmacomputing.com/openapi/public-rest-api/sigma-computing-public-rest-api.json
+```
+
+The report endpoints currently declare `application/json` only. Author JSON
+unless a live request proves another media type works. The schema is broader
+than the documented report contract, so a published element kind is not proof
+that reports can safely author it. Read
+`reference/specification/support-matrix.md` before selecting elements.
+
+Live baseline, verified 2026-08-11: a JSON report with a warehouse-table
+source, text, KPI, combo-chart, bar-chart, grouped presentation table, data
+bars, a hidden dependency page, and header/footer panels passed `/verify`,
+created successfully, survived GET readback, updated as a new document version,
+and exported as a one-page landscape PDF with populated data. The support
+matrix records which findings this proves and which schema-published features
+remain gated.
+
+When documentation, this skill, and a live verify/readback disagree, prefer
+the live result and preserve the evidence. Run the bundled OpenAPI contract
+test against a fresh download when the API reports a shape error:
+
+```bash
+curl -sfL \
+  https://assets.sigmacomputing.com/openapi/public-rest-api/sigma-computing-public-rest-api.json \
+  -o /tmp/sigma-openapi.json
+ruby scripts/test-openapi-contract.rb /tmp/sigma-openapi.json
+```
+
+## Prerequisites and safety
+
+1. Authenticate with the `sigma-api` skill. Set `SIGMA_BASE_URL` and
+   `SIGMA_API_TOKEN`.
+2. Confirm reports are enabled for the organization and the caller has
+   **Create, edit, and publish reports** permission. Updating also requires
+   **Can edit** access to the report.
+3. Treat every create as persistent. The current OpenAPI exposes no report
+   DELETE endpoint. Do not create a probe report without explicit user
+   approval and a named destination folder.
+4. Treat PUT as full-document replacement. Always GET, back up, compare, edit,
+   validate, verify, PUT, and read back.
+5. A report GET can omit unsupported UI-authored features. Never assume a GET
+   representation is lossless merely because the request succeeded.
+
+## Recommended workflow
+
+### Step 1: Discover identity, folder, and a reference report
+
+```bash
+curl -sf -H "Authorization: Bearer $SIGMA_API_TOKEN" \
+  "$SIGMA_BASE_URL/v2/whoami" > /tmp/whoami.json
+
+curl -sf -H "Authorization: Bearer $SIGMA_API_TOKEN" \
+  "$SIGMA_BASE_URL/v2/reports?limit=50" > /tmp/reports.json
+```
+
+Use a recent reference report to obtain the current `schemaVersion` and study
+literal element shapes. Do not hardcode a schema version from an example.
+
+### Step 2: Load the relevant references
+
+Always read:
+
+- `reference/specification/schema.md`
+- `reference/specification/layout.md`
+- `reference/specification/support-matrix.md`
+- `reference/workflows/validate.md`
+
+Also read `reference/workflows/crud.md` before an API write and
+`reference/workflows/convert.md` before converting a workbook.
+
+Common element internals, source formulas, and column shapes are published in
+the same OpenAPI union used by workbooks. If `sigma-workbooks` is installed,
+its table, chart, map, KPI, control, source, formula, and formatting references
+are useful shape recipes. Apply only kinds allowed by the report support
+matrix, and never copy workbook grid layout or workbook-only elements.
+
+### Step 3: Draft a wrapped JSON representation
+
+Start with `reference/specification/example-minimal.json`. The create and
+verify envelope is:
+
+```json
+{
+  "name": "Monthly Statement",
+  "folderId": "<folder-id>",
+  "document": {
+    "schemaVersion": 1,
+    "kind": "report",
+    "config": {"pageWidth": 816, "pageHeight": 1056, "margin": 48},
+    "elements": [],
+    "pages": [{"id": "page-1", "name": "Page 1"}],
+    "layout": "<Page id=\"page-1\"></Page>"
+  }
+}
+```
+
+Rules:
+
+- Keep literal elements in flat `document.elements`.
+- Keep pages and panels as metadata; never nest `elements` inside them.
+- Put all placement in `document.layout` XML.
+- Place leaves with absolute `x`, `y`, `width`, and `height` pixel values.
+- Use report panels only for `header` and `footer` regions.
+- Do not emit workbook `gridColumn`, `gridRow`, container, tab, overlay, or
+  sidebar syntax.
+
+### Step 4: Validate locally
+
+```bash
+ruby scripts/validate-spec.rb --mode create /tmp/report-spec.json
+```
+
+Fix every error. Warnings identify schema-only or unknown capabilities that
+need a live verification decision.
+
+### Step 5: Verify without persistence
+
+```bash
+curl -sf -X POST \
+  -H "Authorization: Bearer $SIGMA_API_TOKEN" \
+  -H "Content-Type: application/json" \
+  -H "Accept: application/json" \
+  --data-binary @/tmp/report-spec.json \
+  "$SIGMA_BASE_URL/v2/reports/spec/verify" \
+  > /tmp/report-verify.json
+```
+
+Verification checks server-side representation and dependencies without
+creating a report. It does not prove the PDF layout is correct or that GET will
+round-trip every UI feature.
+
+### Step 6: Create only with explicit approval
+
+After the user approves the persistent write and destination folder:
+
+```bash
+curl -sf -X POST \
+  -H "Authorization: Bearer $SIGMA_API_TOKEN" \
+  -H "Content-Type: application/json" \
+  -H "Accept: application/json" \
+  --data-binary @/tmp/report-spec.json \
+  "$SIGMA_BASE_URL/v2/reports/spec" \
+  > /tmp/report-create.json
+```
+
+Save the submitted representation under a report-ID-specific path. Report the
+report URL, ID, and saved path.
+
+### Step 7: Read back and inspect output
+
+Immediately GET the representation and compare normalized documents. Confirm
+that optional fields survived and that no element, panel, page, or setting was
+silently dropped. Then export the affected pages to PDF and inspect the actual
+page breaks, clipping, typography, header/footer repetition, and margins.
+
+Do not claim parity from a successful POST or PUT alone.
+
+### Step 8: Update with a loss check
+
+Follow `reference/workflows/crud.md`. The short version is:
+
+1. GET and back up the current report representation.
+2. Inventory report pages, controls, and elements through their resource APIs.
+3. Stop if the inventory contains content absent from the GET representation.
+4. Edit the complete `document`.
+5. Validate in `--mode update` and call `/v2/reports/spec/verify` with a create
+   envelope assembled from the current name/folder and edited document.
+6. PUT exactly `{"document": {...}}`.
+7. GET again, compare, export, and inspect.
+
+## Reference index
+
+| File | Load when |
+|---|---|
+| `reference/specification/schema.md` | Always. Wrapped envelope, document fields, pages, panels, response metadata. |
+| `reference/specification/layout.md` | Always. Pixel XML, bounds, page and panel placement. |
+| `reference/specification/support-matrix.md` | Always. Safe, gated, unsupported, and workbook-only kinds. |
+| `reference/specification/example-minimal.json` | Starting a new report representation. |
+| `reference/workflows/crud.md` | Creating, retrieving, or replacing a report document. |
+| `reference/workflows/validate.md` | Before every verify, POST, or PUT and after readback. |
+| `reference/workflows/convert.md` | Converting an existing workbook into a report. |
+
+## Troubleshooting
+
+| Symptom | Action |
+|---|---|
+| `unknown field`, `unexpected property`, or missing field | Compare the endpoint against the compiled OpenAPI and rerun the contract test. |
+| A field or element disappears on GET | Treat the representation as lossy; do not PUT until the omitted feature is removed intentionally or preserved another way. |
+| Content overlaps or clips | Check pixel bounds, page dimensions, margins, and repeated panel height; inspect a PDF export. |
+| A workbook grid attribute appears in report XML | Replace it with absolute `x`, `y`, `width`, and `height`. |
+| `waterfall-chart`, `progress`, or synced control is requested | Stop or redesign; the published schema is not a safe report-authoring guarantee. |
+| Conversion succeeds with warnings | Review every warning and its element IDs before accepting the generated report. |
+
+Reports are private beta. Prefer explicit evidence and reversible local edits
+over speculative API writes.

--- a/sigma-reports/generated/cline/sigma-reports.md
+++ b/sigma-reports/generated/cline/sigma-reports.md
@@ -1,0 +1,228 @@
+<!--
+Auto-generated from SKILL.md by ~/sigma-skills/scripts/sync-targets.rb.
+Do not edit by hand — edit SKILL.md and re-run the script.
+-->
+
+> Build, validate, retrieve, and safely update Sigma report code representations through /v2/reports/spec. Use for fixed-layout or pixel-perfect reports, invoices, statements, regulatory documents, and PDF delivery. Covers report pages, absolute pixel layout, header/footer panels, common elements, verification, full-document replacement, and workbook conversion to reports. Do not use for responsive dashboards; use sigma-workbooks instead. Requires SIGMA_API_TOKEN from the sigma-api skill.
+
+# Sigma Reports (Code Representation via REST API)
+
+Use this skill for Sigma **reports**, the fixed-page authoring surface exposed
+by `/v2/reports/spec`. Reports are a private-beta resource. They share common
+element shapes with workbooks but have a different resource lifecycle and a
+different layout language.
+
+## Choose the correct resource
+
+Use a report for invoices, statements, regulatory packets, printable forms,
+branded documents, and other outputs whose physical page size matters. Use
+`sigma-workbooks` for responsive dashboards, exploratory analysis, application
+workflows, containers, tabs, modals, drawers, or workbook navigation.
+
+Never create a report by sending `kind: report` to a workbook endpoint. The
+resource families are separate:
+
+- Reports: `/v2/reports/spec`, `/v2/reports/{reportId}/spec`
+- Workbooks: `/v2/workbooks/spec`, `/v2/workbooks/{workbookId}/spec`
+- Conversion: `/v2/workbooks/{workbookId}/convertToReport`
+
+## Source of truth
+
+Use the current compiled OpenAPI for endpoint envelopes and published shapes:
+
+```
+https://assets.sigmacomputing.com/openapi/public-rest-api/sigma-computing-public-rest-api.json
+```
+
+The report endpoints currently declare `application/json` only. Author JSON
+unless a live request proves another media type works. The schema is broader
+than the documented report contract, so a published element kind is not proof
+that reports can safely author it. Read
+`reference/specification/support-matrix.md` before selecting elements.
+
+Live baseline, verified 2026-08-11: a JSON report with a warehouse-table
+source, text, KPI, combo-chart, bar-chart, grouped presentation table, data
+bars, a hidden dependency page, and header/footer panels passed `/verify`,
+created successfully, survived GET readback, updated as a new document version,
+and exported as a one-page landscape PDF with populated data. The support
+matrix records which findings this proves and which schema-published features
+remain gated.
+
+When documentation, this skill, and a live verify/readback disagree, prefer
+the live result and preserve the evidence. Run the bundled OpenAPI contract
+test against a fresh download when the API reports a shape error:
+
+```bash
+curl -sfL \
+  https://assets.sigmacomputing.com/openapi/public-rest-api/sigma-computing-public-rest-api.json \
+  -o /tmp/sigma-openapi.json
+ruby scripts/test-openapi-contract.rb /tmp/sigma-openapi.json
+```
+
+## Prerequisites and safety
+
+1. Authenticate with the `sigma-api` skill. Set `SIGMA_BASE_URL` and
+   `SIGMA_API_TOKEN`.
+2. Confirm reports are enabled for the organization and the caller has
+   **Create, edit, and publish reports** permission. Updating also requires
+   **Can edit** access to the report.
+3. Treat every create as persistent. The current OpenAPI exposes no report
+   DELETE endpoint. Do not create a probe report without explicit user
+   approval and a named destination folder.
+4. Treat PUT as full-document replacement. Always GET, back up, compare, edit,
+   validate, verify, PUT, and read back.
+5. A report GET can omit unsupported UI-authored features. Never assume a GET
+   representation is lossless merely because the request succeeded.
+
+## Recommended workflow
+
+### Step 1: Discover identity, folder, and a reference report
+
+```bash
+curl -sf -H "Authorization: Bearer $SIGMA_API_TOKEN" \
+  "$SIGMA_BASE_URL/v2/whoami" > /tmp/whoami.json
+
+curl -sf -H "Authorization: Bearer $SIGMA_API_TOKEN" \
+  "$SIGMA_BASE_URL/v2/reports?limit=50" > /tmp/reports.json
+```
+
+Use a recent reference report to obtain the current `schemaVersion` and study
+literal element shapes. Do not hardcode a schema version from an example.
+
+### Step 2: Load the relevant references
+
+Always read:
+
+- `reference/specification/schema.md`
+- `reference/specification/layout.md`
+- `reference/specification/support-matrix.md`
+- `reference/workflows/validate.md`
+
+Also read `reference/workflows/crud.md` before an API write and
+`reference/workflows/convert.md` before converting a workbook.
+
+Common element internals, source formulas, and column shapes are published in
+the same OpenAPI union used by workbooks. If `sigma-workbooks` is installed,
+its table, chart, map, KPI, control, source, formula, and formatting references
+are useful shape recipes. Apply only kinds allowed by the report support
+matrix, and never copy workbook grid layout or workbook-only elements.
+
+### Step 3: Draft a wrapped JSON representation
+
+Start with `reference/specification/example-minimal.json`. The create and
+verify envelope is:
+
+```json
+{
+  "name": "Monthly Statement",
+  "folderId": "<folder-id>",
+  "document": {
+    "schemaVersion": 1,
+    "kind": "report",
+    "config": {"pageWidth": 816, "pageHeight": 1056, "margin": 48},
+    "elements": [],
+    "pages": [{"id": "page-1", "name": "Page 1"}],
+    "layout": "<Page id=\"page-1\"></Page>"
+  }
+}
+```
+
+Rules:
+
+- Keep literal elements in flat `document.elements`.
+- Keep pages and panels as metadata; never nest `elements` inside them.
+- Put all placement in `document.layout` XML.
+- Place leaves with absolute `x`, `y`, `width`, and `height` pixel values.
+- Use report panels only for `header` and `footer` regions.
+- Do not emit workbook `gridColumn`, `gridRow`, container, tab, overlay, or
+  sidebar syntax.
+
+### Step 4: Validate locally
+
+```bash
+ruby scripts/validate-spec.rb --mode create /tmp/report-spec.json
+```
+
+Fix every error. Warnings identify schema-only or unknown capabilities that
+need a live verification decision.
+
+### Step 5: Verify without persistence
+
+```bash
+curl -sf -X POST \
+  -H "Authorization: Bearer $SIGMA_API_TOKEN" \
+  -H "Content-Type: application/json" \
+  -H "Accept: application/json" \
+  --data-binary @/tmp/report-spec.json \
+  "$SIGMA_BASE_URL/v2/reports/spec/verify" \
+  > /tmp/report-verify.json
+```
+
+Verification checks server-side representation and dependencies without
+creating a report. It does not prove the PDF layout is correct or that GET will
+round-trip every UI feature.
+
+### Step 6: Create only with explicit approval
+
+After the user approves the persistent write and destination folder:
+
+```bash
+curl -sf -X POST \
+  -H "Authorization: Bearer $SIGMA_API_TOKEN" \
+  -H "Content-Type: application/json" \
+  -H "Accept: application/json" \
+  --data-binary @/tmp/report-spec.json \
+  "$SIGMA_BASE_URL/v2/reports/spec" \
+  > /tmp/report-create.json
+```
+
+Save the submitted representation under a report-ID-specific path. Report the
+report URL, ID, and saved path.
+
+### Step 7: Read back and inspect output
+
+Immediately GET the representation and compare normalized documents. Confirm
+that optional fields survived and that no element, panel, page, or setting was
+silently dropped. Then export the affected pages to PDF and inspect the actual
+page breaks, clipping, typography, header/footer repetition, and margins.
+
+Do not claim parity from a successful POST or PUT alone.
+
+### Step 8: Update with a loss check
+
+Follow `reference/workflows/crud.md`. The short version is:
+
+1. GET and back up the current report representation.
+2. Inventory report pages, controls, and elements through their resource APIs.
+3. Stop if the inventory contains content absent from the GET representation.
+4. Edit the complete `document`.
+5. Validate in `--mode update` and call `/v2/reports/spec/verify` with a create
+   envelope assembled from the current name/folder and edited document.
+6. PUT exactly `{"document": {...}}`.
+7. GET again, compare, export, and inspect.
+
+## Reference index
+
+| File | Load when |
+|---|---|
+| `reference/specification/schema.md` | Always. Wrapped envelope, document fields, pages, panels, response metadata. |
+| `reference/specification/layout.md` | Always. Pixel XML, bounds, page and panel placement. |
+| `reference/specification/support-matrix.md` | Always. Safe, gated, unsupported, and workbook-only kinds. |
+| `reference/specification/example-minimal.json` | Starting a new report representation. |
+| `reference/workflows/crud.md` | Creating, retrieving, or replacing a report document. |
+| `reference/workflows/validate.md` | Before every verify, POST, or PUT and after readback. |
+| `reference/workflows/convert.md` | Converting an existing workbook into a report. |
+
+## Troubleshooting
+
+| Symptom | Action |
+|---|---|
+| `unknown field`, `unexpected property`, or missing field | Compare the endpoint against the compiled OpenAPI and rerun the contract test. |
+| A field or element disappears on GET | Treat the representation as lossy; do not PUT until the omitted feature is removed intentionally or preserved another way. |
+| Content overlaps or clips | Check pixel bounds, page dimensions, margins, and repeated panel height; inspect a PDF export. |
+| A workbook grid attribute appears in report XML | Replace it with absolute `x`, `y`, `width`, and `height`. |
+| `waterfall-chart`, `progress`, or synced control is requested | Stop or redesign; the published schema is not a safe report-authoring guarantee. |
+| Conversion succeeds with warnings | Review every warning and its element IDs before accepting the generated report. |
+
+Reports are private beta. Prefer explicit evidence and reversible local edits
+over speculative API writes.

--- a/sigma-reports/generated/codex/AGENTS.md
+++ b/sigma-reports/generated/codex/AGENTS.md
@@ -1,0 +1,228 @@
+<!--
+Auto-generated from SKILL.md by ~/sigma-skills/scripts/sync-targets.rb.
+Do not edit by hand — edit SKILL.md and re-run the script.
+-->
+
+> Build, validate, retrieve, and safely update Sigma report code representations through /v2/reports/spec. Use for fixed-layout or pixel-perfect reports, invoices, statements, regulatory documents, and PDF delivery. Covers report pages, absolute pixel layout, header/footer panels, common elements, verification, full-document replacement, and workbook conversion to reports. Do not use for responsive dashboards; use sigma-workbooks instead. Requires SIGMA_API_TOKEN from the sigma-api skill.
+
+# Sigma Reports (Code Representation via REST API)
+
+Use this skill for Sigma **reports**, the fixed-page authoring surface exposed
+by `/v2/reports/spec`. Reports are a private-beta resource. They share common
+element shapes with workbooks but have a different resource lifecycle and a
+different layout language.
+
+## Choose the correct resource
+
+Use a report for invoices, statements, regulatory packets, printable forms,
+branded documents, and other outputs whose physical page size matters. Use
+`sigma-workbooks` for responsive dashboards, exploratory analysis, application
+workflows, containers, tabs, modals, drawers, or workbook navigation.
+
+Never create a report by sending `kind: report` to a workbook endpoint. The
+resource families are separate:
+
+- Reports: `/v2/reports/spec`, `/v2/reports/{reportId}/spec`
+- Workbooks: `/v2/workbooks/spec`, `/v2/workbooks/{workbookId}/spec`
+- Conversion: `/v2/workbooks/{workbookId}/convertToReport`
+
+## Source of truth
+
+Use the current compiled OpenAPI for endpoint envelopes and published shapes:
+
+```
+https://assets.sigmacomputing.com/openapi/public-rest-api/sigma-computing-public-rest-api.json
+```
+
+The report endpoints currently declare `application/json` only. Author JSON
+unless a live request proves another media type works. The schema is broader
+than the documented report contract, so a published element kind is not proof
+that reports can safely author it. Read
+`reference/specification/support-matrix.md` before selecting elements.
+
+Live baseline, verified 2026-08-11: a JSON report with a warehouse-table
+source, text, KPI, combo-chart, bar-chart, grouped presentation table, data
+bars, a hidden dependency page, and header/footer panels passed `/verify`,
+created successfully, survived GET readback, updated as a new document version,
+and exported as a one-page landscape PDF with populated data. The support
+matrix records which findings this proves and which schema-published features
+remain gated.
+
+When documentation, this skill, and a live verify/readback disagree, prefer
+the live result and preserve the evidence. Run the bundled OpenAPI contract
+test against a fresh download when the API reports a shape error:
+
+```bash
+curl -sfL \
+  https://assets.sigmacomputing.com/openapi/public-rest-api/sigma-computing-public-rest-api.json \
+  -o /tmp/sigma-openapi.json
+ruby scripts/test-openapi-contract.rb /tmp/sigma-openapi.json
+```
+
+## Prerequisites and safety
+
+1. Authenticate with the `sigma-api` skill. Set `SIGMA_BASE_URL` and
+   `SIGMA_API_TOKEN`.
+2. Confirm reports are enabled for the organization and the caller has
+   **Create, edit, and publish reports** permission. Updating also requires
+   **Can edit** access to the report.
+3. Treat every create as persistent. The current OpenAPI exposes no report
+   DELETE endpoint. Do not create a probe report without explicit user
+   approval and a named destination folder.
+4. Treat PUT as full-document replacement. Always GET, back up, compare, edit,
+   validate, verify, PUT, and read back.
+5. A report GET can omit unsupported UI-authored features. Never assume a GET
+   representation is lossless merely because the request succeeded.
+
+## Recommended workflow
+
+### Step 1: Discover identity, folder, and a reference report
+
+```bash
+curl -sf -H "Authorization: Bearer $SIGMA_API_TOKEN" \
+  "$SIGMA_BASE_URL/v2/whoami" > /tmp/whoami.json
+
+curl -sf -H "Authorization: Bearer $SIGMA_API_TOKEN" \
+  "$SIGMA_BASE_URL/v2/reports?limit=50" > /tmp/reports.json
+```
+
+Use a recent reference report to obtain the current `schemaVersion` and study
+literal element shapes. Do not hardcode a schema version from an example.
+
+### Step 2: Load the relevant references
+
+Always read:
+
+- `reference/specification/schema.md`
+- `reference/specification/layout.md`
+- `reference/specification/support-matrix.md`
+- `reference/workflows/validate.md`
+
+Also read `reference/workflows/crud.md` before an API write and
+`reference/workflows/convert.md` before converting a workbook.
+
+Common element internals, source formulas, and column shapes are published in
+the same OpenAPI union used by workbooks. If `sigma-workbooks` is installed,
+its table, chart, map, KPI, control, source, formula, and formatting references
+are useful shape recipes. Apply only kinds allowed by the report support
+matrix, and never copy workbook grid layout or workbook-only elements.
+
+### Step 3: Draft a wrapped JSON representation
+
+Start with `reference/specification/example-minimal.json`. The create and
+verify envelope is:
+
+```json
+{
+  "name": "Monthly Statement",
+  "folderId": "<folder-id>",
+  "document": {
+    "schemaVersion": 1,
+    "kind": "report",
+    "config": {"pageWidth": 816, "pageHeight": 1056, "margin": 48},
+    "elements": [],
+    "pages": [{"id": "page-1", "name": "Page 1"}],
+    "layout": "<Page id=\"page-1\"></Page>"
+  }
+}
+```
+
+Rules:
+
+- Keep literal elements in flat `document.elements`.
+- Keep pages and panels as metadata; never nest `elements` inside them.
+- Put all placement in `document.layout` XML.
+- Place leaves with absolute `x`, `y`, `width`, and `height` pixel values.
+- Use report panels only for `header` and `footer` regions.
+- Do not emit workbook `gridColumn`, `gridRow`, container, tab, overlay, or
+  sidebar syntax.
+
+### Step 4: Validate locally
+
+```bash
+ruby scripts/validate-spec.rb --mode create /tmp/report-spec.json
+```
+
+Fix every error. Warnings identify schema-only or unknown capabilities that
+need a live verification decision.
+
+### Step 5: Verify without persistence
+
+```bash
+curl -sf -X POST \
+  -H "Authorization: Bearer $SIGMA_API_TOKEN" \
+  -H "Content-Type: application/json" \
+  -H "Accept: application/json" \
+  --data-binary @/tmp/report-spec.json \
+  "$SIGMA_BASE_URL/v2/reports/spec/verify" \
+  > /tmp/report-verify.json
+```
+
+Verification checks server-side representation and dependencies without
+creating a report. It does not prove the PDF layout is correct or that GET will
+round-trip every UI feature.
+
+### Step 6: Create only with explicit approval
+
+After the user approves the persistent write and destination folder:
+
+```bash
+curl -sf -X POST \
+  -H "Authorization: Bearer $SIGMA_API_TOKEN" \
+  -H "Content-Type: application/json" \
+  -H "Accept: application/json" \
+  --data-binary @/tmp/report-spec.json \
+  "$SIGMA_BASE_URL/v2/reports/spec" \
+  > /tmp/report-create.json
+```
+
+Save the submitted representation under a report-ID-specific path. Report the
+report URL, ID, and saved path.
+
+### Step 7: Read back and inspect output
+
+Immediately GET the representation and compare normalized documents. Confirm
+that optional fields survived and that no element, panel, page, or setting was
+silently dropped. Then export the affected pages to PDF and inspect the actual
+page breaks, clipping, typography, header/footer repetition, and margins.
+
+Do not claim parity from a successful POST or PUT alone.
+
+### Step 8: Update with a loss check
+
+Follow `reference/workflows/crud.md`. The short version is:
+
+1. GET and back up the current report representation.
+2. Inventory report pages, controls, and elements through their resource APIs.
+3. Stop if the inventory contains content absent from the GET representation.
+4. Edit the complete `document`.
+5. Validate in `--mode update` and call `/v2/reports/spec/verify` with a create
+   envelope assembled from the current name/folder and edited document.
+6. PUT exactly `{"document": {...}}`.
+7. GET again, compare, export, and inspect.
+
+## Reference index
+
+| File | Load when |
+|---|---|
+| `reference/specification/schema.md` | Always. Wrapped envelope, document fields, pages, panels, response metadata. |
+| `reference/specification/layout.md` | Always. Pixel XML, bounds, page and panel placement. |
+| `reference/specification/support-matrix.md` | Always. Safe, gated, unsupported, and workbook-only kinds. |
+| `reference/specification/example-minimal.json` | Starting a new report representation. |
+| `reference/workflows/crud.md` | Creating, retrieving, or replacing a report document. |
+| `reference/workflows/validate.md` | Before every verify, POST, or PUT and after readback. |
+| `reference/workflows/convert.md` | Converting an existing workbook into a report. |
+
+## Troubleshooting
+
+| Symptom | Action |
+|---|---|
+| `unknown field`, `unexpected property`, or missing field | Compare the endpoint against the compiled OpenAPI and rerun the contract test. |
+| A field or element disappears on GET | Treat the representation as lossy; do not PUT until the omitted feature is removed intentionally or preserved another way. |
+| Content overlaps or clips | Check pixel bounds, page dimensions, margins, and repeated panel height; inspect a PDF export. |
+| A workbook grid attribute appears in report XML | Replace it with absolute `x`, `y`, `width`, and `height`. |
+| `waterfall-chart`, `progress`, or synced control is requested | Stop or redesign; the published schema is not a safe report-authoring guarantee. |
+| Conversion succeeds with warnings | Review every warning and its element IDs before accepting the generated report. |
+
+Reports are private beta. Prefer explicit evidence and reversible local edits
+over speculative API writes.

--- a/sigma-reports/generated/continue/sigma-reports.md
+++ b/sigma-reports/generated/continue/sigma-reports.md
@@ -1,0 +1,228 @@
+<!--
+Auto-generated from SKILL.md by ~/sigma-skills/scripts/sync-targets.rb.
+Do not edit by hand — edit SKILL.md and re-run the script.
+-->
+
+> Build, validate, retrieve, and safely update Sigma report code representations through /v2/reports/spec. Use for fixed-layout or pixel-perfect reports, invoices, statements, regulatory documents, and PDF delivery. Covers report pages, absolute pixel layout, header/footer panels, common elements, verification, full-document replacement, and workbook conversion to reports. Do not use for responsive dashboards; use sigma-workbooks instead. Requires SIGMA_API_TOKEN from the sigma-api skill.
+
+# Sigma Reports (Code Representation via REST API)
+
+Use this skill for Sigma **reports**, the fixed-page authoring surface exposed
+by `/v2/reports/spec`. Reports are a private-beta resource. They share common
+element shapes with workbooks but have a different resource lifecycle and a
+different layout language.
+
+## Choose the correct resource
+
+Use a report for invoices, statements, regulatory packets, printable forms,
+branded documents, and other outputs whose physical page size matters. Use
+`sigma-workbooks` for responsive dashboards, exploratory analysis, application
+workflows, containers, tabs, modals, drawers, or workbook navigation.
+
+Never create a report by sending `kind: report` to a workbook endpoint. The
+resource families are separate:
+
+- Reports: `/v2/reports/spec`, `/v2/reports/{reportId}/spec`
+- Workbooks: `/v2/workbooks/spec`, `/v2/workbooks/{workbookId}/spec`
+- Conversion: `/v2/workbooks/{workbookId}/convertToReport`
+
+## Source of truth
+
+Use the current compiled OpenAPI for endpoint envelopes and published shapes:
+
+```
+https://assets.sigmacomputing.com/openapi/public-rest-api/sigma-computing-public-rest-api.json
+```
+
+The report endpoints currently declare `application/json` only. Author JSON
+unless a live request proves another media type works. The schema is broader
+than the documented report contract, so a published element kind is not proof
+that reports can safely author it. Read
+`reference/specification/support-matrix.md` before selecting elements.
+
+Live baseline, verified 2026-08-11: a JSON report with a warehouse-table
+source, text, KPI, combo-chart, bar-chart, grouped presentation table, data
+bars, a hidden dependency page, and header/footer panels passed `/verify`,
+created successfully, survived GET readback, updated as a new document version,
+and exported as a one-page landscape PDF with populated data. The support
+matrix records which findings this proves and which schema-published features
+remain gated.
+
+When documentation, this skill, and a live verify/readback disagree, prefer
+the live result and preserve the evidence. Run the bundled OpenAPI contract
+test against a fresh download when the API reports a shape error:
+
+```bash
+curl -sfL \
+  https://assets.sigmacomputing.com/openapi/public-rest-api/sigma-computing-public-rest-api.json \
+  -o /tmp/sigma-openapi.json
+ruby scripts/test-openapi-contract.rb /tmp/sigma-openapi.json
+```
+
+## Prerequisites and safety
+
+1. Authenticate with the `sigma-api` skill. Set `SIGMA_BASE_URL` and
+   `SIGMA_API_TOKEN`.
+2. Confirm reports are enabled for the organization and the caller has
+   **Create, edit, and publish reports** permission. Updating also requires
+   **Can edit** access to the report.
+3. Treat every create as persistent. The current OpenAPI exposes no report
+   DELETE endpoint. Do not create a probe report without explicit user
+   approval and a named destination folder.
+4. Treat PUT as full-document replacement. Always GET, back up, compare, edit,
+   validate, verify, PUT, and read back.
+5. A report GET can omit unsupported UI-authored features. Never assume a GET
+   representation is lossless merely because the request succeeded.
+
+## Recommended workflow
+
+### Step 1: Discover identity, folder, and a reference report
+
+```bash
+curl -sf -H "Authorization: Bearer $SIGMA_API_TOKEN" \
+  "$SIGMA_BASE_URL/v2/whoami" > /tmp/whoami.json
+
+curl -sf -H "Authorization: Bearer $SIGMA_API_TOKEN" \
+  "$SIGMA_BASE_URL/v2/reports?limit=50" > /tmp/reports.json
+```
+
+Use a recent reference report to obtain the current `schemaVersion` and study
+literal element shapes. Do not hardcode a schema version from an example.
+
+### Step 2: Load the relevant references
+
+Always read:
+
+- `reference/specification/schema.md`
+- `reference/specification/layout.md`
+- `reference/specification/support-matrix.md`
+- `reference/workflows/validate.md`
+
+Also read `reference/workflows/crud.md` before an API write and
+`reference/workflows/convert.md` before converting a workbook.
+
+Common element internals, source formulas, and column shapes are published in
+the same OpenAPI union used by workbooks. If `sigma-workbooks` is installed,
+its table, chart, map, KPI, control, source, formula, and formatting references
+are useful shape recipes. Apply only kinds allowed by the report support
+matrix, and never copy workbook grid layout or workbook-only elements.
+
+### Step 3: Draft a wrapped JSON representation
+
+Start with `reference/specification/example-minimal.json`. The create and
+verify envelope is:
+
+```json
+{
+  "name": "Monthly Statement",
+  "folderId": "<folder-id>",
+  "document": {
+    "schemaVersion": 1,
+    "kind": "report",
+    "config": {"pageWidth": 816, "pageHeight": 1056, "margin": 48},
+    "elements": [],
+    "pages": [{"id": "page-1", "name": "Page 1"}],
+    "layout": "<Page id=\"page-1\"></Page>"
+  }
+}
+```
+
+Rules:
+
+- Keep literal elements in flat `document.elements`.
+- Keep pages and panels as metadata; never nest `elements` inside them.
+- Put all placement in `document.layout` XML.
+- Place leaves with absolute `x`, `y`, `width`, and `height` pixel values.
+- Use report panels only for `header` and `footer` regions.
+- Do not emit workbook `gridColumn`, `gridRow`, container, tab, overlay, or
+  sidebar syntax.
+
+### Step 4: Validate locally
+
+```bash
+ruby scripts/validate-spec.rb --mode create /tmp/report-spec.json
+```
+
+Fix every error. Warnings identify schema-only or unknown capabilities that
+need a live verification decision.
+
+### Step 5: Verify without persistence
+
+```bash
+curl -sf -X POST \
+  -H "Authorization: Bearer $SIGMA_API_TOKEN" \
+  -H "Content-Type: application/json" \
+  -H "Accept: application/json" \
+  --data-binary @/tmp/report-spec.json \
+  "$SIGMA_BASE_URL/v2/reports/spec/verify" \
+  > /tmp/report-verify.json
+```
+
+Verification checks server-side representation and dependencies without
+creating a report. It does not prove the PDF layout is correct or that GET will
+round-trip every UI feature.
+
+### Step 6: Create only with explicit approval
+
+After the user approves the persistent write and destination folder:
+
+```bash
+curl -sf -X POST \
+  -H "Authorization: Bearer $SIGMA_API_TOKEN" \
+  -H "Content-Type: application/json" \
+  -H "Accept: application/json" \
+  --data-binary @/tmp/report-spec.json \
+  "$SIGMA_BASE_URL/v2/reports/spec" \
+  > /tmp/report-create.json
+```
+
+Save the submitted representation under a report-ID-specific path. Report the
+report URL, ID, and saved path.
+
+### Step 7: Read back and inspect output
+
+Immediately GET the representation and compare normalized documents. Confirm
+that optional fields survived and that no element, panel, page, or setting was
+silently dropped. Then export the affected pages to PDF and inspect the actual
+page breaks, clipping, typography, header/footer repetition, and margins.
+
+Do not claim parity from a successful POST or PUT alone.
+
+### Step 8: Update with a loss check
+
+Follow `reference/workflows/crud.md`. The short version is:
+
+1. GET and back up the current report representation.
+2. Inventory report pages, controls, and elements through their resource APIs.
+3. Stop if the inventory contains content absent from the GET representation.
+4. Edit the complete `document`.
+5. Validate in `--mode update` and call `/v2/reports/spec/verify` with a create
+   envelope assembled from the current name/folder and edited document.
+6. PUT exactly `{"document": {...}}`.
+7. GET again, compare, export, and inspect.
+
+## Reference index
+
+| File | Load when |
+|---|---|
+| `reference/specification/schema.md` | Always. Wrapped envelope, document fields, pages, panels, response metadata. |
+| `reference/specification/layout.md` | Always. Pixel XML, bounds, page and panel placement. |
+| `reference/specification/support-matrix.md` | Always. Safe, gated, unsupported, and workbook-only kinds. |
+| `reference/specification/example-minimal.json` | Starting a new report representation. |
+| `reference/workflows/crud.md` | Creating, retrieving, or replacing a report document. |
+| `reference/workflows/validate.md` | Before every verify, POST, or PUT and after readback. |
+| `reference/workflows/convert.md` | Converting an existing workbook into a report. |
+
+## Troubleshooting
+
+| Symptom | Action |
+|---|---|
+| `unknown field`, `unexpected property`, or missing field | Compare the endpoint against the compiled OpenAPI and rerun the contract test. |
+| A field or element disappears on GET | Treat the representation as lossy; do not PUT until the omitted feature is removed intentionally or preserved another way. |
+| Content overlaps or clips | Check pixel bounds, page dimensions, margins, and repeated panel height; inspect a PDF export. |
+| A workbook grid attribute appears in report XML | Replace it with absolute `x`, `y`, `width`, and `height`. |
+| `waterfall-chart`, `progress`, or synced control is requested | Stop or redesign; the published schema is not a safe report-authoring guarantee. |
+| Conversion succeeds with warnings | Review every warning and its element IDs before accepting the generated report. |
+
+Reports are private beta. Prefer explicit evidence and reversible local edits
+over speculative API writes.

--- a/sigma-reports/generated/cursor/rules/sigma-reports.mdc
+++ b/sigma-reports/generated/cursor/rules/sigma-reports.mdc
@@ -1,0 +1,233 @@
+---
+description: "Build, validate, retrieve, and safely update Sigma report code representations through /v2/reports/spec. Use for fixed-layout or pixel-perfect reports, invoices, statements, regulatory documents, and PDF delivery. Covers report pages, absolute pixel layout, header/footer panels, common elements, verification, full-document replacement, and workbook conversion to reports. Do not use for responsive dashboards; use sigma-workbooks instead. Requires SIGMA_API_TOKEN from the sigma-api skill."
+alwaysApply: false
+---
+
+<!--
+Auto-generated from SKILL.md by ~/sigma-skills/scripts/sync-targets.rb.
+Do not edit by hand — edit SKILL.md and re-run the script.
+-->
+
+> Build, validate, retrieve, and safely update Sigma report code representations through /v2/reports/spec. Use for fixed-layout or pixel-perfect reports, invoices, statements, regulatory documents, and PDF delivery. Covers report pages, absolute pixel layout, header/footer panels, common elements, verification, full-document replacement, and workbook conversion to reports. Do not use for responsive dashboards; use sigma-workbooks instead. Requires SIGMA_API_TOKEN from the sigma-api skill.
+
+# Sigma Reports (Code Representation via REST API)
+
+Use this skill for Sigma **reports**, the fixed-page authoring surface exposed
+by `/v2/reports/spec`. Reports are a private-beta resource. They share common
+element shapes with workbooks but have a different resource lifecycle and a
+different layout language.
+
+## Choose the correct resource
+
+Use a report for invoices, statements, regulatory packets, printable forms,
+branded documents, and other outputs whose physical page size matters. Use
+`sigma-workbooks` for responsive dashboards, exploratory analysis, application
+workflows, containers, tabs, modals, drawers, or workbook navigation.
+
+Never create a report by sending `kind: report` to a workbook endpoint. The
+resource families are separate:
+
+- Reports: `/v2/reports/spec`, `/v2/reports/{reportId}/spec`
+- Workbooks: `/v2/workbooks/spec`, `/v2/workbooks/{workbookId}/spec`
+- Conversion: `/v2/workbooks/{workbookId}/convertToReport`
+
+## Source of truth
+
+Use the current compiled OpenAPI for endpoint envelopes and published shapes:
+
+```
+https://assets.sigmacomputing.com/openapi/public-rest-api/sigma-computing-public-rest-api.json
+```
+
+The report endpoints currently declare `application/json` only. Author JSON
+unless a live request proves another media type works. The schema is broader
+than the documented report contract, so a published element kind is not proof
+that reports can safely author it. Read
+`reference/specification/support-matrix.md` before selecting elements.
+
+Live baseline, verified 2026-08-11: a JSON report with a warehouse-table
+source, text, KPI, combo-chart, bar-chart, grouped presentation table, data
+bars, a hidden dependency page, and header/footer panels passed `/verify`,
+created successfully, survived GET readback, updated as a new document version,
+and exported as a one-page landscape PDF with populated data. The support
+matrix records which findings this proves and which schema-published features
+remain gated.
+
+When documentation, this skill, and a live verify/readback disagree, prefer
+the live result and preserve the evidence. Run the bundled OpenAPI contract
+test against a fresh download when the API reports a shape error:
+
+```bash
+curl -sfL \
+  https://assets.sigmacomputing.com/openapi/public-rest-api/sigma-computing-public-rest-api.json \
+  -o /tmp/sigma-openapi.json
+ruby scripts/test-openapi-contract.rb /tmp/sigma-openapi.json
+```
+
+## Prerequisites and safety
+
+1. Authenticate with the `sigma-api` skill. Set `SIGMA_BASE_URL` and
+   `SIGMA_API_TOKEN`.
+2. Confirm reports are enabled for the organization and the caller has
+   **Create, edit, and publish reports** permission. Updating also requires
+   **Can edit** access to the report.
+3. Treat every create as persistent. The current OpenAPI exposes no report
+   DELETE endpoint. Do not create a probe report without explicit user
+   approval and a named destination folder.
+4. Treat PUT as full-document replacement. Always GET, back up, compare, edit,
+   validate, verify, PUT, and read back.
+5. A report GET can omit unsupported UI-authored features. Never assume a GET
+   representation is lossless merely because the request succeeded.
+
+## Recommended workflow
+
+### Step 1: Discover identity, folder, and a reference report
+
+```bash
+curl -sf -H "Authorization: Bearer $SIGMA_API_TOKEN" \
+  "$SIGMA_BASE_URL/v2/whoami" > /tmp/whoami.json
+
+curl -sf -H "Authorization: Bearer $SIGMA_API_TOKEN" \
+  "$SIGMA_BASE_URL/v2/reports?limit=50" > /tmp/reports.json
+```
+
+Use a recent reference report to obtain the current `schemaVersion` and study
+literal element shapes. Do not hardcode a schema version from an example.
+
+### Step 2: Load the relevant references
+
+Always read:
+
+- `reference/specification/schema.md`
+- `reference/specification/layout.md`
+- `reference/specification/support-matrix.md`
+- `reference/workflows/validate.md`
+
+Also read `reference/workflows/crud.md` before an API write and
+`reference/workflows/convert.md` before converting a workbook.
+
+Common element internals, source formulas, and column shapes are published in
+the same OpenAPI union used by workbooks. If `sigma-workbooks` is installed,
+its table, chart, map, KPI, control, source, formula, and formatting references
+are useful shape recipes. Apply only kinds allowed by the report support
+matrix, and never copy workbook grid layout or workbook-only elements.
+
+### Step 3: Draft a wrapped JSON representation
+
+Start with `reference/specification/example-minimal.json`. The create and
+verify envelope is:
+
+```json
+{
+  "name": "Monthly Statement",
+  "folderId": "<folder-id>",
+  "document": {
+    "schemaVersion": 1,
+    "kind": "report",
+    "config": {"pageWidth": 816, "pageHeight": 1056, "margin": 48},
+    "elements": [],
+    "pages": [{"id": "page-1", "name": "Page 1"}],
+    "layout": "<Page id=\"page-1\"></Page>"
+  }
+}
+```
+
+Rules:
+
+- Keep literal elements in flat `document.elements`.
+- Keep pages and panels as metadata; never nest `elements` inside them.
+- Put all placement in `document.layout` XML.
+- Place leaves with absolute `x`, `y`, `width`, and `height` pixel values.
+- Use report panels only for `header` and `footer` regions.
+- Do not emit workbook `gridColumn`, `gridRow`, container, tab, overlay, or
+  sidebar syntax.
+
+### Step 4: Validate locally
+
+```bash
+ruby scripts/validate-spec.rb --mode create /tmp/report-spec.json
+```
+
+Fix every error. Warnings identify schema-only or unknown capabilities that
+need a live verification decision.
+
+### Step 5: Verify without persistence
+
+```bash
+curl -sf -X POST \
+  -H "Authorization: Bearer $SIGMA_API_TOKEN" \
+  -H "Content-Type: application/json" \
+  -H "Accept: application/json" \
+  --data-binary @/tmp/report-spec.json \
+  "$SIGMA_BASE_URL/v2/reports/spec/verify" \
+  > /tmp/report-verify.json
+```
+
+Verification checks server-side representation and dependencies without
+creating a report. It does not prove the PDF layout is correct or that GET will
+round-trip every UI feature.
+
+### Step 6: Create only with explicit approval
+
+After the user approves the persistent write and destination folder:
+
+```bash
+curl -sf -X POST \
+  -H "Authorization: Bearer $SIGMA_API_TOKEN" \
+  -H "Content-Type: application/json" \
+  -H "Accept: application/json" \
+  --data-binary @/tmp/report-spec.json \
+  "$SIGMA_BASE_URL/v2/reports/spec" \
+  > /tmp/report-create.json
+```
+
+Save the submitted representation under a report-ID-specific path. Report the
+report URL, ID, and saved path.
+
+### Step 7: Read back and inspect output
+
+Immediately GET the representation and compare normalized documents. Confirm
+that optional fields survived and that no element, panel, page, or setting was
+silently dropped. Then export the affected pages to PDF and inspect the actual
+page breaks, clipping, typography, header/footer repetition, and margins.
+
+Do not claim parity from a successful POST or PUT alone.
+
+### Step 8: Update with a loss check
+
+Follow `reference/workflows/crud.md`. The short version is:
+
+1. GET and back up the current report representation.
+2. Inventory report pages, controls, and elements through their resource APIs.
+3. Stop if the inventory contains content absent from the GET representation.
+4. Edit the complete `document`.
+5. Validate in `--mode update` and call `/v2/reports/spec/verify` with a create
+   envelope assembled from the current name/folder and edited document.
+6. PUT exactly `{"document": {...}}`.
+7. GET again, compare, export, and inspect.
+
+## Reference index
+
+| File | Load when |
+|---|---|
+| `reference/specification/schema.md` | Always. Wrapped envelope, document fields, pages, panels, response metadata. |
+| `reference/specification/layout.md` | Always. Pixel XML, bounds, page and panel placement. |
+| `reference/specification/support-matrix.md` | Always. Safe, gated, unsupported, and workbook-only kinds. |
+| `reference/specification/example-minimal.json` | Starting a new report representation. |
+| `reference/workflows/crud.md` | Creating, retrieving, or replacing a report document. |
+| `reference/workflows/validate.md` | Before every verify, POST, or PUT and after readback. |
+| `reference/workflows/convert.md` | Converting an existing workbook into a report. |
+
+## Troubleshooting
+
+| Symptom | Action |
+|---|---|
+| `unknown field`, `unexpected property`, or missing field | Compare the endpoint against the compiled OpenAPI and rerun the contract test. |
+| A field or element disappears on GET | Treat the representation as lossy; do not PUT until the omitted feature is removed intentionally or preserved another way. |
+| Content overlaps or clips | Check pixel bounds, page dimensions, margins, and repeated panel height; inspect a PDF export. |
+| A workbook grid attribute appears in report XML | Replace it with absolute `x`, `y`, `width`, and `height`. |
+| `waterfall-chart`, `progress`, or synced control is requested | Stop or redesign; the published schema is not a safe report-authoring guarantee. |
+| Conversion succeeds with warnings | Review every warning and its element IDs before accepting the generated report. |
+
+Reports are private beta. Prefer explicit evidence and reversible local edits
+over speculative API writes.

--- a/sigma-reports/reference/specification/example-minimal.json
+++ b/sigma-reports/reference/specification/example-minimal.json
@@ -1,0 +1,45 @@
+{
+  "name": "Monthly Statement",
+  "folderId": "<folder-id>",
+  "description": "Minimal fixed-layout report example",
+  "document": {
+    "schemaVersion": 1,
+    "kind": "report",
+    "config": {
+      "pageWidth": 816,
+      "pageHeight": 1056,
+      "margin": 48
+    },
+    "elements": [
+      {
+        "id": "statement-title",
+        "kind": "text",
+        "body": "# Monthly Statement"
+      },
+      {
+        "id": "footer-text",
+        "kind": "text",
+        "body": "Confidential"
+      }
+    ],
+    "pages": [
+      {
+        "id": "page-1",
+        "name": "Page 1"
+      }
+    ],
+    "panels": [
+      {
+        "id": "report-footer",
+        "type": "footer",
+        "title": "Report footer",
+        "pages": ["page-1"],
+        "config": {
+          "height": 40,
+          "backgroundColor": "#F5F7FA"
+        }
+      }
+    ],
+    "layout": "<?xml version=\"1.0\" encoding=\"utf-8\"?>\n<Page id=\"page-1\">\n  <Element elementId=\"statement-title\" x=\"48\" y=\"48\" width=\"720\" height=\"72\"/>\n</Page>\n<Panel id=\"report-footer\" type=\"footer\">\n  <Element elementId=\"footer-text\" x=\"48\" y=\"8\" width=\"720\" height=\"24\"/>\n</Panel>"
+  }
+}

--- a/sigma-reports/reference/specification/layout.md
+++ b/sigma-reports/reference/specification/layout.md
@@ -1,0 +1,106 @@
+# Report Pixel Layout
+
+Report layout is an XML fragment stored in `document.layout`. It is not the
+responsive CSS-grid representation used by workbooks.
+
+## Grammar
+
+Top-level roots are `<Page>` and `<Panel>`. Leaf elements use absolute pixel
+coordinates:
+
+```xml
+<?xml version="1.0" encoding="utf-8"?>
+<Page id="page-1">
+  <Element elementId="title" x="48" y="40" width="720" height="48"/>
+  <Element elementId="detail" x="48" y="112" width="720" height="760"/>
+</Page>
+<Panel id="statement-footer" type="footer">
+  <Element elementId="footer-text" x="48" y="8" width="720" height="24"/>
+</Panel>
+```
+
+The API describes layout as a fragment with multiple top-level roots. XML
+tools that require one document root must wrap it temporarily for parsing;
+never send that wrapper to Sigma.
+
+## Placement rules
+
+- Each `<Page id>` matches exactly one `document.pages[].id`.
+- Each `<Panel id>` matches exactly one `document.panels[].id`.
+- Panel layout `type` must equal the panel metadata type: `header` or `footer`.
+- Each `<Element elementId>` matches one flat `document.elements[].id`.
+- Place each element exactly once across all pages and panels.
+- `x` and `y` are finite, non-negative pixel coordinates.
+- `width` and `height` are finite, positive pixel dimensions.
+- An element must fit within its page dimensions or panel dimensions.
+- Put no element arrays inside page or panel metadata.
+
+## Page and margin bounds
+
+`document.config.pageWidth` and `pageHeight` define the physical page canvas.
+`margin` defines the intended inset. The local validator enforces the outer
+page bounds and checks that margins leave a positive content area.
+
+Keep authored page content inside the margin unless the design intentionally
+uses bleed. A layout can be mathematically inside the page and still overlap a
+header, footer, or printable margin, so PDF inspection remains mandatory.
+
+For a page width `W`, height `H`, and margin `M`, a conservative content box is:
+
+```
+x >= M
+y >= M + header height
+x + width <= W - M
+y + height <= H - M - footer height
+```
+
+The API's absolute coordinate origin and panel repetition behavior should be
+confirmed from a readback/PDF in the target organization before automating a
+large document.
+
+## Forbidden workbook syntax
+
+Do not use:
+
+- `gridColumn`, `gridRow`, `gridTemplateColumns`, `gridTemplateRows`
+- `<Container>`, `<TabbedContainer>`, `<Tab>`, `<Overlay>`
+- workbook header/sidebar panel types
+- `kind: container`, `tabbed-container`, `repeated-container`, or `page-break`
+
+Those constructs belong to workbook layout. A report page already has fixed
+physical dimensions; pagination comes from report pages, not workbook
+`page-break` elements.
+
+## Header and footer panels
+
+A report panel is declared once and assigned to pages through `panels[].pages`.
+Its content is placed in one matching layout root:
+
+```xml
+<Panel id="statement-header" type="header">
+  <Element elementId="company-logo" x="48" y="8" width="120" height="40"/>
+  <Element elementId="statement-label" x="520" y="8" width="248" height="40"/>
+</Panel>
+```
+
+Size panel children against `panels[].config.height` and the report page width.
+A page can receive at most one header and one footer.
+
+Live-confirmed 2026-08-11: a 70-pixel navy header and 30-pixel footer, each
+containing styled text elements, passed verify and create, round-tripped with
+panel metadata and layout unchanged, survived a full-document PUT, and rendered
+in the exported landscape PDF. Panel element coordinates are local to the
+panel; the visible page's element coordinates remained local to the page body.
+
+## Validation
+
+Run:
+
+```bash
+ruby scripts/validate-spec.rb --mode create /tmp/report-spec.json
+```
+
+The validator parses XML with a real XML parser, rejects workbook grid
+attributes and nested layout tags, checks page/panel roots, verifies exact
+element coverage, and checks numeric outer bounds. It cannot prove visual
+quality. Export and inspect a PDF after every persistent write.

--- a/sigma-reports/reference/specification/schema.md
+++ b/sigma-reports/reference/specification/schema.md
@@ -1,0 +1,151 @@
+# Report Code Representation Schema
+
+The compiled OpenAPI is authoritative for the current envelope:
+
+```bash
+jq '.paths."/v2/reports/spec".post.requestBody.content."application/json".schema' \
+  /tmp/sigma-openapi.json
+```
+
+## Create and verify envelope
+
+`POST /v2/reports/spec` and `POST /v2/reports/spec/verify` take the same wrapped
+JSON shape:
+
+```json
+{
+  "name": "Quarterly Statement",
+  "folderId": "<folder-id>",
+  "description": "Optional outer description",
+  "document": {
+    "schemaVersion": 1,
+    "kind": "report",
+    "config": {
+      "margin": 48,
+      "pageHeight": 1056,
+      "pageWidth": 816
+    },
+    "elements": [],
+    "pages": [{"id": "page-1", "name": "Page 1"}],
+    "panels": [],
+    "layout": "<Page id=\"page-1\"></Page>"
+  }
+}
+```
+
+Required outer fields are `name`, `folderId`, and `document`. Required
+document fields are `schemaVersion`, `kind`, `elements`, and `pages`. This
+skill requires explicit layout when elements are non-empty.
+
+Use a `schemaVersion` returned by a recent report GET. Do not infer it from a
+workbook or hardcode the value shown in examples.
+
+## Update envelope
+
+`PUT /v2/reports/{reportId}/spec` accepts only a complete document wrapper:
+
+```json
+{
+  "document": {
+    "schemaVersion": 1,
+    "kind": "report",
+    "config": {},
+    "elements": [],
+    "pages": [],
+    "panels": [],
+    "layout": "..."
+  }
+}
+```
+
+Do not include `name`, `folderId`, `reportId`, versions, timestamps, or other
+GET metadata. PUT creates a new report version and replaces the complete
+document. Anything omitted from the document can be lost.
+
+## Pages
+
+Pages are metadata, not element containers:
+
+```json
+{
+  "id": "page-1",
+  "name": "Statement",
+  "type": "page",
+  "visibility": "hidden",
+  "pageWidth": "standard",
+  "backgroundColor": "#FFFFFF"
+}
+```
+
+The current shared page schema exposes `id`, `name`, `type`, `visibility`,
+`pageWidth`, `backgroundColor`, and `backgroundImage`. Report physical size is
+controlled by `document.config.pageWidth` and `pageHeight`; do not confuse that
+pixel configuration with the shared page metadata field.
+
+Keep report pages at or below the documented 1,000-page limit. The local
+validator rejects larger documents.
+
+## Report configuration
+
+`document.config` is report-specific:
+
+- `pageWidth`: page width in pixels
+- `pageHeight`: page height in pixels
+- `margin`: page margin in pixels
+
+Values must be finite and non-negative where applicable. Page width and height
+must be positive and no larger than 10,000 pixels. A margin must leave a
+positive content area.
+
+## Header and footer panels
+
+Report panels are not workbook panels:
+
+```json
+{
+  "id": "statement-header",
+  "type": "header",
+  "title": "Statement header",
+  "pages": ["page-1"],
+  "config": {
+    "height": 64,
+    "backgroundColor": "#F5F7FA"
+  }
+}
+```
+
+- `type` is `header` or `footer`, never workbook `sidebar`.
+- `pages` contains IDs of report pages that receive the panel.
+- `config.height` is in pixels.
+- Panel content remains in flat `document.elements` and is assigned by a
+  matching `<Panel>` layout root.
+- A page can have at most one header and one footer assignment.
+
+## Flat elements
+
+All literal elements live in `document.elements`. Pages and panels never have
+nested `elements` arrays. Every element has a unique ID and is placed exactly
+once in layout.
+
+Reports use the OpenAPI `CommonElement` union. This does not mean every union
+member works safely in reports. Apply `support-matrix.md` before authoring.
+
+## GET metadata
+
+GET returns outer report identity, ownership, timestamps, URL, and document
+version metadata in addition to `document`. Preserve the full GET response as
+a backup, but extract only `document` for PUT.
+
+The exact response fields can evolve. Inspect:
+
+```bash
+jq '.paths."/v2/reports/{reportId}/spec".get.responses."200".content."application/json".schema' \
+  /tmp/sigma-openapi.json
+```
+
+## Media type
+
+The current OpenAPI declares `application/json` for create, verify, read, and
+update. Some narrative documentation mentions YAML, but that contradiction has
+not been established as a safe report contract. Use JSON until a live probe
+proves otherwise.

--- a/sigma-reports/reference/specification/support-matrix.md
+++ b/sigma-reports/reference/specification/support-matrix.md
@@ -1,0 +1,106 @@
+# Report Element Support Matrix
+
+The report request schema references `CommonElement`, but schema publication is
+not the same as safe report support. Use this conservative matrix.
+
+## States
+
+| State | Meaning | Authoring policy |
+|---|---|---|
+| Live-proven | Passed verify, create, readback, update, and PDF export in a report-enabled org | Safe baseline; still validate each new shape |
+| Documented | Covered by report examples or report documentation and present in OpenAPI | Validate and verify before write |
+| Schema-only | Present in `CommonElement`, but report behavior or PDF behavior is not established here | Warn; require targeted live verify/readback/PDF evidence |
+| Unsupported | Report documentation identifies the feature as unsupported | Reject for authoring |
+| Workbook-only | Present only in `WorkbookElement` | Reject; redesign or use a workbook |
+
+## Live-proven baseline
+
+The following kinds passed verify, persistent create, GET readback,
+full-document PUT, and populated landscape PDF export on 2026-08-11:
+
+- `bar-chart`, including horizontal orientation, single color, sorting, and
+  hidden legend
+- `combo-chart`, with bar and line series over a `DateTrunc("quarter", ...)`
+  axis
+- `kpi-chart`, with `Sum`, `CountDistinct`, ratio formulas, number formats,
+  value color/font size, and layout anchor/title orientation
+- `table`, including warehouse-table and table-element sources, grouping,
+  aggregate calculations, presentation style, banding, horizontal grid lines,
+  and `dataBars` conditional formatting
+- `text`, including Markdown and inline font/color styling
+
+The same report proved a hidden dependency page, absolute pixel layout,
+header/footer panel assignment and rendering, complete panel readback, and a
+new document version after PUT. This is a baseline, not blanket proof of every
+optional field on these kinds.
+
+## Documented common kinds
+
+- `area-chart`
+- `control`, except `controlType: synced`
+- `divider`
+- `geography-map`
+- `image`
+- `line-chart`
+- `pivot-table`
+- `point-map`
+- `region-map`
+- `scatter-chart`
+
+Use the current OpenAPI for each complete element shape. When installed, the
+matching `sigma-workbooks/reference/specification/` element, source, formula,
+and formatting guides provide useful common-shape recipes. Ignore all workbook
+layout and workbook-only behavior in those guides.
+
+## Schema-only kinds
+
+- `button`
+- `embed`
+- `input-table`
+- `plugin`
+
+These may verify in some configurations, but interactive or write-back
+behavior and PDF output require explicit evidence. The local validator emits a
+warning rather than accepting them silently.
+
+The inherited top-level `document.settings` field is also schema-published but
+not report-proven by this skill. Preserve it unchanged when it appears in a
+readback, warn before PUT, and do not author new theme/navigation settings
+without targeted verify, readback, and PDF evidence.
+
+## Unsupported kinds and subtypes
+
+- `waterfall-chart`
+- `progress` (gauge/progress presentation)
+- `control` with `controlType: synced`
+
+These appear in the shared OpenAPI union but are called unsupported by report
+documentation. The local validator rejects them.
+
+## Workbook-only kinds
+
+- `chat`
+- `container`
+- `form`
+- `navigation`
+- `page-break`
+- `repeated-container`
+- `tabbed-container`
+
+Do not emulate these by copying workbook layout XML. Convert the design to
+fixed report pages or keep it as a workbook.
+
+## Unknown future kinds
+
+The API can add common kinds before this skill is updated. The validator warns
+on an unknown kind instead of claiming it is invalid. Inspect the current
+OpenAPI and report documentation, run `/v2/reports/spec/verify`, and update the
+matrix only after evidence establishes the correct state.
+
+## Lossy readback warning
+
+`GET /v2/reports/{reportId}/spec` can omit features unsupported by report code
+representation. Before PUT, compare the code representation with the report's
+element, page, and control inventory APIs. If inventory objects are missing
+from `document`, stop. Replacing the document can permanently remove omitted
+features from the next report version.

--- a/sigma-reports/reference/workflows/convert.md
+++ b/sigma-reports/reference/workflows/convert.md
@@ -1,0 +1,42 @@
+# Convert a Workbook to a Report
+
+Use `POST /v2/workbooks/{workbookId}/convertToReport`. The source workbook is
+not modified; the endpoint creates a new report.
+
+```json
+{
+  "name": "Operations Packet",
+  "destinationFolderId": "<folder-id>",
+  "description": "Printable operations summary",
+  "pageIds": ["overview-page-id"],
+  "format": {
+    "pageSize": "letter",
+    "layout": "landscape"
+  }
+}
+```
+
+Preset page sizes are `letter`, `a4`, `legal`, and `a3`, with `portrait` or
+`landscape` layout. A custom format accepts `pageSize: custom`, a unit of
+`pixels`, `inches`, or `centimeters`, and explicit width/height.
+
+The response contains `convertedReport`, `sourceWorkbook`, and `warnings`.
+Treat `warnings` as a required review gate, including unknown future warning
+codes. Details can identify source and generated report element IDs.
+
+Conversion can remove unsupported contents or move supported dependents to a
+hidden page. Common risks include containers, repeated containers, tabs,
+actions, overlays, sidebars, schedules, and sharing configuration. Do not
+accept a converted report until you:
+
+1. Review every warning and affected ID.
+2. GET the generated report representation.
+3. Compare source workbook intent with generated report pages and elements.
+4. Replace workbook interaction patterns with fixed report-page designs.
+5. Validate the representation locally and through report verify.
+6. Export the complete report to PDF and inspect every page.
+7. Recreate report schedules, grants, and delivery settings intentionally;
+   they are not implied by code-representation conversion.
+
+Conversion is persistent and creates a report. Obtain explicit approval for
+the destination and name before invoking it.

--- a/sigma-reports/reference/workflows/crud.md
+++ b/sigma-reports/reference/workflows/crud.md
@@ -1,0 +1,99 @@
+# Report Code Representation CRUD
+
+All calls require `Authorization: Bearer $SIGMA_API_TOKEN`. The current OpenAPI
+declares JSON bodies and responses for the report spec endpoints.
+
+## Verify without persistence
+
+Use the create envelope with the verify endpoint:
+
+```bash
+curl -sf -X POST \
+  -H "Authorization: Bearer $SIGMA_API_TOKEN" \
+  -H "Content-Type: application/json" \
+  -H "Accept: application/json" \
+  --data-binary @/tmp/report-spec.json \
+  "$SIGMA_BASE_URL/v2/reports/spec/verify"
+```
+
+Make this the default live probe. It does not create a report.
+
+## Create
+
+Creating is persistent and the current API has no report DELETE endpoint. Get
+explicit approval for the destination folder before calling:
+
+```bash
+curl -sf -X POST \
+  -H "Authorization: Bearer $SIGMA_API_TOKEN" \
+  -H "Content-Type: application/json" \
+  -H "Accept: application/json" \
+  --data-binary @/tmp/report-spec.json \
+  "$SIGMA_BASE_URL/v2/reports/spec" \
+  > /tmp/report-create.json
+```
+
+The success response contains `success` and `reportId`. Save the submitted
+representation under a report-ID-specific path immediately.
+
+Live-confirmed 2026-08-11: create returned HTTP 200 with
+`{"success":true,"reportId":"..."}` after the same envelope returned
+`{"valid":true}` from verify.
+
+## Retrieve
+
+```bash
+curl -sf \
+  -H "Authorization: Bearer $SIGMA_API_TOKEN" \
+  -H "Accept: application/json" \
+  "$SIGMA_BASE_URL/v2/reports/<report-id>/spec" \
+  > /tmp/report-<report-id>-before.json
+```
+
+Keep the complete response as the rollback record. It includes outer metadata
+and the report `document`.
+
+## Update
+
+PUT is full replacement and creates a new report version. Send exactly one
+outer property, `document`:
+
+```bash
+jq '{document: .document}' /tmp/report-edited.json \
+  > /tmp/report-put.json
+
+ruby scripts/validate-spec.rb --mode update /tmp/report-put.json
+
+curl -sf -X PUT \
+  -H "Authorization: Bearer $SIGMA_API_TOKEN" \
+  -H "Content-Type: application/json" \
+  -H "Accept: application/json" \
+  --data-binary @/tmp/report-put.json \
+  "$SIGMA_BASE_URL/v2/reports/<report-id>/spec" \
+  > /tmp/report-update-response.json
+```
+
+Before PUT:
+
+1. GET the latest representation and preserve its version metadata.
+2. List the report's pages, elements, and controls through their inventory
+   endpoints.
+3. Compare inventory IDs with the representation.
+4. Stop if inventory content is absent from `document`; GET can be lossy.
+5. Preserve every page, panel, element, source, formula, setting, and layout
+   entry not intentionally changed.
+6. Validate the update body locally.
+7. Assemble a create envelope around the edited document and call verify.
+
+After PUT, GET again and compare normalized documents. Export the affected
+pages as PDF and inspect them.
+
+Live-confirmed 2026-08-11: PUT returned HTTP 200, retained the report ID, and
+advanced `documentVersion`/`latestDocumentVersion` from 1 to 2. Header/footer
+panels, element IDs, and pixel layout survived readback unchanged.
+
+## No automated cleanup assumption
+
+Do not design tests around create-then-delete. The current OpenAPI exposes GET
+on `/v2/reports/{reportId}` but no DELETE operation. Reuse a designated manual
+test report only when the user has approved that persistent resource.

--- a/sigma-reports/reference/workflows/validate.md
+++ b/sigma-reports/reference/workflows/validate.md
@@ -1,0 +1,79 @@
+# Report Validation
+
+Validation has four separate gates. None substitutes for another.
+
+## 1. Offline representation validation
+
+```bash
+ruby scripts/validate-spec.rb --mode create /tmp/report-spec.json
+ruby scripts/validate-spec.rb --mode update /tmp/report-put.json
+```
+
+The validator checks:
+
+- create or update wrapper shape;
+- required document fields and `kind: report`;
+- page, panel, and element IDs;
+- 1,000-page and 10,000-pixel limits;
+- panel types, page assignments, and one-header/one-footer per page;
+- documented unsupported, workbook-only, schema-only, and unknown kinds;
+- real XML parsing of Page, Panel, and Element layout nodes;
+- absolute numeric coordinates and dimensions;
+- page and panel outer bounds;
+- exact one-time placement of every element;
+- matching layout roots for pages and panels;
+- rejection of workbook grid/container syntax.
+
+Warnings are not proof of safety. Resolve schema-only or unknown kinds through
+a targeted OpenAPI review and live verify before writing.
+
+## 2. Server verify
+
+POST the create envelope to `/v2/reports/spec/verify`. This is non-persistent
+and should precede every create or update. For an update, wrap the edited
+document with the current report name and folder solely for verification, then
+send only `{document: ...}` to PUT.
+
+Verify can catch schema and dependency errors that an offline validator cannot.
+
+## 3. Readback and loss detection
+
+After every persistent write, GET the report representation and compare:
+
+- all element, page, and panel IDs;
+- sources, columns, formulas, formats, and filters;
+- layout coordinates and dimensions;
+- report page configuration;
+- panel assignments and heights;
+- fields that the service normalized or dropped.
+
+Before updating an existing report, compare the GET representation with page,
+element, and control inventory endpoints. A feature present in inventory but
+absent from the code representation is a destructive-update risk.
+
+## 4. PDF and data parity
+
+Export the affected report to PDF and inspect:
+
+- clipping and overlap;
+- page breaks and page count;
+- margins, bleed, and whitespace;
+- repeating header/footer placement;
+- fonts, colors, images, and chart legends;
+- table row continuation and totals;
+- control/filter effects;
+- representative values and aggregates against the warehouse.
+
+API success cannot prove visual or data parity.
+
+## Common failures
+
+| Failure | Meaning |
+|---|---|
+| `document.kind must be report` | A workbook document was sent to a report endpoint. |
+| element missing from layout | Add one `<Element elementId="...">` under a Page or Panel root. |
+| undeclared element in layout | Fix the ID or add the literal element to `document.elements`. |
+| workbook grid attribute | Replace grid syntax with pixel `x`, `y`, `width`, and `height`. |
+| panel type mismatch | Make layout and metadata both `header` or both `footer`. |
+| field disappears on GET | Treat readback as lossy; do not blindly PUT the result. |
+| verify succeeds but PDF is wrong | Fix physical layout; verify is not a render test. |

--- a/sigma-reports/scripts/extract-openapi-contract.rb
+++ b/sigma-reports/scripts/extract-openapi-contract.rb
@@ -1,0 +1,153 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+# Extract the small, executable report-as-code contract pinned by this skill.
+# Usage: ruby scripts/extract-openapi-contract.rb OPENAPI_JSON
+
+require 'date'
+require 'json'
+
+def resolve(schema, openapi)
+  return schema unless schema.is_a?(Hash) && schema['$ref']
+
+  schema['$ref'].delete_prefix('#/').split('/').reduce(openapi) { |node, key| node.fetch(key) }
+end
+
+def merged_required(schema, openapi)
+  schema = resolve(schema, openapi)
+  return [] unless schema.is_a?(Hash)
+
+  (Array(schema['required']) + Array(schema['allOf']).flat_map { |part| merged_required(part, openapi) }).uniq.sort
+end
+
+def merged_properties(schema, openapi)
+  schema = resolve(schema, openapi)
+  return [] unless schema.is_a?(Hash)
+
+  (schema.fetch('properties', {}).keys + Array(schema['allOf']).flat_map { |part| merged_properties(part, openapi) }).uniq.sort
+end
+
+def property(schema, name, openapi)
+  schema = resolve(schema, openapi)
+  return unless schema.is_a?(Hash)
+  return schema.dig('properties', name) if schema.dig('properties', name)
+
+  Array(schema['allOf']).each do |part|
+    found = property(part, name, openapi)
+    return found if found
+  end
+  nil
+end
+
+def shape(schema, openapi)
+  {'required' => merged_required(schema, openapi), 'properties' => merged_properties(schema, openapi)}
+end
+
+def enum_values(schema, openapi)
+  schema = resolve(schema, openapi)
+  return [] unless schema.is_a?(Hash)
+
+  (Array(schema['enum']) + %w[oneOf anyOf allOf].flat_map do |key|
+    Array(schema[key]).flat_map { |part| enum_values(part, openapi) }
+  end).uniq.sort
+end
+
+def collect_discriminators(schema, discriminator, openapi, out = [], seen = {})
+  return out unless schema.is_a?(Hash)
+
+  if schema['$ref']
+    return out if seen[schema['$ref']]
+
+    seen[schema['$ref']] = true
+    schema = resolve(schema, openapi)
+  end
+  values = enum_values(property(schema, discriminator, openapi), openapi)
+  out << {'title' => schema['title'], discriminator => values.first} if schema['title'] && values.one?
+  %w[oneOf anyOf allOf].each do |key|
+    Array(schema[key]).each { |part| collect_discriminators(part, discriminator, openapi, out, seen.dup) }
+  end
+  out.uniq { |entry| entry[discriminator] }.sort_by { |entry| entry[discriminator] }
+end
+
+def request_schema(openapi, path, method)
+  openapi.dig('paths', path, method, 'requestBody', 'content', 'application/json', 'schema')
+end
+
+def response_schema(openapi, path, method, status)
+  openapi.dig('paths', path, method, 'responses', status, 'content', 'application/json', 'schema')
+end
+
+path = ARGV.fetch(0) { abort 'usage: extract-openapi-contract.rb OPENAPI_JSON' }
+openapi = JSON.parse(File.read(path))
+schemas = openapi.fetch('components').fetch('schemas')
+create_path = '/v2/reports/spec'
+verify_path = '/v2/reports/spec/verify'
+spec_path = '/v2/reports/{reportId}/spec'
+resource_path = '/v2/reports/{reportId}'
+convert_path = '/v2/workbooks/{workbookId}/convertToReport'
+
+create = request_schema(openapi, create_path, 'post')
+verify = request_schema(openapi, verify_path, 'post')
+update = request_schema(openapi, spec_path, 'put')
+read = response_schema(openapi, spec_path, 'get', '200')
+convert_request = request_schema(openapi, convert_path, 'post')
+convert_response = response_schema(openapi, convert_path, 'post', '201')
+create_document = property(create, 'document', openapi)
+update_document = property(update, 'document', openapi)
+read_document = property(read, 'document', openapi)
+page = resolve(property(create_document, 'pages', openapi).fetch('items'), openapi)
+panel = resolve(property(create_document, 'panels', openapi).fetch('items'), openapi)
+config = property(create_document, 'config', openapi)
+panel_config = property(panel, 'config', openapi)
+common_elements = collect_discriminators(schemas.fetch('CommonElement'), 'kind', openapi)
+common_kinds = common_elements.map { |entry| entry.fetch('kind') }
+workbook_only_elements = collect_discriminators(schemas.fetch('WorkbookElement'), 'kind', openapi)
+                         .reject { |entry| common_kinds.include?(entry.fetch('kind')) }
+
+contract = {
+  'source' => {
+    'openapiVersion' => openapi.fetch('openapi'),
+    'apiVersion' => openapi.fetch('info').fetch('version'),
+    'capturedAt' => ENV.fetch('CAPTURED_AT', Date.today.iso8601)
+  },
+  'mediaTypes' => {
+    'create' => openapi.dig('paths', create_path, 'post', 'requestBody', 'content').keys.sort,
+    'verify' => openapi.dig('paths', verify_path, 'post', 'requestBody', 'content').keys.sort,
+    'read' => openapi.dig('paths', spec_path, 'get', 'responses', '200', 'content').keys.sort,
+    'update' => openapi.dig('paths', spec_path, 'put', 'requestBody', 'content').keys.sort
+  },
+  'schemas' => {
+    'CreateReportSpec' => shape(create, openapi),
+    'CreateReportSpec.document' => shape(create_document, openapi),
+    'VerifyReportSpec' => shape(verify, openapi),
+    'UpdateReportSpec' => shape(update, openapi),
+    'UpdateReportSpec.document' => shape(update_document, openapi),
+    'ReportSpec' => shape(read, openapi),
+    'ReportSpec.document' => shape(read_document, openapi),
+    'ReportPage' => shape(page, openapi),
+    'ReportPanel' => shape(panel, openapi),
+    'ReportPanel.config' => shape(panel_config, openapi),
+    'ReportConfig' => shape(config, openapi),
+    'ConvertWorkbookToReport' => shape(convert_request, openapi),
+    'ConvertWorkbookToReportResponse' => shape(convert_response, openapi)
+  },
+  'enums' => {
+    'documentKind' => enum_values(property(create_document, 'kind', openapi), openapi),
+    'panelType' => enum_values(property(panel, 'type', openapi), openapi)
+  },
+  'publishedVariants' => {
+    'commonElements' => common_elements,
+    'workbookOnlyElements' => workbook_only_elements,
+    'controls' => collect_discriminators(schemas.fetch('CommonElement'), 'controlType', openapi)
+  },
+  'operations' => {
+    'reportResourceMethods' => openapi.fetch('paths').fetch(resource_path).keys.grep(/\A(?:get|post|put|patch|delete)\z/).sort,
+    'createStatuses' => openapi.dig('paths', create_path, 'post', 'responses').keys.sort,
+    'verifyStatuses' => openapi.dig('paths', verify_path, 'post', 'responses').keys.sort,
+    'readStatuses' => openapi.dig('paths', spec_path, 'get', 'responses').keys.sort,
+    'updateStatuses' => openapi.dig('paths', spec_path, 'put', 'responses').keys.sort,
+    'convertStatuses' => openapi.dig('paths', convert_path, 'post', 'responses').keys.sort
+  }
+}
+
+puts JSON.pretty_generate(contract)

--- a/sigma-reports/scripts/fixtures/openapi-report-contract.json
+++ b/sigma-reports/scripts/fixtures/openapi-report-contract.json
@@ -1,0 +1,131 @@
+{
+  "source": {
+    "openapiVersion": "3.1.0",
+    "apiVersion": "2.0.0",
+    "capturedAt": "2026-08-11"
+  },
+  "mediaTypes": {
+    "create": ["application/json"],
+    "verify": ["application/json"],
+    "read": ["application/json"],
+    "update": ["application/json"]
+  },
+  "schemas": {
+    "CreateReportSpec": {
+      "required": ["document", "folderId", "name"],
+      "properties": ["description", "document", "folderId", "name"]
+    },
+    "CreateReportSpec.document": {
+      "required": ["elements", "kind", "pages", "schemaVersion"],
+      "properties": ["config", "elements", "kind", "layout", "pages", "panels", "schemaVersion", "settings"]
+    },
+    "VerifyReportSpec": {
+      "required": ["document", "folderId", "name"],
+      "properties": ["description", "document", "folderId", "name"]
+    },
+    "UpdateReportSpec": {
+      "required": ["document"],
+      "properties": ["document"]
+    },
+    "UpdateReportSpec.document": {
+      "required": ["elements", "kind", "pages", "schemaVersion"],
+      "properties": ["config", "elements", "kind", "layout", "pages", "panels", "schemaVersion", "settings"]
+    },
+    "ReportSpec": {
+      "required": ["createdAt", "createdBy", "document", "documentVersion", "folderId", "latestDocumentVersion", "name", "ownerId", "reportId", "updatedAt", "updatedBy", "url"],
+      "properties": ["createdAt", "createdBy", "description", "document", "documentVersion", "folderId", "latestDocumentVersion", "name", "ownerId", "reportId", "updatedAt", "updatedBy", "url"]
+    },
+    "ReportSpec.document": {
+      "required": ["elements", "kind", "layout", "pages", "schemaVersion"],
+      "properties": ["config", "elements", "kind", "layout", "pages", "panels", "schemaVersion", "settings"]
+    },
+    "ReportPage": {
+      "required": ["id", "name"],
+      "properties": ["backgroundColor", "backgroundImage", "id", "name", "pageWidth", "type", "visibility"]
+    },
+    "ReportPanel": {
+      "required": ["id", "type"],
+      "properties": ["config", "id", "pages", "title", "type"]
+    },
+    "ReportPanel.config": {
+      "required": [],
+      "properties": ["backgroundColor", "height"]
+    },
+    "ReportConfig": {
+      "required": [],
+      "properties": ["margin", "pageHeight", "pageWidth"]
+    },
+    "ConvertWorkbookToReport": {
+      "required": ["name"],
+      "properties": ["description", "destinationFolderId", "format", "name", "pageIds"]
+    },
+    "ConvertWorkbookToReportResponse": {
+      "required": ["convertedReport", "sourceWorkbook", "warnings"],
+      "properties": ["convertedReport", "sourceWorkbook", "warnings"]
+    }
+  },
+  "enums": {
+    "documentKind": ["report"],
+    "panelType": ["footer", "header"]
+  },
+  "publishedVariants": {
+    "commonElements": [
+      {"title": "Area Chart", "kind": "area-chart"},
+      {"title": "Bar Chart", "kind": "bar-chart"},
+      {"title": "Button", "kind": "button"},
+      {"title": "Combo Chart", "kind": "combo-chart"},
+      {"title": "Checkbox", "kind": "control"},
+      {"title": "Divider", "kind": "divider"},
+      {"title": "Embed", "kind": "embed"},
+      {"title": "Geography Map", "kind": "geography-map"},
+      {"title": "Image", "kind": "image"},
+      {"title": "Input Table", "kind": "input-table"},
+      {"title": "KPI", "kind": "kpi-chart"},
+      {"title": "Line Chart", "kind": "line-chart"},
+      {"title": "Pivot Table", "kind": "pivot-table"},
+      {"title": "Plugin", "kind": "plugin"},
+      {"title": "Point Map", "kind": "point-map"},
+      {"title": "Progress", "kind": "progress"},
+      {"title": "Region Map", "kind": "region-map"},
+      {"title": "Scatter Chart", "kind": "scatter-chart"},
+      {"title": "Table", "kind": "table"},
+      {"title": "Text", "kind": "text"},
+      {"title": "Waterfall Chart", "kind": "waterfall-chart"}
+    ],
+    "workbookOnlyElements": [
+      {"title": "Chat", "kind": "chat"},
+      {"title": "Container", "kind": "container"},
+      {"title": "Form", "kind": "form"},
+      {"title": "Manual navigation", "kind": "navigation"},
+      {"title": "Page break", "kind": "page-break"},
+      {"title": "Repeated container", "kind": "repeated-container"},
+      {"title": "Tabbed container", "kind": "tabbed-container"}
+    ],
+    "controls": [
+      {"title": "Checkbox", "controlType": "checkbox"},
+      {"title": "Date", "controlType": "date"},
+      {"title": "Date Range", "controlType": "date-range"},
+      {"title": "Drill down", "controlType": "drill"},
+      {"title": "Hierarchy", "controlType": "hierarchy"},
+      {"title": "Legend", "controlType": "legend"},
+      {"title": "Number", "controlType": "number"},
+      {"title": "Number Range", "controlType": "number-range"},
+      {"title": "Range Slider", "controlType": "range-slider"},
+      {"title": "Segmented Control", "controlType": "segmented"},
+      {"title": "Slider", "controlType": "slider"},
+      {"title": "Switch", "controlType": "switch"},
+      {"title": "Synced", "controlType": "synced"},
+      {"title": "Text", "controlType": "text"},
+      {"title": "Text Area", "controlType": "text-area"},
+      {"title": "Top N", "controlType": "top-n"}
+    ]
+  },
+  "operations": {
+    "reportResourceMethods": ["get"],
+    "createStatuses": ["200", "default"],
+    "verifyStatuses": ["200", "default"],
+    "readStatuses": ["200", "default"],
+    "updateStatuses": ["200", "default"],
+    "convertStatuses": ["201", "default"]
+  }
+}

--- a/sigma-reports/scripts/lib/report_spec_validator.rb
+++ b/sigma-reports/scripts/lib/report_spec_validator.rb
@@ -1,0 +1,365 @@
+# frozen_string_literal: true
+
+require 'json'
+require 'rexml/document'
+
+module ReportSpec
+  class Validator
+    MAX_PAGES = 1_000
+    MAX_PAGE_DIMENSION = 10_000
+
+    DOCUMENTED_KINDS = %w[
+      area-chart bar-chart combo-chart control divider geography-map image
+      kpi-chart line-chart pivot-table point-map region-map scatter-chart
+      table text
+    ].freeze
+    SCHEMA_ONLY_KINDS = %w[button embed input-table plugin].freeze
+    UNSUPPORTED_KINDS = %w[progress waterfall-chart].freeze
+    WORKBOOK_ONLY_KINDS = %w[
+      chat container form navigation page-break repeated-container
+      tabbed-container
+    ].freeze
+    FORBIDDEN_LAYOUT_ATTRIBUTES = %w[
+      gridColumn gridRow gridTemplateColumns gridTemplateRows
+    ].freeze
+
+    attr_reader :errors, :warnings
+
+    def initialize(payload, mode: :create)
+      @payload = payload
+      @mode = mode.to_sym
+      @errors = []
+      @warnings = []
+    end
+
+    def validate
+      validate_envelope
+      return self unless @document.is_a?(Hash)
+
+      validate_document
+      validate_pages
+      validate_panels
+      validate_elements
+      validate_layout
+      self
+    end
+
+    def valid?
+      errors.empty?
+    end
+
+    private
+
+    def validate_envelope
+      unless @payload.is_a?(Hash)
+        errors << 'root must be a JSON object'
+        return
+      end
+
+      case @mode
+      when :create
+        %w[name folderId document].each do |key|
+          errors << "missing required create field: #{key}" unless @payload.key?(key)
+        end
+      when :update
+        errors << 'update body must contain exactly one property: document' unless @payload.keys == ['document']
+      else
+        errors << "unknown validation mode: #{@mode}"
+      end
+
+      @document = @payload['document']
+      errors << 'document must be an object' unless @document.is_a?(Hash)
+    end
+
+    def validate_document
+      %w[schemaVersion kind elements pages].each do |key|
+        errors << "missing required document field: #{key}" unless @document.key?(key)
+      end
+      errors << 'document.schemaVersion must be a number' unless @document['schemaVersion'].is_a?(Numeric)
+      errors << 'document.kind must be report' unless @document['kind'] == 'report'
+      errors << 'document.elements must be an array' unless @document['elements'].is_a?(Array)
+      errors << 'document.pages must be an array' unless @document['pages'].is_a?(Array)
+      errors << 'document.panels must be an array when present' if @document.key?('panels') && !@document['panels'].is_a?(Array)
+      warnings << 'document.settings is schema-published but not report-proven; preserve readback unchanged and verify carefully' if @document.key?('settings')
+
+      config = @document['config']
+      if config && !config.is_a?(Hash)
+        errors << 'document.config must be an object when present'
+        return
+      end
+      return unless config
+
+      width = validate_number(config['pageWidth'], 'document.config.pageWidth', positive: true, max: MAX_PAGE_DIMENSION)
+      height = validate_number(config['pageHeight'], 'document.config.pageHeight', positive: true, max: MAX_PAGE_DIMENSION)
+      margin = validate_number(config['margin'], 'document.config.margin', nonnegative: true)
+      errors << 'document.config.margin must leave positive page width' if width && margin && margin * 2 >= width
+      errors << 'document.config.margin must leave positive page height' if height && margin && margin * 2 >= height
+    end
+
+    def validate_pages
+      @pages = array(@document['pages'])
+      errors << 'document.pages must contain at least one page' if @pages.empty?
+      errors << "document.pages exceeds the #{MAX_PAGES}-page limit" if @pages.length > MAX_PAGES
+
+      @page_ids = validate_ids(@pages, 'page')
+      @pages.each_with_index do |page, index|
+        unless page.is_a?(Hash)
+          errors << "document.pages[#{index}] must be an object"
+          next
+        end
+        errors << "page #{label(page, index)} must have a non-empty name" unless nonempty_string?(page['name'])
+        errors << "page #{label(page, index)} must not contain nested elements" if page.key?('elements')
+      end
+    end
+
+    def validate_panels
+      @panels = array(@document['panels'])
+      @panel_ids = validate_ids(@panels, 'panel')
+      assignments = Hash.new { |hash, key| hash[key] = [] }
+
+      @panels.each_with_index do |panel, index|
+        unless panel.is_a?(Hash)
+          errors << "document.panels[#{index}] must be an object"
+          next
+        end
+        panel_label = label(panel, index)
+        type = panel['type']
+        errors << "panel #{panel_label} type must be header or footer" unless %w[header footer].include?(type)
+        errors << "panel #{panel_label} must not contain nested elements" if panel.key?('elements')
+
+        pages = panel['pages']
+        if pages && !pages.is_a?(Array)
+          errors << "panel #{panel_label} pages must be an array"
+        else
+          array(pages).each do |page_id|
+            errors << "panel #{panel_label} references unknown page: #{page_id}" unless @page_ids.include?(page_id)
+            assignments[[page_id, type]] << panel['id'] if %w[header footer].include?(type)
+          end
+        end
+
+        config = panel['config']
+        if config && !config.is_a?(Hash)
+          errors << "panel #{panel_label} config must be an object"
+        elsif config
+          validate_number(config['height'], "panel #{panel_label} config.height", positive: true, max: MAX_PAGE_DIMENSION)
+          if config.key?('backgroundColor') && !config['backgroundColor'].is_a?(String)
+            errors << "panel #{panel_label} config.backgroundColor must be a string"
+          end
+        end
+      end
+
+      assignments.each do |(page_id, type), panel_ids|
+        next unless panel_ids.length > 1
+
+        errors << "page #{page_id} has more than one #{type} panel: #{panel_ids.join(', ')}"
+      end
+    end
+
+    def validate_elements
+      @elements = array(@document['elements'])
+      @element_ids = validate_ids(@elements, 'element')
+
+      @elements.each_with_index do |element, index|
+        unless element.is_a?(Hash)
+          errors << "document.elements[#{index}] must be an object"
+          next
+        end
+        element_label = label(element, index)
+        kind = element['kind']
+        unless nonempty_string?(kind)
+          errors << "element #{element_label} must have a non-empty kind"
+          next
+        end
+
+        if UNSUPPORTED_KINDS.include?(kind)
+          errors << "element #{element_label} kind #{kind} is unsupported for report authoring"
+        elsif WORKBOOK_ONLY_KINDS.include?(kind)
+          errors << "element #{element_label} kind #{kind} is workbook-only"
+        elsif SCHEMA_ONLY_KINDS.include?(kind)
+          warnings << "element #{element_label} kind #{kind} is schema-only; require live verify/readback/PDF evidence"
+        elsif !DOCUMENTED_KINDS.include?(kind)
+          warnings << "element #{element_label} kind #{kind} is unknown to this support matrix"
+        end
+
+        if kind == 'control' && element['controlType'] == 'synced'
+          errors << "element #{element_label} uses unsupported synced controlType"
+        end
+      end
+    end
+
+    def validate_layout
+      layout = @document['layout']
+      if @elements.any? && !nonempty_string?(layout)
+        errors << 'document.layout is required when document.elements is non-empty'
+        return
+      end
+      return unless nonempty_string?(layout)
+
+      if layout.match?(/<!DOCTYPE|<!ENTITY/i)
+        errors << 'document.layout must not contain a DOCTYPE or ENTITY declaration'
+        return
+      end
+
+      fragment = layout.sub(/\A\s*<\?xml[^?]*\?>\s*/m, '')
+      xml = REXML::Document.new("<ReportLayout>#{fragment}</ReportLayout>")
+      placements = Hash.new(0)
+      page_roots = []
+      panel_roots = []
+
+      xml.root.elements.each do |root|
+        case root.name
+        when 'Page'
+          page_roots << root.attributes['id']
+          validate_region_root(root, 'Page', @page_ids, placements)
+        when 'Panel'
+          panel_roots << root.attributes['id']
+          validate_region_root(root, 'Panel', @panel_ids, placements)
+          validate_panel_root(root)
+        else
+          errors << "layout top-level node must be Page or Panel, got #{root.name}"
+        end
+      end
+
+      validate_root_coverage(page_roots, @page_ids, 'page')
+      validate_root_coverage(panel_roots, @panel_ids, 'panel')
+      placements.each do |element_id, count|
+        errors << "layout references undeclared elementId: #{element_id}" unless @element_ids.include?(element_id)
+        errors << "element is placed more than once in layout: #{element_id}" if count > 1
+      end
+      (@element_ids - placements.keys).each { |id| errors << "element is not placed in layout: #{id}" }
+    rescue REXML::ParseException => e
+      errors << "document.layout is invalid XML: #{e.message.lines.first.strip}"
+    end
+
+    def validate_region_root(root, kind, declared_ids, placements)
+      id = root.attributes['id']
+      errors << "layout #{kind} is missing id" unless nonempty_string?(id)
+      errors << "layout #{kind} references undeclared #{kind.downcase} id: #{id}" if nonempty_string?(id) && !declared_ids.include?(id)
+      reject_grid_attributes(root, "layout #{kind} #{id || '(unnamed)'}")
+
+      root.elements.each do |child|
+        if child.name != 'Element'
+          errors << "layout #{kind} #{id || '(unnamed)'} may contain only Element leaves, got #{child.name}"
+          next
+        end
+        validate_layout_element(child, root, placements)
+      end
+    end
+
+    def validate_layout_element(node, root, placements)
+      element_id = node.attributes['elementId']
+      unless nonempty_string?(element_id)
+        errors << "layout Element under #{root.name} #{root.attributes['id']} is missing elementId"
+        return
+      end
+      placements[element_id] += 1
+      reject_grid_attributes(node, "layout Element #{element_id}")
+      errors << "layout Element #{element_id} must not contain child nodes" if node.has_elements?
+
+      x = validate_xml_number(node, 'x', element_id, nonnegative: true)
+      y = validate_xml_number(node, 'y', element_id, nonnegative: true)
+      width = validate_xml_number(node, 'width', element_id, positive: true)
+      height = validate_xml_number(node, 'height', element_id, positive: true)
+      return unless x && y && width && height
+
+      page_width = number(@document.dig('config', 'pageWidth'))
+      region_height = if root.name == 'Panel'
+                        panel = @panels.find { |entry| entry.is_a?(Hash) && entry['id'] == root.attributes['id'] }
+                        number(panel&.dig('config', 'height'))
+                      else
+                        number(@document.dig('config', 'pageHeight'))
+                      end
+      errors << "layout Element #{element_id} exceeds page width" if page_width && x + width > page_width
+      errors << "layout Element #{element_id} exceeds #{root.name.downcase} height" if region_height && y + height > region_height
+    end
+
+    def validate_panel_root(root)
+      panel = @panels.find { |entry| entry.is_a?(Hash) && entry['id'] == root.attributes['id'] }
+      type = root.attributes['type']
+      errors << "layout Panel #{root.attributes['id']} type must be header or footer" unless %w[header footer].include?(type)
+      return unless panel && type
+
+      errors << "layout Panel #{root.attributes['id']} type #{type} does not match metadata type #{panel['type']}" if panel['type'] != type
+    end
+
+    def validate_root_coverage(actual, declared, kind)
+      actual.compact.group_by(&:itself).each do |id, copies|
+        errors << "#{kind} is declared more than once in layout: #{id}" if copies.length > 1
+      end
+      (declared - actual.compact).each { |id| errors << "#{kind} is missing from layout: #{id}" }
+    end
+
+    def reject_grid_attributes(node, label)
+      FORBIDDEN_LAYOUT_ATTRIBUTES.each do |attribute|
+        errors << "#{label} uses forbidden workbook attribute #{attribute}" if node.attributes[attribute]
+      end
+    end
+
+    def validate_xml_number(node, attribute, element_id, positive: false, nonnegative: false)
+      raw = node.attributes[attribute]
+      unless raw
+        errors << "layout Element #{element_id} is missing #{attribute}"
+        return
+      end
+      value = number(raw)
+      unless value
+        errors << "layout Element #{element_id} #{attribute} must be a finite number"
+        return
+      end
+      errors << "layout Element #{element_id} #{attribute} must be positive" if positive && value <= 0
+      errors << "layout Element #{element_id} #{attribute} must be non-negative" if nonnegative && value.negative?
+      value
+    end
+
+    def validate_number(value, label, positive: false, nonnegative: false, max: nil)
+      return unless value
+
+      parsed = number(value)
+      unless parsed
+        errors << "#{label} must be a finite number"
+        return
+      end
+      errors << "#{label} must be positive" if positive && parsed <= 0
+      errors << "#{label} must be non-negative" if nonnegative && parsed.negative?
+      errors << "#{label} must not exceed #{max}" if max && parsed > max
+      parsed
+    end
+
+    def validate_ids(entries, kind)
+      ids = []
+      entries.each_with_index do |entry, index|
+        next unless entry.is_a?(Hash)
+
+        id = entry['id']
+        if nonempty_string?(id)
+          ids << id
+        else
+          errors << "#{kind} at index #{index} must have a non-empty id"
+        end
+      end
+      ids.group_by(&:itself).each do |id, copies|
+        errors << "duplicate #{kind} id: #{id}" if copies.length > 1
+      end
+      ids.uniq
+    end
+
+    def number(value)
+      parsed = Float(value)
+      parsed if parsed.finite?
+    rescue ArgumentError, TypeError
+      nil
+    end
+
+    def array(value)
+      value.is_a?(Array) ? value : []
+    end
+
+    def nonempty_string?(value)
+      value.is_a?(String) && !value.strip.empty?
+    end
+
+    def label(entry, index)
+      entry['id'] || "at index #{index}"
+    end
+  end
+end

--- a/sigma-reports/scripts/test-openapi-contract.rb
+++ b/sigma-reports/scripts/test-openapi-contract.rb
@@ -1,0 +1,113 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+# Offline contract regression:
+#   ruby scripts/test-openapi-contract.rb
+# Compare with a freshly downloaded OpenAPI document:
+#   ruby scripts/test-openapi-contract.rb /tmp/sigma-openapi.json
+
+require 'json'
+require 'open3'
+
+FIXTURE = File.expand_path('fixtures/openapi-report-contract.json', __dir__)
+EXTRACTOR = File.expand_path('extract-openapi-contract.rb', __dir__)
+contract = JSON.parse(File.read(FIXTURE))
+failures = []
+
+def assert_contract(failures, description)
+  failures << description unless yield
+end
+
+schemas = contract.fetch('schemas')
+create = schemas.fetch('CreateReportSpec')
+create_document = schemas.fetch('CreateReportSpec.document')
+verify = schemas.fetch('VerifyReportSpec')
+update = schemas.fetch('UpdateReportSpec')
+read_document = schemas.fetch('ReportSpec.document')
+page = schemas.fetch('ReportPage')
+panel = schemas.fetch('ReportPanel')
+panel_config = schemas.fetch('ReportPanel.config')
+config = schemas.fetch('ReportConfig')
+convert_response = schemas.fetch('ConvertWorkbookToReportResponse')
+common_kinds = contract.dig('publishedVariants', 'commonElements').map { |entry| entry.fetch('kind') }
+workbook_only_kinds = contract.dig('publishedVariants', 'workbookOnlyElements').map { |entry| entry.fetch('kind') }
+control_types = contract.dig('publishedVariants', 'controls').map { |entry| entry.fetch('controlType') }
+
+assert_contract(failures, 'report spec endpoints declare JSON only') do
+  contract.fetch('mediaTypes').values.all? { |types| types == ['application/json'] }
+end
+assert_contract(failures, 'create requires name, folderId, and document') do
+  create.fetch('required') == %w[document folderId name]
+end
+assert_contract(failures, 'verify uses the create envelope') do
+  verify == create
+end
+assert_contract(failures, 'update accepts only a required document') do
+  update.fetch('required') == ['document'] && update.fetch('properties') == ['document']
+end
+assert_contract(failures, 'report document requires core collections and report kind') do
+  %w[elements kind pages schemaVersion].all? { |key| create_document.fetch('required').include?(key) } &&
+    contract.dig('enums', 'documentKind') == ['report']
+end
+assert_contract(failures, 'report document exposes config, layout, and panels') do
+  %w[config elements kind layout pages panels schemaVersion].all? do |key|
+    create_document.fetch('properties').include?(key)
+  end
+end
+assert_contract(failures, 'readback requires layout') do
+  read_document.fetch('required').include?('layout')
+end
+assert_contract(failures, 'page metadata has no nested elements') do
+  %w[id name].all? { |key| page.fetch('required').include?(key) } &&
+    !page.fetch('properties').include?('elements')
+end
+assert_contract(failures, 'report config is pixel page sizing') do
+  config.fetch('properties') == %w[margin pageHeight pageWidth]
+end
+assert_contract(failures, 'report panels are headers or footers with pixel config') do
+  %w[id type].all? { |key| panel.fetch('required').include?(key) } &&
+    %w[config id pages title type].all? { |key| panel.fetch('properties').include?(key) } &&
+    contract.dig('enums', 'panelType') == %w[footer header] &&
+    panel_config.fetch('properties') == %w[backgroundColor height]
+end
+assert_contract(failures, 'common report union publishes expected kinds') do
+  %w[table text control waterfall-chart progress input-table].all? { |kind| common_kinds.include?(kind) }
+end
+assert_contract(failures, 'workbook-only union remains separate') do
+  %w[chat container form navigation page-break repeated-container tabbed-container].all? do |kind|
+    workbook_only_kinds.include?(kind) && !common_kinds.include?(kind)
+  end
+end
+assert_contract(failures, 'synced control remains schema-published and policy-gated') do
+  control_types.include?('synced')
+end
+assert_contract(failures, 'report resource has no delete method') do
+  contract.dig('operations', 'reportResourceMethods') == ['get']
+end
+assert_contract(failures, 'conversion response requires warnings') do
+  %w[convertedReport sourceWorkbook warnings].all? do |key|
+    convert_response.fetch('required').include?(key)
+  end
+end
+
+if ARGV[0]
+  captured_at = contract.dig('source', 'capturedAt')
+  stdout, stderr, status = Open3.capture3(
+    {'CAPTURED_AT' => captured_at},
+    'ruby', EXTRACTOR, ARGV[0]
+  )
+  if status.success?
+    live_contract = JSON.parse(stdout)
+    failures << 'committed fixture differs from supplied OpenAPI' unless live_contract == contract
+  else
+    failures << "extractor failed: #{stderr.strip}"
+  end
+end
+
+if failures.empty?
+  puts "PASS: report OpenAPI contract (#{common_kinds.length} common elements, #{control_types.length} controls)"
+  exit 0
+end
+
+failures.each { |failure| warn "FAIL: #{failure}" }
+exit 1

--- a/sigma-reports/scripts/test-validator.rb
+++ b/sigma-reports/scripts/test-validator.rb
@@ -1,0 +1,132 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require 'json'
+require 'minitest/autorun'
+require_relative 'lib/report_spec_validator'
+
+class ReportSpecValidatorTest < Minitest::Test
+  def valid_payload
+    {
+      'name' => 'Statement',
+      'folderId' => 'folder-1',
+      'document' => {
+        'schemaVersion' => 1,
+        'kind' => 'report',
+        'config' => {'pageWidth' => 800, 'pageHeight' => 1_000, 'margin' => 40},
+        'elements' => [
+          {'id' => 'title', 'kind' => 'text', 'body' => 'Title'},
+          {'id' => 'footer-text', 'kind' => 'text', 'body' => 'Footer'}
+        ],
+        'pages' => [{'id' => 'page-1', 'name' => 'Page 1'}],
+        'panels' => [
+          {
+            'id' => 'footer', 'type' => 'footer', 'pages' => ['page-1'],
+            'config' => {'height' => 40}
+          }
+        ],
+        'layout' => <<~XML
+          <?xml version="1.0" encoding="utf-8"?>
+          <Page id="page-1">
+            <Element elementId="title" x="40" y="40" width="720" height="80"/>
+          </Page>
+          <Panel id="footer" type="footer">
+            <Element elementId="footer-text" x="40" y="8" width="720" height="24"/>
+          </Panel>
+        XML
+      }
+    }
+  end
+
+  def validate(payload = valid_payload, mode: :create)
+    ReportSpec::Validator.new(payload, mode: mode).validate
+  end
+
+  def test_accepts_valid_create_representation
+    result = validate
+    assert_empty result.errors
+    assert_empty result.warnings
+  end
+
+  def test_update_accepts_only_document_wrapper
+    payload = {'document' => valid_payload.fetch('document'), 'name' => 'Not allowed'}
+    result = validate(payload, mode: :update)
+    assert_includes result.errors, 'update body must contain exactly one property: document'
+  end
+
+  def test_rejects_unsupported_and_workbook_only_elements
+    payload = valid_payload
+    payload['document']['elements'][0]['kind'] = 'waterfall-chart'
+    payload['document']['elements'][1]['kind'] = 'container'
+    result = validate(payload)
+    assert result.errors.any? { |error| error.include?('waterfall-chart is unsupported') }
+    assert result.errors.any? { |error| error.include?('container is workbook-only') }
+  end
+
+  def test_warns_for_schema_only_element
+    payload = valid_payload
+    payload['document']['elements'][0]['kind'] = 'plugin'
+    result = validate(payload)
+    assert result.warnings.any? { |warning| warning.include?('plugin is schema-only') }
+  end
+
+  def test_rejects_grid_layout_duplicate_placement_and_bounds
+    payload = valid_payload
+    payload['document']['layout'] = <<~XML
+      <Page id="page-1">
+        <Element elementId="title" x="40" y="40" width="900" height="80" gridColumn="1 / 25"/>
+        <Element elementId="title" x="40" y="140" width="720" height="80"/>
+      </Page>
+      <Panel id="footer" type="footer">
+        <Element elementId="footer-text" x="40" y="8" width="720" height="40"/>
+      </Panel>
+    XML
+    result = validate(payload)
+    assert result.errors.any? { |error| error.include?('forbidden workbook attribute gridColumn') }
+    assert result.errors.any? { |error| error.include?('placed more than once') }
+    assert result.errors.any? { |error| error.include?('exceeds page width') }
+    assert result.errors.any? { |error| error.include?('exceeds panel height') }
+  end
+
+  def test_rejects_panel_assignment_and_layout_type_mismatch
+    payload = valid_payload
+    payload['document']['panels'][0]['pages'] = ['missing-page']
+    payload['document']['layout'] = payload['document']['layout'].sub('type="footer"', 'type="header"')
+    result = validate(payload)
+    assert result.errors.any? { |error| error.include?('references unknown page') }
+    assert result.errors.any? { |error| error.include?('does not match metadata type') }
+  end
+
+  def test_rejects_missing_and_undeclared_layout_objects
+    payload = valid_payload
+    payload['document']['layout'] = <<~XML
+      <Page id="other-page">
+        <Element elementId="unknown" x="0" y="0" width="10" height="10"/>
+      </Page>
+    XML
+    result = validate(payload)
+    assert result.errors.any? { |error| error.include?('undeclared page id') }
+    assert result.errors.any? { |error| error.include?('references undeclared elementId') }
+    assert result.errors.any? { |error| error.include?('page is missing from layout') }
+    assert result.errors.any? { |error| error.include?('panel is missing from layout') }
+  end
+
+  def test_rejects_invalid_xml_and_doctype
+    payload = valid_payload
+    payload['document']['layout'] = '<Page id="page-1"><Element></Page>'
+    assert validate(payload).errors.any? { |error| error.include?('invalid XML') }
+
+    payload['document']['layout'] = '<!DOCTYPE Page><Page id="page-1"/>'
+    assert validate(payload).errors.any? { |error| error.include?('DOCTYPE') }
+  end
+
+  def test_minimal_example_uses_current_text_element_shape
+    example_path = File.expand_path('../reference/specification/example-minimal.json', __dir__)
+    example = JSON.parse(File.read(example_path))
+    text_elements = example.dig('document', 'elements').select { |element| element['kind'] == 'text' }
+
+    assert text_elements.all? { |element| element.key?('body') }
+    refute text_elements.any? { |element| element.key?('text') || element.key?('name') }
+    assert ReportSpec::Validator.new(example, mode: :create).validate.valid?
+  end
+end

--- a/sigma-reports/scripts/validate-spec.rb
+++ b/sigma-reports/scripts/validate-spec.rb
@@ -1,0 +1,38 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require 'json'
+require 'optparse'
+require_relative 'lib/report_spec_validator'
+
+mode = :create
+parser = OptionParser.new do |options|
+  options.banner = 'Usage: ruby scripts/validate-spec.rb [--mode create|update] REPORT_SPEC.json'
+  options.on('--mode MODE', %w[create update], 'Envelope mode (default: create)') { |value| mode = value.to_sym }
+end
+
+parser.parse!
+path = ARGV.shift
+abort parser.to_s unless path && ARGV.empty?
+
+begin
+  payload = JSON.parse(File.read(path))
+rescue Errno::ENOENT
+  warn "ERROR: file not found: #{path}"
+  exit 2
+rescue JSON::ParserError => e
+  warn "ERROR: invalid JSON: #{e.message}"
+  exit 2
+end
+
+result = ReportSpec::Validator.new(payload, mode: mode).validate
+result.warnings.each { |warning| warn "WARN: #{warning}" }
+result.errors.each { |error| warn "ERROR: #{error}" }
+
+if result.valid?
+  puts "PASS: report #{mode} representation is locally valid (#{result.warnings.length} warning(s))"
+  exit 0
+end
+
+warn "FAIL: #{result.errors.length} error(s), #{result.warnings.length} warning(s)"
+exit 1

--- a/sigma-workbooks/reference/specification/schema.md
+++ b/sigma-workbooks/reference/specification/schema.md
@@ -197,8 +197,9 @@ Key differences from the workbook shapes documented in this skill:
   workbook equivalent.
 
 This skill targets `/v2/workbooks/spec`; report authoring is out of scope
-here beyond this pointer. To build a report, start from the `/v2/reports/*`
-OpenAPI paths directly rather than reusing workbook layout recipes.
+here. Load the sibling `sigma-reports` skill for the report lifecycle, pixel
+layout, support matrix, offline validator, and safe full-replacement workflow.
+Do not reuse workbook layout recipes for reports.
 
 ## Minimal working example
 


### PR DESCRIPTION
## Summary

- add a standalone `sigma-reports` skill for fixed-page report code representations, pixel layout, header/footer panels, safe CRUD, validation, and workbook conversion
- add a JSON report validator with envelope, ID, panel, bounds, XML layout, support-matrix, and workbook-only checks
- pin the current report OpenAPI contract and add offline regression tests
- generate Codex, Cursor, Cline, and Continue variants and wire the skill into README routing, installer guidance, and CI

## Validation

- `ruby sigma-reports/scripts/test-validator.rb` (9 tests, 24 assertions)
- `ruby sigma-reports/scripts/test-openapi-contract.rb /tmp/sigma-openapi.json` (exact match; 21 common elements, 16 controls)
- minimal example passes `validate-spec.rb`
- all existing credential-free repository tests pass
- live private-beta validation: `/verify`, create, GET readback, full-document PUT/version increment, and populated landscape PDF export all passed for a warehouse-backed executive report with KPIs, combo/bar charts, grouped presentation table, data bars, hidden dependency page, and header/footer panels

## Safety

- documents that report create is persistent and the current OpenAPI exposes no report DELETE endpoint
- gates schema-only and explicitly unsupported report features instead of treating the shared `CommonElement` union as blanket support