### PR TITLE
Add design-artifact workflow to sigma-workbooks skill

### DIFF
--- a/sigma-plugin-authoring/SKILL.md
+++ b/sigma-plugin-authoring/SKILL.md
@@ -42,6 +42,16 @@ OpenAPI" section). Only recreate as a plugin when the native surface is a
 confirmed miss — plugins carry real lifecycle cost (hosting, registration,
 re-registration on URL change) that a native chart doesn't.
 
+**A screenshot, mockup, or Claude design artifact is not itself a reason to
+build a plugin.** For a whole dashboard/app artifact, start with
+`sigma-workbooks/reference/workflows/from-image.md`. App shell, headers, rails,
+cards, buttons, controls, input tables, agents, and ordinary charts should be
+native workbook elements. Return here only for an individual bespoke data
+visualization whose marks/interactions have no native Sigma equivalent. Do not
+rebuild an entire artifact as one HTML plugin merely to get pixel control; that
+throws away native filtering, writeback, agent, accessibility, and workbook
+composition behavior.
+
 ## The recipe
 
 ### 1. Build the plugin

--- a/sigma-plugin-authoring/generated/cline/sigma-plugin-authoring.md
+++ b/sigma-plugin-authoring/generated/cline/sigma-plugin-authoring.md
@@ -32,6 +32,16 @@ OpenAPI" section). Only recreate as a plugin when the native surface is a
 confirmed miss — plugins carry real lifecycle cost (hosting, registration,
 re-registration on URL change) that a native chart doesn't.
 
+**A screenshot, mockup, or Claude design artifact is not itself a reason to
+build a plugin.** For a whole dashboard/app artifact, start with
+`sigma-workbooks/reference/workflows/from-image.md`. App shell, headers, rails,
+cards, buttons, controls, input tables, agents, and ordinary charts should be
+native workbook elements. Return here only for an individual bespoke data
+visualization whose marks/interactions have no native Sigma equivalent. Do not
+rebuild an entire artifact as one HTML plugin merely to get pixel control; that
+throws away native filtering, writeback, agent, accessibility, and workbook
+composition behavior.
+
 ## The recipe
 
 ### 1. Build the plugin

--- a/sigma-plugin-authoring/generated/codex/AGENTS.md
+++ b/sigma-plugin-authoring/generated/codex/AGENTS.md
@@ -32,6 +32,16 @@ OpenAPI" section). Only recreate as a plugin when the native surface is a
 confirmed miss — plugins carry real lifecycle cost (hosting, registration,
 re-registration on URL change) that a native chart doesn't.
 
+**A screenshot, mockup, or Claude design artifact is not itself a reason to
+build a plugin.** For a whole dashboard/app artifact, start with
+`sigma-workbooks/reference/workflows/from-image.md`. App shell, headers, rails,
+cards, buttons, controls, input tables, agents, and ordinary charts should be
+native workbook elements. Return here only for an individual bespoke data
+visualization whose marks/interactions have no native Sigma equivalent. Do not
+rebuild an entire artifact as one HTML plugin merely to get pixel control; that
+throws away native filtering, writeback, agent, accessibility, and workbook
+composition behavior.
+
 ## The recipe
 
 ### 1. Build the plugin

--- a/sigma-plugin-authoring/generated/continue/sigma-plugin-authoring.md
+++ b/sigma-plugin-authoring/generated/continue/sigma-plugin-authoring.md
@@ -32,6 +32,16 @@ OpenAPI" section). Only recreate as a plugin when the native surface is a
 confirmed miss — plugins carry real lifecycle cost (hosting, registration,
 re-registration on URL change) that a native chart doesn't.
 
+**A screenshot, mockup, or Claude design artifact is not itself a reason to
+build a plugin.** For a whole dashboard/app artifact, start with
+`sigma-workbooks/reference/workflows/from-image.md`. App shell, headers, rails,
+cards, buttons, controls, input tables, agents, and ordinary charts should be
+native workbook elements. Return here only for an individual bespoke data
+visualization whose marks/interactions have no native Sigma equivalent. Do not
+rebuild an entire artifact as one HTML plugin merely to get pixel control; that
+throws away native filtering, writeback, agent, accessibility, and workbook
+composition behavior.
+
 ## The recipe
 
 ### 1. Build the plugin

--- a/sigma-plugin-authoring/generated/cursor/rules/sigma-plugin-authoring.mdc
+++ b/sigma-plugin-authoring/generated/cursor/rules/sigma-plugin-authoring.mdc
@@ -37,6 +37,16 @@ OpenAPI" section). Only recreate as a plugin when the native surface is a
 confirmed miss — plugins carry real lifecycle cost (hosting, registration,
 re-registration on URL change) that a native chart doesn't.
 
+**A screenshot, mockup, or Claude design artifact is not itself a reason to
+build a plugin.** For a whole dashboard/app artifact, start with
+`sigma-workbooks/reference/workflows/from-image.md`. App shell, headers, rails,
+cards, buttons, controls, input tables, agents, and ordinary charts should be
+native workbook elements. Return here only for an individual bespoke data
+visualization whose marks/interactions have no native Sigma equivalent. Do not
+rebuild an entire artifact as one HTML plugin merely to get pixel control; that
+throws away native filtering, writeback, agent, accessibility, and workbook
+composition behavior.
+
 ## The recipe
 
 ### 1. Build the plugin

--- a/sigma-workbooks/SKILL.md
+++ b/sigma-workbooks/SKILL.md
@@ -6,7 +6,8 @@ description: >-
   tables, formulas, and sources. The Sigma OpenAPI is the source of truth for
   every shape and field; this skill adds navigation, style guidance, and
   proven recipes for effective dashboards. Use when the user wants to
-  construct a dashboard from a spec, add or modify pages / elements /
+  construct a dashboard from a spec, reproduce a screenshot/mockup/Claude
+  design artifact as a native Sigma app, add or modify pages / elements /
   controls / formulas, validate a spec before submission, or work through
   the workbook spec lifecycle programmatically. Requires an SIGMA_API_TOKEN
   — obtain via the sigma-api skill first.
@@ -119,7 +120,13 @@ HOME_FOLDER_ID=$(curl -s -H "Authorization: Bearer $SIGMA_API_TOKEN" \
   "$SIGMA_BASE_URL/v2/members/$USER_ID" | jq -r '.homeFolderId')
 ```
 
-If the user provided a **target image** (a screenshot, mockup, or PDF of a dashboard they want reproduced), pause here and load `reference/workflows/from-image.md` — it adds explicit observation, description, and validation steps that have to happen *before* normal data discovery. The standard workflow alone tends to produce workbooks with the right vibe but the wrong shape when the input is visual.
+If the user provided a **target image or design artifact** (a screenshot,
+mockup, PDF, or Claude-generated app design they want reproduced), pause here
+and load `reference/workflows/from-image.md` — it adds mandatory whole-screen
+inventory, behavior classification, design-manifest, native-first routing,
+render-diff, and iteration gates that happen *before and alongside* normal data
+discovery. The standard workflow alone tends to reproduce the data visuals
+while missing the app shell and behavior.
 
 ### Step 1 — Find a reference workbook to study
 
@@ -303,7 +310,7 @@ The reference is feature-sliced — don't read every file up-front. The index ha
 | `reference/workflows/actions.md` | Buttons, write-back, and **all twelve** action effects — insert/update/delete-rows, clear-control, set-control-value, open/close-overlay (modal **and** drawer), open-url, open-document (incl. passing `targetControls` into another workbook), navigate, select-tab, refresh-element — plus the append-only-log pattern and the masked-error catalog. Load when the user wants a button, a "log/save/submit" action, tab/page navigation, a deep link, or a write-back workflow. |
 | `reference/workflows/crud.md` | POST / GET / PUT against the workbook spec endpoints. Load when creating, retrieving, or updating a workbook. |
 | `reference/workflows/validate.md` | Pre-submit + post-create validation. Load before any POST or PUT. |
-| `reference/workflows/from-image.md` | The user supplied a target image (screenshot, mockup, BI-tool export) to reproduce. Load *before* discovery — it adds explicit observation and validation steps. |
+| `reference/workflows/from-image.md` | The user supplied a target image or Claude design artifact to reproduce. Load *before* discovery — it inventories the entire app shell and behavior, routes native Sigma vs plugin/UI-only surfaces, requires a local design manifest, and enforces first-render → diff → final-render acceptance. |
 | `reference/workflows/element-rep.md` | **Large or multi-page workbooks, parallel element work, or iterative refinement.** `scripts/wb-rep.rb` explodes the spec into one small file per element (pull/status/push/render) so edits never drag the whole spec through context — element-level semantics over the whole-spec API, plus PNG renders to inspect what you built. |
 
 ## Quick Formula Rules

--- a/sigma-workbooks/generated/cline/sigma-workbooks.md
+++ b/sigma-workbooks/generated/cline/sigma-workbooks.md
@@ -3,7 +3,7 @@ Auto-generated from SKILL.md by ~/sigma-skills/scripts/sync-targets.rb.
 Do not edit by hand — edit SKILL.md and re-run the script.
 -->
 
-> Build, edit, and iterate on Sigma workbook specs — the JSON definition you POST to /v2/workbooks/spec, covering pages, layout, controls, charts, KPIs, tables, formulas, and sources. The Sigma OpenAPI is the source of truth for every shape and field; this skill adds navigation, style guidance, and proven recipes for effective dashboards. Use when the user wants to construct a dashboard from a spec, add or modify pages / elements / controls / formulas, validate a spec before submission, or work through the workbook spec lifecycle programmatically. Requires an SIGMA_API_TOKEN — obtain via the sigma-api skill first.
+> Build, edit, and iterate on Sigma workbook specs — the JSON definition you POST to /v2/workbooks/spec, covering pages, layout, controls, charts, KPIs, tables, formulas, and sources. The Sigma OpenAPI is the source of truth for every shape and field; this skill adds navigation, style guidance, and proven recipes for effective dashboards. Use when the user wants to construct a dashboard from a spec, reproduce a screenshot/mockup/Claude design artifact as a native Sigma app, add or modify pages / elements / controls / formulas, validate a spec before submission, or work through the workbook spec lifecycle programmatically. Requires an SIGMA_API_TOKEN — obtain via the sigma-api skill first.
 
 # Sigma Workbooks (Spec via REST API)
 
@@ -112,7 +112,13 @@ HOME_FOLDER_ID=$(curl -s -H "Authorization: Bearer $SIGMA_API_TOKEN" \
   "$SIGMA_BASE_URL/v2/members/$USER_ID" | jq -r '.homeFolderId')
 ```
 
-If the user provided a **target image** (a screenshot, mockup, or PDF of a dashboard they want reproduced), pause here and load `reference/workflows/from-image.md` — it adds explicit observation, description, and validation steps that have to happen *before* normal data discovery. The standard workflow alone tends to produce workbooks with the right vibe but the wrong shape when the input is visual.
+If the user provided a **target image or design artifact** (a screenshot,
+mockup, PDF, or Claude-generated app design they want reproduced), pause here
+and load `reference/workflows/from-image.md` — it adds mandatory whole-screen
+inventory, behavior classification, design-manifest, native-first routing,
+render-diff, and iteration gates that happen *before and alongside* normal data
+discovery. The standard workflow alone tends to reproduce the data visuals
+while missing the app shell and behavior.
 
 ### Step 1 — Find a reference workbook to study
 
@@ -296,7 +302,7 @@ The reference is feature-sliced — don't read every file up-front. The index ha
 | `reference/workflows/actions.md` | Buttons, write-back, and **all twelve** action effects — insert/update/delete-rows, clear-control, set-control-value, open/close-overlay (modal **and** drawer), open-url, open-document (incl. passing `targetControls` into another workbook), navigate, select-tab, refresh-element — plus the append-only-log pattern and the masked-error catalog. Load when the user wants a button, a "log/save/submit" action, tab/page navigation, a deep link, or a write-back workflow. |
 | `reference/workflows/crud.md` | POST / GET / PUT against the workbook spec endpoints. Load when creating, retrieving, or updating a workbook. |
 | `reference/workflows/validate.md` | Pre-submit + post-create validation. Load before any POST or PUT. |
-| `reference/workflows/from-image.md` | The user supplied a target image (screenshot, mockup, BI-tool export) to reproduce. Load *before* discovery — it adds explicit observation and validation steps. |
+| `reference/workflows/from-image.md` | The user supplied a target image or Claude design artifact to reproduce. Load *before* discovery — it inventories the entire app shell and behavior, routes native Sigma vs plugin/UI-only surfaces, requires a local design manifest, and enforces first-render → diff → final-render acceptance. |
 | `reference/workflows/element-rep.md` | **Large or multi-page workbooks, parallel element work, or iterative refinement.** `scripts/wb-rep.rb` explodes the spec into one small file per element (pull/status/push/render) so edits never drag the whole spec through context — element-level semantics over the whole-spec API, plus PNG renders to inspect what you built. |
 
 ## Quick Formula Rules

--- a/sigma-workbooks/generated/codex/AGENTS.md
+++ b/sigma-workbooks/generated/codex/AGENTS.md
@@ -3,7 +3,7 @@ Auto-generated from SKILL.md by ~/sigma-skills/scripts/sync-targets.rb.
 Do not edit by hand — edit SKILL.md and re-run the script.
 -->
 
-> Build, edit, and iterate on Sigma workbook specs — the JSON definition you POST to /v2/workbooks/spec, covering pages, layout, controls, charts, KPIs, tables, formulas, and sources. The Sigma OpenAPI is the source of truth for every shape and field; this skill adds navigation, style guidance, and proven recipes for effective dashboards. Use when the user wants to construct a dashboard from a spec, add or modify pages / elements / controls / formulas, validate a spec before submission, or work through the workbook spec lifecycle programmatically. Requires an SIGMA_API_TOKEN — obtain via the sigma-api skill first.
+> Build, edit, and iterate on Sigma workbook specs — the JSON definition you POST to /v2/workbooks/spec, covering pages, layout, controls, charts, KPIs, tables, formulas, and sources. The Sigma OpenAPI is the source of truth for every shape and field; this skill adds navigation, style guidance, and proven recipes for effective dashboards. Use when the user wants to construct a dashboard from a spec, reproduce a screenshot/mockup/Claude design artifact as a native Sigma app, add or modify pages / elements / controls / formulas, validate a spec before submission, or work through the workbook spec lifecycle programmatically. Requires an SIGMA_API_TOKEN — obtain via the sigma-api skill first.
 
 # Sigma Workbooks (Spec via REST API)
 
@@ -112,7 +112,13 @@ HOME_FOLDER_ID=$(curl -s -H "Authorization: Bearer $SIGMA_API_TOKEN" \
   "$SIGMA_BASE_URL/v2/members/$USER_ID" | jq -r '.homeFolderId')
 ```
 
-If the user provided a **target image** (a screenshot, mockup, or PDF of a dashboard they want reproduced), pause here and load `reference/workflows/from-image.md` — it adds explicit observation, description, and validation steps that have to happen *before* normal data discovery. The standard workflow alone tends to produce workbooks with the right vibe but the wrong shape when the input is visual.
+If the user provided a **target image or design artifact** (a screenshot,
+mockup, PDF, or Claude-generated app design they want reproduced), pause here
+and load `reference/workflows/from-image.md` — it adds mandatory whole-screen
+inventory, behavior classification, design-manifest, native-first routing,
+render-diff, and iteration gates that happen *before and alongside* normal data
+discovery. The standard workflow alone tends to reproduce the data visuals
+while missing the app shell and behavior.
 
 ### Step 1 — Find a reference workbook to study
 
@@ -296,7 +302,7 @@ The reference is feature-sliced — don't read every file up-front. The index ha
 | `reference/workflows/actions.md` | Buttons, write-back, and **all twelve** action effects — insert/update/delete-rows, clear-control, set-control-value, open/close-overlay (modal **and** drawer), open-url, open-document (incl. passing `targetControls` into another workbook), navigate, select-tab, refresh-element — plus the append-only-log pattern and the masked-error catalog. Load when the user wants a button, a "log/save/submit" action, tab/page navigation, a deep link, or a write-back workflow. |
 | `reference/workflows/crud.md` | POST / GET / PUT against the workbook spec endpoints. Load when creating, retrieving, or updating a workbook. |
 | `reference/workflows/validate.md` | Pre-submit + post-create validation. Load before any POST or PUT. |
-| `reference/workflows/from-image.md` | The user supplied a target image (screenshot, mockup, BI-tool export) to reproduce. Load *before* discovery — it adds explicit observation and validation steps. |
+| `reference/workflows/from-image.md` | The user supplied a target image or Claude design artifact to reproduce. Load *before* discovery — it inventories the entire app shell and behavior, routes native Sigma vs plugin/UI-only surfaces, requires a local design manifest, and enforces first-render → diff → final-render acceptance. |
 | `reference/workflows/element-rep.md` | **Large or multi-page workbooks, parallel element work, or iterative refinement.** `scripts/wb-rep.rb` explodes the spec into one small file per element (pull/status/push/render) so edits never drag the whole spec through context — element-level semantics over the whole-spec API, plus PNG renders to inspect what you built. |
 
 ## Quick Formula Rules

--- a/sigma-workbooks/generated/continue/sigma-workbooks.md
+++ b/sigma-workbooks/generated/continue/sigma-workbooks.md
@@ -3,7 +3,7 @@ Auto-generated from SKILL.md by ~/sigma-skills/scripts/sync-targets.rb.
 Do not edit by hand — edit SKILL.md and re-run the script.
 -->
 
-> Build, edit, and iterate on Sigma workbook specs — the JSON definition you POST to /v2/workbooks/spec, covering pages, layout, controls, charts, KPIs, tables, formulas, and sources. The Sigma OpenAPI is the source of truth for every shape and field; this skill adds navigation, style guidance, and proven recipes for effective dashboards. Use when the user wants to construct a dashboard from a spec, add or modify pages / elements / controls / formulas, validate a spec before submission, or work through the workbook spec lifecycle programmatically. Requires an SIGMA_API_TOKEN — obtain via the sigma-api skill first.
+> Build, edit, and iterate on Sigma workbook specs — the JSON definition you POST to /v2/workbooks/spec, covering pages, layout, controls, charts, KPIs, tables, formulas, and sources. The Sigma OpenAPI is the source of truth for every shape and field; this skill adds navigation, style guidance, and proven recipes for effective dashboards. Use when the user wants to construct a dashboard from a spec, reproduce a screenshot/mockup/Claude design artifact as a native Sigma app, add or modify pages / elements / controls / formulas, validate a spec before submission, or work through the workbook spec lifecycle programmatically. Requires an SIGMA_API_TOKEN — obtain via the sigma-api skill first.
 
 # Sigma Workbooks (Spec via REST API)
 
@@ -112,7 +112,13 @@ HOME_FOLDER_ID=$(curl -s -H "Authorization: Bearer $SIGMA_API_TOKEN" \
   "$SIGMA_BASE_URL/v2/members/$USER_ID" | jq -r '.homeFolderId')
 ```
 
-If the user provided a **target image** (a screenshot, mockup, or PDF of a dashboard they want reproduced), pause here and load `reference/workflows/from-image.md` — it adds explicit observation, description, and validation steps that have to happen *before* normal data discovery. The standard workflow alone tends to produce workbooks with the right vibe but the wrong shape when the input is visual.
+If the user provided a **target image or design artifact** (a screenshot,
+mockup, PDF, or Claude-generated app design they want reproduced), pause here
+and load `reference/workflows/from-image.md` — it adds mandatory whole-screen
+inventory, behavior classification, design-manifest, native-first routing,
+render-diff, and iteration gates that happen *before and alongside* normal data
+discovery. The standard workflow alone tends to reproduce the data visuals
+while missing the app shell and behavior.
 
 ### Step 1 — Find a reference workbook to study
 
@@ -296,7 +302,7 @@ The reference is feature-sliced — don't read every file up-front. The index ha
 | `reference/workflows/actions.md` | Buttons, write-back, and **all twelve** action effects — insert/update/delete-rows, clear-control, set-control-value, open/close-overlay (modal **and** drawer), open-url, open-document (incl. passing `targetControls` into another workbook), navigate, select-tab, refresh-element — plus the append-only-log pattern and the masked-error catalog. Load when the user wants a button, a "log/save/submit" action, tab/page navigation, a deep link, or a write-back workflow. |
 | `reference/workflows/crud.md` | POST / GET / PUT against the workbook spec endpoints. Load when creating, retrieving, or updating a workbook. |
 | `reference/workflows/validate.md` | Pre-submit + post-create validation. Load before any POST or PUT. |
-| `reference/workflows/from-image.md` | The user supplied a target image (screenshot, mockup, BI-tool export) to reproduce. Load *before* discovery — it adds explicit observation and validation steps. |
+| `reference/workflows/from-image.md` | The user supplied a target image or Claude design artifact to reproduce. Load *before* discovery — it inventories the entire app shell and behavior, routes native Sigma vs plugin/UI-only surfaces, requires a local design manifest, and enforces first-render → diff → final-render acceptance. |
 | `reference/workflows/element-rep.md` | **Large or multi-page workbooks, parallel element work, or iterative refinement.** `scripts/wb-rep.rb` explodes the spec into one small file per element (pull/status/push/render) so edits never drag the whole spec through context — element-level semantics over the whole-spec API, plus PNG renders to inspect what you built. |
 
 ## Quick Formula Rules

--- a/sigma-workbooks/generated/cursor/rules/sigma-workbooks.mdc
+++ b/sigma-workbooks/generated/cursor/rules/sigma-workbooks.mdc
@@ -1,5 +1,5 @@
 ---
-description: "Build, edit, and iterate on Sigma workbook specs — the JSON definition you POST to /v2/workbooks/spec, covering pages, layout, controls, charts, KPIs, tables, formulas, and sources. The Sigma OpenAPI is the source of truth for every shape and field; this skill adds navigation, style guidance, and proven recipes for effective dashboards. Use when the user wants to construct a dashboard from a spec, add or modify pages / elements / controls / formulas, validate a spec before submission, or work through the workbook spec lifecycle programmatically. Requires an SIGMA_API_TOKEN — obtain via the sigma-api skill first."
+description: "Build, edit, and iterate on Sigma workbook specs — the JSON definition you POST to /v2/workbooks/spec, covering pages, layout, controls, charts, KPIs, tables, formulas, and sources. The Sigma OpenAPI is the source of truth for every shape and field; this skill adds navigation, style guidance, and proven recipes for effective dashboards. Use when the user wants to construct a dashboard from a spec, reproduce a screenshot/mockup/Claude design artifact as a native Sigma app, add or modify pages / elements / controls / formulas, validate a spec before submission, or work through the workbook spec lifecycle programmatically. Requires an SIGMA_API_TOKEN — obtain via the sigma-api skill first."
 alwaysApply: false
 ---
 
@@ -8,7 +8,7 @@ Auto-generated from SKILL.md by ~/sigma-skills/scripts/sync-targets.rb.
 Do not edit by hand — edit SKILL.md and re-run the script.
 -->
 
-> Build, edit, and iterate on Sigma workbook specs — the JSON definition you POST to /v2/workbooks/spec, covering pages, layout, controls, charts, KPIs, tables, formulas, and sources. The Sigma OpenAPI is the source of truth for every shape and field; this skill adds navigation, style guidance, and proven recipes for effective dashboards. Use when the user wants to construct a dashboard from a spec, add or modify pages / elements / controls / formulas, validate a spec before submission, or work through the workbook spec lifecycle programmatically. Requires an SIGMA_API_TOKEN — obtain via the sigma-api skill first.
+> Build, edit, and iterate on Sigma workbook specs — the JSON definition you POST to /v2/workbooks/spec, covering pages, layout, controls, charts, KPIs, tables, formulas, and sources. The Sigma OpenAPI is the source of truth for every shape and field; this skill adds navigation, style guidance, and proven recipes for effective dashboards. Use when the user wants to construct a dashboard from a spec, reproduce a screenshot/mockup/Claude design artifact as a native Sigma app, add or modify pages / elements / controls / formulas, validate a spec before submission, or work through the workbook spec lifecycle programmatically. Requires an SIGMA_API_TOKEN — obtain via the sigma-api skill first.
 
 # Sigma Workbooks (Spec via REST API)
 
@@ -117,7 +117,13 @@ HOME_FOLDER_ID=$(curl -s -H "Authorization: Bearer $SIGMA_API_TOKEN" \
   "$SIGMA_BASE_URL/v2/members/$USER_ID" | jq -r '.homeFolderId')
 ```
 
-If the user provided a **target image** (a screenshot, mockup, or PDF of a dashboard they want reproduced), pause here and load `reference/workflows/from-image.md` — it adds explicit observation, description, and validation steps that have to happen *before* normal data discovery. The standard workflow alone tends to produce workbooks with the right vibe but the wrong shape when the input is visual.
+If the user provided a **target image or design artifact** (a screenshot,
+mockup, PDF, or Claude-generated app design they want reproduced), pause here
+and load `reference/workflows/from-image.md` — it adds mandatory whole-screen
+inventory, behavior classification, design-manifest, native-first routing,
+render-diff, and iteration gates that happen *before and alongside* normal data
+discovery. The standard workflow alone tends to reproduce the data visuals
+while missing the app shell and behavior.
 
 ### Step 1 — Find a reference workbook to study
 
@@ -301,7 +307,7 @@ The reference is feature-sliced — don't read every file up-front. The index ha
 | `reference/workflows/actions.md` | Buttons, write-back, and **all twelve** action effects — insert/update/delete-rows, clear-control, set-control-value, open/close-overlay (modal **and** drawer), open-url, open-document (incl. passing `targetControls` into another workbook), navigate, select-tab, refresh-element — plus the append-only-log pattern and the masked-error catalog. Load when the user wants a button, a "log/save/submit" action, tab/page navigation, a deep link, or a write-back workflow. |
 | `reference/workflows/crud.md` | POST / GET / PUT against the workbook spec endpoints. Load when creating, retrieving, or updating a workbook. |
 | `reference/workflows/validate.md` | Pre-submit + post-create validation. Load before any POST or PUT. |
-| `reference/workflows/from-image.md` | The user supplied a target image (screenshot, mockup, BI-tool export) to reproduce. Load *before* discovery — it adds explicit observation and validation steps. |
+| `reference/workflows/from-image.md` | The user supplied a target image or Claude design artifact to reproduce. Load *before* discovery — it inventories the entire app shell and behavior, routes native Sigma vs plugin/UI-only surfaces, requires a local design manifest, and enforces first-render → diff → final-render acceptance. |
 | `reference/workflows/element-rep.md` | **Large or multi-page workbooks, parallel element work, or iterative refinement.** `scripts/wb-rep.rb` explodes the spec into one small file per element (pull/status/push/render) so edits never drag the whole spec through context — element-level semantics over the whole-spec API, plus PNG renders to inspect what you built. |
 
 ## Quick Formula Rules

--- a/sigma-workbooks/reference/workflows/from-image.md
+++ b/sigma-workbooks/reference/workflows/from-image.md
@@ -1,12 +1,20 @@
-# Building from a target image
+# Building from a target image or design artifact
 
-Use this workflow when the user has provided a screenshot, mockup, or PDF of a dashboard they want reproduced in Sigma — including migrations from Tableau, Looker, PowerBI, or any other BI tool.
+Use this workflow when the user has provided a screenshot, mockup, PDF, or
+Claude-generated design artifact they want reproduced in Sigma — including
+migrations from Tableau, Looker, PowerBI, or any other BI tool.
 
 The general spec workflow ([the rest of SKILL.md](../../SKILL.md)) still applies. This document covers **only the additional steps** that come *before* and *alongside* normal data discovery and spec drafting.
 
 ## Why this workflow exists
 
-When the user supplies an image, the agent's first job isn't to call the API — it's to *interpret*. A workbook spec is a precise object; an image is not. Going straight from "I see a picture" to "POST this YAML" almost always produces a workbook that has the right vibe but wrong shape, wrong axes, or wrong groupings — because the agent never committed to an interpretation explicit enough to debug.
+When the user supplies an image, the agent's first job isn't to call the API —
+it's to *interpret*. A workbook spec is a precise object; an image is not.
+Going straight from "I see a picture" to "POST this YAML" almost always
+produces a workbook that has the right vibe but wrong shape, wrong axes, wrong
+groupings, or none of the product shell and behavior visible in the artifact.
+The common bad first pass recreates the charts and ignores the header, rail,
+tabs, buttons, input semantics, agent panel, spacing, and visual hierarchy.
 
 The workflow below makes the interpretation step explicit and auditable.
 
@@ -20,11 +28,35 @@ If the user provided a target image, treat the workbook-creation task as a two-i
 
 ### Step 0b — Describe what you see, in Sigma terms
 
-After reading the image, **write out an inventory** of what you saw. Do this as part of your reply / planning, before drafting any spec. The inventory has three sections:
+After reading the image, **write out an inventory** of what you saw. Do this as
+part of your reply / planning, before drafting any spec. The inventory has five
+sections:
 
-1. **Element count and kinds.** For each visible element, name the Sigma `kind` it most closely maps to (`kpi-chart`, `bar-chart`, `line-chart`, `donut-chart`, `table`, `text`, `image`, `geography-map`, etc.). If you're not sure, describe the visual marks (bars of equal width? a line? a sector?) and state your best guess.
-2. **Per-element details.** For each element: what's on the x-axis, y-axis, color/series channel? Is it grouped or stacked? Are there filters or controls visible?
-3. **Layout.** Grid density (how many elements per row, how many rows), any container groupings (logos / headers / sections), any visible whitespace.
+1. **Workbook boundaries.** Decide whether each screen is a page or a separate
+   workbook. Respect the user's explicit split. When artifacts show distinct
+   apps (for example, an analytics assistant and a writeback planner), do not
+   collapse them into one workbook merely because they share branding.
+2. **App shell and chrome.** Inventory the logo/wordmark, left rail, breadcrumb,
+   title/subtitle, header actions, tabs, cards, dividers, canvas background,
+   and any footer/status strip. Record alignment, grouping, spacing, radii,
+   borders, and active states. These are deliverable elements, not decoration
+   to add after the data visuals.
+3. **Data elements and kinds.** For each visible element, name the Sigma `kind`
+   it most closely maps to (`kpi-chart`, `bar-chart`, `line-chart`,
+   `donut-chart`, `table`, `input-table`, `chat`, `control`, etc.). If unsure,
+   describe the marks and state the best guess. **A grid with editable cells,
+   Save/Cancel state, pencil icons, or unsaved-edit text is an `input-table`,
+   not a read-only `table`. A conversation rail is `document.agents[]` plus a
+   `chat` element, not a text box.**
+4. **Per-element details.** For each data element: what's on the x-axis, y-axis,
+   color/series channel? Is it grouped or stacked? Which columns are editable,
+   computed, or key/context columns? Which controls are visible and what are
+   their defaults?
+5. **Behavior.** For every button, tab, control, editable cell, and agent, write
+   what the user expects it to do. Classify the implementation as
+   `native-spec`, `ui-only`, `plugin`, or `unavailable`. Never silently turn an
+   interactive-looking surface into a decorative no-op. Ask for approval before
+   shipping a decorative stand-in.
 
 The goal is to produce an explicit, debuggable interpretation. If you build a workbook and the visual judge says "this looks different," you can point at the inventory and see exactly where you went wrong.
 
@@ -32,8 +64,36 @@ The goal is to produce an explicit, debuggable interpretation. If you build a wo
 
 Before drafting, read your own inventory and check it against the image again. Two questions:
 
-- **Are there elements you didn't list?** Look at the corners and edges; small KPIs and titles get missed.
+- **Are there elements you didn't list?** Look at the corners and edges; logos,
+  breadcrumbs, small KPIs, action buttons, status text, and editable-column
+  affordances get missed.
 - **Is anything ambiguous?** "I see a bar chart with bars of different colors — that could be `color.by: category` on a single grouping, or it could be a stacked bar with one stack." When in doubt, prefer the simpler interpretation and note that you're guessing — don't quietly commit.
+- **Did you classify behavior, not just appearance?** A screenshot cannot prove
+  whether a button publishes, navigates, opens settings, or is decorative.
+  Resolve this before implementing it.
+
+### Step 0c.1 — Record a design manifest
+
+For a multi-screen artifact or any app-like surface, create a local JSON
+manifest before drafting:
+
+```bash
+ruby scripts/design-artifact.rb init /tmp/design-manifest.json
+# fill the manifest from the artifact inventory
+ruby scripts/design-artifact.rb check /tmp/design-manifest.json
+```
+
+The manifest forces each visible surface to have a Sigma implementation,
+acceptance criterion, and behavior classification. Use `--strict` only at the
+end; it fails while obvious visual mismatches, unverified interactions, or
+unaccepted tradeoffs remain:
+
+```bash
+ruby scripts/design-artifact.rb check --strict /tmp/design-manifest.json
+```
+
+The manifest is local run state. Do not commit customer screenshots, logos,
+organization identifiers, workbook IDs, or warehouse paths into this skill.
 
 ### Step 0d — Now proceed with normal discovery
 
@@ -73,12 +133,122 @@ Before drafting, for each measure (the y-axis aggregate) you picked:
 
 After creation, the produced chart's y-axis range should look approximately like the target's. A "0-100%" axis when the target shows "0-4%" is a calculation error, not a formatting one.
 
-### Step 0e — Draft and verify
+### Step 0d.3 — Extract a small design system
 
-From here, follow the standard workflow (Steps 5–8). One additional verification step before declaring done:
+Do this before writing layout XML:
 
-- **Export the workbook to PDF** via `POST /v2/workbooks/{id}/export` with `{"format": {"type": "pdf", "layout": "landscape"}}`, download via `GET /v2/query/{queryId}/download`, then compare the result side-by-side with the target image.
-- Diff at the inventory level: do the chart kinds match? Are the axes assigned correctly? Does the layout density match? If not, iterate via PUT before declaring done.
+- **Palette:** canvas, card, border, primary ink, muted text, accent, semantic
+  colors. Sample or estimate hex values from the artifact; do not substitute
+  the default dark hero recipe when the target is a light app shell.
+- **Typography:** wordmark, page title, subtitle, section title, control label,
+  and data-cell scale.
+- **Geometry:** rail width, header height, number of grid columns, card gaps,
+  radii, borders, and content density.
+- **Alignment groups:** which items visually belong together. Header action
+  buttons that sit shoulder-to-shoulder must occupy adjacent tight cells; two
+  right-aligned buttons in wide independent cells will drift apart.
+
+Apply these consistently across every workbook generated from the artifact.
+
+### Step 0d.4 — Route to native Sigma first
+
+Use native workbook elements for the whole screen whenever possible:
+
+- app chrome → `container`, `text`, `image`, `divider`, `button`, `navigation`;
+- editable grid → `input-table`;
+- assistant rail → `document.agents[]` + `chat`;
+- cross-workbook tabs → button actions with `open-document`;
+- data visuals → native chart/table/KPI kinds.
+
+Load `sigma-plugin-authoring` only for a **bespoke data visualization with no
+native Sigma equivalent**. A screenshot that merely looks polished is not a
+reason to build a custom plugin.
+
+### Step 0d.5 — Treat assets honestly
+
+For a visible logo, prefer an existing public HTTPS asset or a user-provided
+asset URL. If none is available:
+
+1. ask whether a close primitive/icon approximation is acceptable;
+2. label the approximation as a tradeoff in the manifest;
+3. do not claim a monogram is the source logo.
+
+Inline SVG data URIs may pass `/v2/workbooks/spec/verify` but still trigger a
+Cloudflare WAF challenge on the actual `POST`/`PUT`. Only a successful write,
+readback, and render proves the asset path works.
+
+### Step 0e — Draft the native structure first
+
+The first draft must include every structural surface from the inventory:
+workbook split, shell, header, navigation/tabs, controls, data elements, input
+tables, agents, and explicit layout. Do not defer the app shell to a later
+"polish" pass; that produces a valid but visibly wrong first result and makes
+the user push for the design they already supplied.
+
+For input-table artifacts:
+
+- use a real `input-table` on the first draft;
+- establish deterministic linked keys before creation (keys are immutable);
+- include the write connection/writeback schema as required by the live schema;
+- preserve editable vs computed columns;
+- verify defaults and row cardinality by export;
+- record the UI-only published-data-entry and publish gates explicitly.
+
+For agent artifacts, use a real agent/chat when the org feature is available.
+Do not substitute static explanatory text and call it an agent.
+
+### Step 0f — Render, compare, and iterate
+
+From here, follow the standard workflow (Steps 5–8). A successful spec verify,
+POST, readback, or compile check is **not visual acceptance**.
+
+1. Render every visible page to PNG at approximately the target artifact's
+   viewport/aspect ratio. PDF is useful for print artifacts; use PNG for app
+   screenshots because responsive layout is the thing being judged.
+2. Read the rendered PNG itself and compare it side-by-side with the target.
+3. Diff at four levels:
+   - **structure:** workbook/page split, shell, header, rail, cards, agent rail;
+   - **geometry:** width ratios, heights, alignment, gaps, density;
+   - **semantics:** chart kinds, axes, input/edit behavior, agent capability;
+   - **finish:** colors, borders, typography, active states, clipping.
+4. Put every visible mismatch into `visual.mismatches` in the manifest.
+5. Iterate with `PUT`, re-render, and remove mismatches only when the new render
+   proves they are fixed.
+
+**Do not stop at the first render.** Artifact-driven work requires at least a
+first render and a final render. The final render must have no unresolved
+`high`-severity mismatch. An accepted limitation (for example, formula columns
+always rendering last) belongs in `acceptedTradeoffs`, not silently ignored.
+
+### Step 0g — Exercise behavior
+
+For each control and interactive surface:
+
+- confirm stored defaults on readback (single-select controls may store a
+  scalar `value`, while multi-select controls use `values`);
+- export with at least two control states and prove both what changes and what
+  must not change;
+- for input tables, edit a real row, save, re-query, and verify computed values;
+- for agents, ask a question with a known answer and verify the response;
+- for buttons/tabs, exercise navigation/action behavior where authentication
+  permits it.
+
+Client-credential REST auth does not create an authenticated browser session.
+If UI-only data-entry permission, first-save provisioning, or publish remains,
+report that gate precisely; do not claim completion from API evidence.
+
+### Step 0h — Completion gate
+
+Before declaring done:
+
+```bash
+ruby scripts/design-artifact.rb check --strict /tmp/design-manifest.json
+./scripts/verify-workbook.sh "$WORKBOOK_ID"
+```
+
+Also re-render every visible page. Report the workbook URLs, spec paths,
+accepted tradeoffs, and any UI-only gates. Do not make the user rediscover
+obvious visual differences that are already visible in the render.
 
 ## Things to watch out for
 
@@ -86,6 +256,12 @@ From here, follow the standard workflow (Steps 5–8). One additional verificati
 - **Don't carry source-tool concepts directly.** Tableau "sheets," Looker "looks," PowerBI "visuals" all map onto Sigma's flat `elements[]` list, but they don't translate 1:1. A Tableau dashboard tab is a Sigma `page`; a Tableau sheet is one or more Sigma elements.
 - **Title text isn't the data.** A chart titled "Gross Revenue by Ship Speed" tells you what the user wants the chart *labeled*; the data fields are inferred from the visual marks, axes, and the user's other instructions — not from the title.
 - **When the data is empty.** If your produced workbook renders "No data" for a panel, the structural interpretation may be right but the data substitution wrong. Re-check: did you pick a column that actually has rows in the selected time range? Did the default filter exclude everything? Fix and re-verify rather than calling it done.
+- **Don't decorate fake behavior.** A button styled "Publish" is not a publish
+  feature unless it actually publishes. Remove it, wire a real action, or mark
+  it as an explicitly accepted decorative surface.
+- **Don't conflate writeback rows with spec state.** Input-table rows live in
+  managed warehouse state and can survive spec `PUT`s. Verify both the document
+  and the rows after structural changes.
 
 ## What this workflow does NOT cover
 

--- a/sigma-workbooks/scripts/design-artifact.rb
+++ b/sigma-workbooks/scripts/design-artifact.rb
@@ -1,0 +1,296 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+# Local planning/completion manifest for screenshot/mockup-driven workbook
+# builds. Stdlib only; customer artifacts and org identifiers stay outside the
+# skill tree.
+
+require 'json'
+
+module DesignArtifact
+  IMPLEMENTATIONS = %w[native-spec ui-only plugin unavailable].freeze
+  VERDICTS = %w[pending pass fail accepted-gap].freeze
+  SEVERITIES = %w[low medium high].freeze
+  MISMATCH_STATUSES = %w[open fixed accepted].freeze
+
+  TEMPLATE = {
+    'schemaVersion' => 1,
+    'artifacts' => [
+      {
+        'id' => 'target-1',
+        'path' => '/absolute/path/to/target.png',
+        'viewport' => { 'width' => 1440, 'height' => 900 }
+      }
+    ],
+    'workbooks' => [
+      {
+        'name' => 'Workbook name',
+        'artifactRefs' => ['target-1'],
+        'boundaryDecision' => 'One separate workbook for this app surface.',
+        'surfaces' => [
+          {
+            'id' => 'app-shell',
+            'target' => 'Left rail, breadcrumb, title row, actions, and tabs',
+            'sigmaKind' => 'container/text/button',
+            'implementation' => 'native-spec',
+            'acceptance' => 'Rendered geometry and active states match the artifact.'
+          },
+          {
+            'id' => 'primary-data',
+            'target' => 'Primary data visualization or editable grid',
+            'sigmaKind' => 'bar-chart',
+            'implementation' => 'native-spec',
+            'acceptance' => 'Kind, channels, values, labels, and density match.'
+          }
+        ],
+        'interactions' => [
+          {
+            'id' => 'primary-interaction',
+            'expectedBehavior' => 'Describe the button/control/edit behavior.',
+            'implementation' => 'native-spec',
+            'verification' => 'pending',
+            'evidence' => ''
+          }
+        ],
+        'visual' => {
+          'renders' => [
+            { 'stage' => 'first', 'path' => '', 'reviewed' => false },
+            { 'stage' => 'final', 'path' => '', 'reviewed' => false }
+          ],
+          'mismatches' => [
+            {
+              'id' => 'example-gap',
+              'severity' => 'high',
+              'status' => 'open',
+              'description' => 'Replace with a real first-render mismatch.'
+            }
+          ],
+          'acceptedTradeoffs' => []
+        },
+        'runtime' => {
+          'specVerify' => 'pending',
+          'compile' => 'pending',
+          'dataParity' => 'pending',
+          'controls' => 'pending',
+          'writeback' => 'accepted-gap',
+          'agent' => 'accepted-gap'
+        }
+      }
+    ]
+  }.freeze
+
+  module_function
+
+  def errors(manifest, strict: false)
+    out = []
+    unless manifest.is_a?(Hash)
+      return ['root must be a JSON object']
+    end
+
+    out << 'schemaVersion must be 1' unless manifest['schemaVersion'] == 1
+    artifacts = manifest['artifacts']
+    out << 'artifacts must be a non-empty array' unless artifacts.is_a?(Array) && !artifacts.empty?
+    artifact_ids = []
+    if artifacts.is_a?(Array)
+      artifacts.each_with_index do |artifact, index|
+        at = "artifacts[#{index}]"
+        unless artifact.is_a?(Hash)
+          out << "#{at} must be an object"
+          next
+        end
+        require_string(artifact, 'id', at, out)
+        require_string(artifact, 'path', at, out)
+        artifact_ids << artifact['id'] if artifact['id'].is_a?(String)
+        viewport = artifact['viewport']
+        unless viewport.is_a?(Hash) &&
+               viewport['width'].is_a?(Numeric) && viewport['width'].positive? &&
+               viewport['height'].is_a?(Numeric) && viewport['height'].positive?
+          out << "#{at}.viewport must contain positive numeric width and height"
+        end
+      end
+    end
+    out << 'artifact ids must be unique' if artifact_ids.uniq.length != artifact_ids.length
+
+    workbooks = manifest['workbooks']
+    out << 'workbooks must be a non-empty array' unless workbooks.is_a?(Array) && !workbooks.empty?
+    return out unless workbooks.is_a?(Array)
+
+    workbooks.each_with_index do |workbook, index|
+      wb = "workbooks[#{index}]"
+      unless workbook.is_a?(Hash)
+        out << "#{wb} must be an object"
+        next
+      end
+
+      require_string(workbook, 'name', wb, out)
+      require_string(workbook, 'boundaryDecision', wb, out)
+      refs = workbook['artifactRefs']
+      if !refs.is_a?(Array) || refs.empty? || refs.any? { |ref| !artifact_ids.include?(ref) }
+        out << "#{wb}.artifactRefs must be a non-empty array of known artifact ids"
+      end
+
+      surfaces = workbook['surfaces']
+      if !surfaces.is_a?(Array) || surfaces.empty?
+        out << "#{wb}.surfaces must be a non-empty array"
+      else
+        surfaces.each_with_index do |surface, surface_index|
+          sf = "#{wb}.surfaces[#{surface_index}]"
+          unless surface.is_a?(Hash)
+            out << "#{sf} must be an object"
+            next
+          end
+          %w[id target sigmaKind acceptance].each { |key| require_string(surface, key, sf, out) }
+          enum(surface, 'implementation', IMPLEMENTATIONS, sf, out)
+        end
+      end
+
+      interactions = workbook['interactions']
+      if !interactions.is_a?(Array)
+        out << "#{wb}.interactions must be an array (use [] only when the artifact has no behavior)"
+      else
+        interactions.each_with_index do |interaction, interaction_index|
+          ix = "#{wb}.interactions[#{interaction_index}]"
+          unless interaction.is_a?(Hash)
+            out << "#{ix} must be an object"
+            next
+          end
+          %w[id expectedBehavior].each { |key| require_string(interaction, key, ix, out) }
+          enum(interaction, 'implementation', IMPLEMENTATIONS, ix, out)
+          enum(interaction, 'verification', VERDICTS, ix, out)
+          if strict && interaction['verification'] == 'pending'
+            out << "#{ix}.verification is still pending"
+          end
+          if strict && interaction['verification'] == 'pass' && interaction['evidence'].to_s.strip.empty?
+            out << "#{ix}.evidence is required for a passing interaction"
+          end
+        end
+      end
+
+      validate_visual(workbook['visual'], wb, out, strict: strict)
+      validate_runtime(workbook['runtime'], wb, out, strict: strict)
+    end
+
+    out
+  end
+
+  def validate_visual(visual, wb, out, strict:)
+    unless visual.is_a?(Hash)
+      out << "#{wb}.visual must be an object"
+      return
+    end
+
+    renders = visual['renders']
+    unless renders.is_a?(Array)
+      out << "#{wb}.visual.renders must be an array"
+      renders = []
+    end
+    renders.each_with_index do |render, index|
+      at = "#{wb}.visual.renders[#{index}]"
+      unless render.is_a?(Hash)
+        out << "#{at} must be an object"
+        next
+      end
+      require_string(render, 'stage', at, out)
+      next unless strict
+
+      require_string(render, 'path', at, out)
+      out << "#{at}.reviewed must be true" unless render['reviewed'] == true
+    end
+    if strict
+      stages = renders.filter_map { |render| render['stage'] if render.is_a?(Hash) }
+      out << "#{wb}.visual.renders needs reviewed first and final renders" unless
+        stages.include?('first') && stages.include?('final')
+    end
+
+    mismatches = visual['mismatches']
+    unless mismatches.is_a?(Array)
+      out << "#{wb}.visual.mismatches must be an array"
+      mismatches = []
+    end
+    mismatches.each_with_index do |mismatch, index|
+      at = "#{wb}.visual.mismatches[#{index}]"
+      unless mismatch.is_a?(Hash)
+        out << "#{at} must be an object"
+        next
+      end
+      %w[id description].each { |key| require_string(mismatch, key, at, out) }
+      enum(mismatch, 'severity', SEVERITIES, at, out)
+      enum(mismatch, 'status', MISMATCH_STATUSES, at, out)
+      if strict && mismatch['severity'] == 'high' && mismatch['status'] == 'open'
+        out << "#{at} is an unresolved high-severity mismatch"
+      end
+    end
+
+    tradeoffs = visual['acceptedTradeoffs']
+    out << "#{wb}.visual.acceptedTradeoffs must be an array" unless tradeoffs.is_a?(Array)
+  end
+
+  def validate_runtime(runtime, wb, out, strict:)
+    unless runtime.is_a?(Hash)
+      out << "#{wb}.runtime must be an object"
+      return
+    end
+
+    %w[specVerify compile dataParity controls writeback agent].each do |gate|
+      enum(runtime, gate, VERDICTS, "#{wb}.runtime", out)
+    end
+    return unless strict
+
+    %w[specVerify compile dataParity].each do |gate|
+      out << "#{wb}.runtime.#{gate} must pass" unless runtime[gate] == 'pass'
+    end
+    %w[controls writeback agent].each do |gate|
+      next if %w[pass accepted-gap].include?(runtime[gate])
+
+      out << "#{wb}.runtime.#{gate} must pass or be an accepted gap"
+    end
+  end
+
+  def require_string(hash, key, prefix, out)
+    out << "#{prefix}.#{key} must be a non-empty string" unless
+      hash[key].is_a?(String) && !hash[key].strip.empty?
+  end
+
+  def enum(hash, key, allowed, prefix, out)
+    out << "#{prefix}.#{key} must be one of: #{allowed.join(', ')}" unless allowed.include?(hash[key])
+  end
+
+  def write_template(path)
+    raise ArgumentError, "#{path} already exists" if File.exist?(path)
+
+    File.write(path, JSON.pretty_generate(TEMPLATE) + "\n")
+  end
+end
+
+if $PROGRAM_NAME == __FILE__
+  command = ARGV.shift
+  strict = ARGV.delete('--strict')
+  path = ARGV.shift
+  unless %w[init check].include?(command) && path && ARGV.empty?
+    warn 'Usage: ruby scripts/design-artifact.rb init <manifest.json>'
+    warn '   or: ruby scripts/design-artifact.rb check [--strict] <manifest.json>'
+    exit 2
+  end
+
+  if command == 'init'
+    DesignArtifact.write_template(path)
+    puts "Wrote #{path}"
+    exit 0
+  end
+
+  begin
+    manifest = JSON.parse(File.read(path))
+  rescue Errno::ENOENT, JSON::ParserError => e
+    warn "design-artifact: #{e.message}"
+    exit 1
+  end
+
+  errors = DesignArtifact.errors(manifest, strict: !strict.nil?)
+  if errors.empty?
+    puts "OK: #{path}#{strict ? ' (strict)' : ''}"
+    exit 0
+  end
+
+  errors.each { |error| warn "ERROR: #{error}" }
+  exit 1
+end

--- a/sigma-workbooks/scripts/test-design-artifact.rb
+++ b/sigma-workbooks/scripts/test-design-artifact.rb
@@ -1,0 +1,86 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require 'json'
+require 'tmpdir'
+require_relative 'design-artifact'
+
+failures = []
+
+def check(name, failures)
+  yield
+  puts "PASS: #{name}"
+rescue StandardError => e
+  failures << "#{name}: #{e.message}"
+  warn "FAIL: #{name}: #{e.message}"
+end
+
+check('template passes planning validation', failures) do
+  errors = DesignArtifact.errors(JSON.parse(JSON.generate(DesignArtifact::TEMPLATE)))
+  raise errors.join('; ') unless errors.empty?
+end
+
+check('template does not pass strict completion', failures) do
+  errors = DesignArtifact.errors(JSON.parse(JSON.generate(DesignArtifact::TEMPLATE)), strict: true)
+  raise 'strict check unexpectedly passed' if errors.empty?
+  raise 'missing render error' unless errors.any? { |error| error.include?('reviewed') }
+  raise 'missing mismatch error' unless errors.any? { |error| error.include?('high-severity') }
+  raise 'missing runtime error' unless errors.any? { |error| error.include?('specVerify must pass') }
+end
+
+check('completed manifest passes strict validation', failures) do
+  manifest = JSON.parse(JSON.generate(DesignArtifact::TEMPLATE))
+  workbook = manifest.fetch('workbooks').first
+  workbook.fetch('interactions').first.merge!(
+    'verification' => 'pass',
+    'evidence' => '/tmp/export-control-state.csv'
+  )
+  workbook.fetch('visual').fetch('renders').each do |render|
+    render['path'] = "/tmp/#{render.fetch('stage')}.png"
+    render['reviewed'] = true
+  end
+  workbook.fetch('visual').fetch('mismatches').first['status'] = 'fixed'
+  workbook['runtime'] = {
+    'specVerify' => 'pass',
+    'compile' => 'pass',
+    'dataParity' => 'pass',
+    'controls' => 'pass',
+    'writeback' => 'accepted-gap',
+    'agent' => 'accepted-gap'
+  }
+  errors = DesignArtifact.errors(manifest, strict: true)
+  raise errors.join('; ') unless errors.empty?
+end
+
+check('unknown artifact refs are rejected', failures) do
+  manifest = JSON.parse(JSON.generate(DesignArtifact::TEMPLATE))
+  manifest.fetch('workbooks').first['artifactRefs'] = ['missing']
+  errors = DesignArtifact.errors(manifest)
+  raise 'unknown ref was accepted' unless errors.any? { |error| error.include?('known artifact ids') }
+end
+
+check('passing interactions require evidence in strict mode', failures) do
+  manifest = JSON.parse(JSON.generate(DesignArtifact::TEMPLATE))
+  workbook = manifest.fetch('workbooks').first
+  interaction = workbook.fetch('interactions').first
+  interaction['verification'] = 'pass'
+  interaction['evidence'] = ''
+  errors = DesignArtifact.errors(manifest, strict: true)
+  raise 'missing evidence was accepted' unless errors.any? { |error| error.include?('evidence is required') }
+end
+
+check('init refuses to overwrite an existing manifest', failures) do
+  Dir.mktmpdir do |dir|
+    path = File.join(dir, 'design.json')
+    DesignArtifact.write_template(path)
+    begin
+      DesignArtifact.write_template(path)
+    rescue ArgumentError
+      next
+    end
+    raise 'existing manifest was overwritten'
+  end
+end
+
+abort "#{failures.length} failure(s)" unless failures.empty?
+puts 'All design-artifact tests passed.'


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Why

This lands the change from [twells89/tableau-to-sigma-enhancement-phase#10](https://github.com/twells89/tableau-to-sigma-enhancement-phase/pull/10) in its intended home. That PR could not push here directly (the Cursor GitHub App installation was scoped to the other repo), so it carried an upstream-rooted patch in `handoff/` for exactly this purpose.

Building Sigma apps from Claude design artifacts / screenshots surfaced a repeatable gap: the old `from-image.md` inventoried data visuals, controls, and coarse layout, so an agent following it reproduced the charts and dropped everything that makes the artifact look like an application — logo, left rail, breadcrumb, title row, action buttons, tabs, card structure, spacing, and interaction semantics. The result compiled and rendered but still needed rounds of "make it sleeker", "add the logo", "the buttons look awkwardly separated" — all avoidable, since the information was in the artifact from the start.

## What changed

**`sigma-workbooks/reference/workflows/from-image.md`** — the inventory now covers the whole screen, not just data visuals:

- **Workbook boundaries** — distinct app surfaces stay distinct workbooks instead of collapsing because they share branding.
- **App shell and chrome** is a first-class inventory section, built in the first draft rather than deferred to a "polish" pass.
- **Behavior classification** — every button, tab, control, editable cell, and agent is labelled `native-spec` / `ui-only` / `plugin` / `unavailable` before implementation, so an interactive-looking surface is never silently shipped as a decorative no-op.
- **Element semantics** — an editable grid is an `input-table`, not a `table`; a conversation rail is `agents[]` + `chat`, not a text box.
- **Design-system extraction** (palette, type scale, geometry, alignment groups) before layout XML — including the trap that two right-aligned buttons in wide independent grid cells drift apart.
- **Native-first routing** — a polished screenshot is not a reason to rebuild a page as a custom plugin.
- **Asset honesty** — a monogram is not the source logo, and inline SVG data URIs can pass `/verify` while the actual write is blocked.
- **Render → diff → iterate** — a passing verify/POST/readback/compile is explicitly *not* visual acceptance.

**`sigma-workbooks/scripts/design-artifact.rb`** (new, stdlib only) — an `init` / `check` / `check --strict` manifest so fidelity is auditable. Strict mode fails on unresolved high-severity mismatches, pending or unevidenced interactions, unreviewed renders, and unmet runtime gates.

**`sigma-workbooks/scripts/test-design-artifact.rb`** (new) — six tests, including that a freshly-initialised template *passes* planning validation and *fails* strict completion, so the manifest can't be rubber-stamped.

**`sigma-workbooks/SKILL.md`** — frontmatter, Step 0 routing, and the reference-index entry.

**`sigma-plugin-authoring/SKILL.md`** — guard against rebuilding an entire artifact as one HTML plugin.

**`*/generated/**`** — regenerated Codex / Cursor / Cline / Continue variants (verified in sync via `scripts/sync-targets.rb`).

## How it got here

Applied the `handoff/sigma-skills-design-artifact-workflow.patch` from PR #10 via `git am` (single commit, upstream-rooted, applied cleanly).

## Verification

- `ruby sigma-workbooks/scripts/test-design-artifact.rb` — 6/6 pass
- Full creds-free suite (mirrors `.github/workflows/tests.yml`, excluding the live-creds `test-verify.rb`) — 14/14 pass
- `ruby scripts/sync-targets.rb sigma-workbooks` and `... sigma-plugin-authoring` produce no drift (`git diff` empty)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-11f193f6-f428-40ec-bf7b-6acc6b7ab2e8?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-11f193f6-f428-40ec-bf7b-6acc6b7ab2e8&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

