### PR TITLE
fix(sigma-workbooks): align agent action shapes

### DIFF
--- a/sigma-workbooks/reference/specification/agents.md
+++ b/sigma-workbooks/reference/specification/agents.md
@@ -126,7 +126,7 @@ agents:
                 inputName: note         # the agent supplies this at call time
 ```
 
-`value: { type: "agent-input", inputName }` is the tool-call analog of the
+`values: { <column-id>: { type: "agent-input", inputName } }` is the tool-call analog of the
 `type: "control"` / `type: "constant"` value shapes an `insert-rows` effect takes
 from a button (see `reference/workflows/actions.md`) — instead of pulling from a
 control's current value or a hard-coded constant, the value comes from an argument
@@ -156,8 +156,8 @@ tools:
 |---|---|---|
 | `action` | `toolId`, `name`, `description`, `steps`, `requiresApproval?` | **Live-verified** (create + readback) |
 | `mcp-connector` | `toolId`, `name`, `connectorId` | Shape accepted; needs a real connector — see below |
-| `warehouse-agent` | `toolId`, `description`, `connectionId`, `path` | Not exercised (no such agent in the test org) |
-| `search-service` | `toolId`, `description`, `connectionId`, `path` | Not exercised (no such service in the test org) |
+| `warehouse-agent` | `toolId`, `connectionId`, `path` (live readback; `description` optional) | Shape parses; `/verify` resolves the path against the host and can return `invocable inodes are not supported by this host` when the host lacks the registered agent. |
+| `search-service` | `toolId`, `connectionId`, `path` (live-example shape; `description` optional) | Requires a registered search service; verify with a real path before shipping. |
 
 `mcp-connector` lets a workbook agent call an external MCP tool by `connectorId`.
 A syntactically valid but fake `connectorId` is rejected with `invocable inodes are
@@ -165,7 +165,16 @@ not supported by this host: '<id>'` — i.e. the **shape parses** and the id is
 resolved against real org inodes, so this needs an actual registered connector to
 verify end to end. `warehouse-agent` and `search-service` both take a
 `connectionId` + `path` pair (a warehouse-side agent/service), same as a
-warehouse-table path.
+warehouse-table path. The compiled OpenAPI currently under-describes these live
+fields, so use a live readback or `/verify` result as the tiebreaker rather than
+omitting them.
+
+For action-agent steps, `/verify` accepts `agent-input` values for
+`set-control-value` and both `page` and `control` `clear-control` scopes. The
+button-specific guidance in `reference/workflows/actions.md` is narrower because
+only page-scoped `clear-control` has been proven to fire from a button; acceptance
+of an agent step does not prove that an action will execute successfully at run
+time.
 
 ### `steps[]` — `effect` or `sequence`
 
@@ -191,9 +200,10 @@ steps:
 > (This refines the blanket "action sequences are unsupported" claim: they are not
 > *authorable*, but they are *referenceable*.)
 
-> **Scope note:** the write/action agent shape above documents a live-verified
-> *pattern* — it is not independently exercised end-to-end in this pass (no
-> automated test drives an agent into actually invoking a tool).
+> **Scope note:** the write/action agent shape and the listed effect-step shapes
+> have been accepted by neutral `/verify` probes, including action tools targeting
+> `inputMode: view` tables. This is not end-to-end execution: no automated test
+> drives an agent into actually invoking a tool or proves a warehouse mutation.
 > `Richness.agent`'s `tools:` parameter passes an already-shaped array through
 > **verbatim** (never reshapes it) for exactly this reason: confirm any non-trivial
 > tool/step shape against a live POST + readback before shipping it, same discipline
@@ -230,13 +240,13 @@ gated feature look implemented.
 
 ## Cross-links
 
-- `scripts/lib/richness.rb` — `Richness.agent(id:, name:, instructions:,
-  data_source_ids:, tools: [])` builds the `agents[]` entry (`data_source_ids`
-  maps to `dataSources`; empty `tools:` is omitted from the emitted Hash,
-  matching the read-only shape above). `Richness.chat(id:, agent_id:)` builds
-  the page element. Both are gated behind `Richness::SURFACES[:agent]`; a
-  NO-GO flip returns `{opt_in: true, id:}` rather than emitting an unverified
-  shape.
+- `scripts/lib/richness.rb` — `Richness.agent(id:, instructions:, name: nil,
+  data_source_ids: [], tools: [], description: nil, greeting: nil)` builds the
+  `agents[]` entry (`data_source_ids` maps to `dataSources`; empty `tools:` is
+  omitted from the emitted Hash, matching the read-only shape above).
+  `Richness.chat(id:, agent_id:)` builds the page element. Both are gated behind
+  `Richness::SURFACES[:agent]`; a NO-GO flip returns `{opt_in: true, id:}` rather
+  than emitting an unverified shape.
 - `reference/workflows/actions.md` — the `insert-rows`/`clear-control`/
   `set-control-value` effect shapes a write-agent's tool `steps[]` reuses, and
   the append-only-log input-table pattern a logging tool typically targets.

--- a/sigma-workbooks/reference/workflows/actions.md
+++ b/sigma-workbooks/reference/workflows/actions.md
@@ -127,6 +127,11 @@ The only verified `value` shape is a constant text value (e.g. a "quick filter
 preset" button). Useful paired with a `list`/`segmented` control to give users a
 one-click shortcut into a known filter state.
 
+An action-agent step is a separate host: `/verify` also accepts
+`value: { type: agent-input, inputName: <name> }` there. That proves the step
+shape only; it does not prove that the agent will invoke it or that the control
+will accept the supplied value at runtime.
+
 ## Overlays: `open-overlay` / `close-overlay` (modal **and** drawer)
 
 Modal and drawer metadata lives in `document.overlays`, not
@@ -274,6 +279,11 @@ type: column-match, column: status, condition: "=", value: {...} }`.
 `>=` / `<` / `<=` / `Contains` / `NotContains` / `StartsWith` / `EndsWith`
 (`value` required), or `Between` / `NotBetween` (`low`/`high` required instead
 of `value`).
+
+For an action-agent tool, `primaryKeys` and the `values` map must use the target
+input-table element's own column IDs. Do not copy friendly names or IDs from a
+derived table/chart that reads from the input table; Sigma may report those as
+`bad column` during `/verify`.
 
 > **`current-row` is not reachable from a page-level button.** It rejects with
 > `current-row selector requires the action host to be within the target input

--- a/sigma-workbooks/scripts/lib/richness.rb
+++ b/sigma-workbooks/scripts/lib/richness.rb
@@ -225,18 +225,23 @@ module Richness
   # than a 400 (see `chat`'s docstring and reference/workflows/actions.md for
   # the caller-side fallback pattern). NO-GO surface ->
   # {'opt_in'=>true,'id'=>id}: never emit a faked agent.
-  def self.agent(id:, name:, instructions:, data_source_ids:, tools: [], surfaces: SURFACES)
+  # `instructions` must be present, but an empty string is accepted. `name` and
+  # `data_source_ids` are optional in the live API. `description` and `greeting`
+  # are passed through when supplied; callers remain responsible for shaping a
+  # valid greeting object (static or generated).
+  def self.agent(id:, instructions:, name: nil, data_source_ids: [], tools: [], description: nil, greeting: nil, surfaces: SURFACES)
     raise ArgumentError, 'id required' if id.to_s.empty?
-    raise ArgumentError, 'name required' if name.to_s.empty?
-    raise ArgumentError, 'instructions required' if instructions.to_s.empty?
+    raise ArgumentError, 'instructions required' if instructions.nil?
     return { 'opt_in' => true, 'id' => id } unless surfaces[:agent]
 
     out = {
       'id' => id,
-      'name' => name,
       'instructions' => instructions,
       'dataSources' => (data_source_ids || []).map { |eid| { 'kind' => 'table', 'elementId' => eid } }
     }
+    out['name'] = name unless name.nil?
+    out['description'] = description unless description.nil?
+    out['greeting'] = greeting unless greeting.nil?
     out['tools'] = tools unless tools.nil? || tools.empty?
     out
   end

--- a/sigma-workbooks/scripts/lib/test_richness.rb
+++ b/sigma-workbooks/scripts/lib/test_richness.rb
@@ -202,7 +202,7 @@ end
 AGENT_TOOLS = [
   { 'toolId' => 't-log-note', 'kind' => 'action', 'name' => 'Log note', 'description' => 'Insert a review note.',
     'steps' => [{ 'kind' => 'effect', 'effect' => 'insert-rows', 'table' => 'annotations',
-                  'value' => { 'type' => 'agent-input', 'inputName' => 'note' } }] }
+                  'values' => { 'an-note' => { 'type' => 'agent-input', 'inputName' => 'note' } } }] }
 ].freeze
 
 check('agent: read-only analyst (tools: []) OMITS the tools key entirely') do
@@ -217,6 +217,16 @@ check('agent: multiple data_source_ids map to multiple dataSources entries, in o
   el = Richness.agent(id: 'ag-1', name: 'Analyst', instructions: 'x', data_source_ids: %w[src-a src-b])
   el['dataSources'] == [{ 'kind' => 'table', 'elementId' => 'src-a' }, { 'kind' => 'table', 'elementId' => 'src-b' }]
 end
+check('agent: optional name/data source arguments emit an API-valid minimal entry') do
+  el = Richness.agent(id: 'ag-min', instructions: '')
+  el == { 'id' => 'ag-min', 'instructions' => '', 'dataSources' => [] }
+end
+check('agent: optional description and greeting pass through') do
+  greeting = { 'mode' => 'static', 'message' => 'Ready.' }
+  el = Richness.agent(id: 'ag-described', name: 'Assistant', instructions: 'x', data_source_ids: [],
+                      description: 'A helper.', greeting: greeting)
+  el['description'] == 'A helper.' && el['greeting'] == greeting
+end
 check('agent: non-empty tools: is added verbatim') do
   el = Richness.agent(id: 'ag-2', name: 'Assistant', instructions: 'Act on my behalf.',
                        data_source_ids: ['src'], tools: AGENT_TOOLS)
@@ -227,15 +237,17 @@ check('agent: id required') do
     Richness.agent(id: '', name: 'A', instructions: 'x', data_source_ids: ['src']); false
   rescue ArgumentError; true; end
 end
-check('agent: name required') do
+check('agent: instructions must be present') do
   begin
-    Richness.agent(id: 'ag-1', name: '', instructions: 'x', data_source_ids: ['src']); false
+    Richness.agent(id: 'ag-1', name: 'A', instructions: nil, data_source_ids: ['src']); false
   rescue ArgumentError; true; end
 end
-check('agent: instructions required') do
+check('agent: omitted instructions is rejected by Ruby keyword arity') do
   begin
-    Richness.agent(id: 'ag-1', name: 'A', instructions: '', data_source_ids: ['src']); false
-  rescue ArgumentError; true; end
+    Richness.agent(id: 'ag-1', name: 'A', data_source_ids: ['src']); false
+  rescue ArgumentError
+    true
+  end
 end
 check('agent: NO-GO surface -> opt-in marker, never a faked agent') do
   el = Richness.agent(id: 'ag-1', name: 'A', instructions: 'x', data_source_ids: ['src'],

--- a/sigma-workbooks/scripts/lib/testdata/richness_golden.json
+++ b/sigma-workbooks/scripts/lib/testdata/richness_golden.json
@@ -31,9 +31,11 @@
             "kind": "effect",
             "effect": "insert-rows",
             "table": "annotations",
-            "value": {
-              "type": "agent-input",
-              "inputName": "note"
+            "values": {
+              "an-note": {
+                "type": "agent-input",
+                "inputName": "note"
+              }
             }
           }
         ]


### PR DESCRIPTION
## Summary
- use `values` keyed by the input table column ID for agent `insert-rows` steps
- allow the API-optional agent fields and pass through `description`/`greeting`
- align the canonical agent/action documentation with the live-verified shapes

## Verification
- `ruby sigma-workbooks/scripts/lib/test_richness.rb`
- `git diff --check origin/main...HEAD`