### PR TITLE
feat(workbooks): add operational app best practices

### DIFF
--- a/sigma-workbooks/SKILL.md
+++ b/sigma-workbooks/SKILL.md
@@ -168,6 +168,14 @@ Load `reference/workflows/discover.md`. Quick summary:
 
 Map the user's request to the **Reference Index** below. State the features you identified, then read the listed reference files before drafting. **If the user asks for a feature this skill doesn't cover**, fetch the OpenAPI and inspect the relevant schema.
 
+If the request includes an input table, writeback, “populate,” “seed,” planning,
+approval, allocation, or exception workflow, load
+`reference/specification/input-tables.md` before choosing an architecture.
+Creating an input-table element, loading initial rows, composing a downstream
+read path, and submitting a runtime action are four different operations. Do
+not substitute actions, unions, or joins for one another when the first
+approach leaves the table empty.
+
 ### Step 5 — Draft the spec to a local file
 
 Write the spec YAML to disk (e.g., `/tmp/workbook-spec.yaml`). YAML is preferred over JSON in this skill — easier to read, diff, and comment for human review. The API accepts either; pick YAML unless something downstream specifically needs JSON. Key rules:
@@ -279,7 +287,7 @@ The reference is feature-sliced — don't read every file up-front. The index ha
 | `reference/specification/kpis.md` | KPI, stat, big number, single value, metric card — including layout / value styling, the comparison Δ badge (`comparisonColumn` + `comparison:{display:"delta"}` — spec-authorable and readback-stable; the house default), and the trend/sparkline block (still UI-bound). |
 | `reference/specification/controls.md` | Filter, dropdown, picker, multi-select, date range, date picker, text filter, number range, slider, segmented, hierarchy, legend, and drill controls. Also entry controls and formula handles. |
 | `reference/specification/content-elements.md` | The non-data elements — `text` (Markdown + inline styling), `image`, `divider`, `embed` (external URLs), `page-break` (PDF/print pagination), `form`, `progress`, `navigation`, `plugin`. Titles, callouts, logos, rules, embedded content. |
-| `reference/specification/input-tables.md` | Operational supplement for `input-table` (spec shape lives in `tables.md`): write-connection requirement, the publish gate, reading data back via warehouse views, element endpoints for auditing, and migration patterns (Excel/planning models). |
+| `reference/specification/input-tables.md` | **Load for every input-table or “populate/seed” request.** Operational supplement for `input-table`: supported row-arrival decision tree, write connection, UI-only published permission, publish gate, linked-key correlation, warehouse views, and why actions/unions/joins are not bulk seeding mechanisms. |
 | `reference/specification/styling.md` | **Load when building a dashboard from scratch.** Design recipe library — vetted color palette, hero header strip, gradient header/KPI cards + composite sparkline, KPI card row, section headers, divider rhythm, categorical chart colors. Turns a default-arrange workbook into a designed-looking one without UI editing. |
 | `reference/specification/agents.md` | Workbook AI agent, chat with your data, agent, chatbot, AI assistant. The workbook-top-level `agents:[]` array + page-level `chat` element; read-only analyst vs. write/action agent; the four `tools[]` kinds (`action`, `mcp-connector`, `warehouse-agent`, `search-service`), `greeting`, `requiresApproval`, why action sequences are referenceable but not authorable; org-feature gate + graceful degrade. |
 
@@ -308,8 +316,13 @@ The reference is feature-sliced — don't read every file up-front. The index ha
 | `reference/workflows/discover.md` | Finding connections, tables, and column names. Load before composing a new spec. |
 | `reference/workflows/composition.md` | Open-ended design decisions — calibrating workbook complexity to the request, when to ask the user, what to ask, surfacing structural choices in the final summary, and a few safe defaults (hidden source pages, ranked-table sort direction). Load before drafting anything when the prompt leaves significant design choices unmade. |
 | `reference/workflows/actions.md` | Buttons, write-back, and **all twelve** action effects — insert/update/delete-rows, clear-control, set-control-value, open/close-overlay (modal **and** drawer), open-url, open-document (incl. passing `targetControls` into another workbook), navigate, select-tab, refresh-element — plus the append-only-log pattern and the masked-error catalog. Load when the user wants a button, a "log/save/submit" action, tab/page navigation, a deep link, or a write-back workflow. |
+| `reference/workflows/planning-apps.md` | **Scenario planning, budgeting, and forecasting apps.** Scenario × Period × Planning Line grain, governed baseline, scenario matrix, linked override grid, financial sign, filter-propagation choices, approval/audit, and runtime gates. |
+| `reference/workflows/allocation-apps.md` | **Allocation and capacity apps.** Budget/target vs. baseline at Period × Allocation Dimension grain, linked editable units/uplifts, working allocation, request queue, and exact variance gates. |
+| `reference/workflows/approval-apps.md` | **Approval and decision apps.** Stable entity-key queues, counter-values, immutable audit logs, one-row status updates, agent boundaries, and runtime tests. |
+| `reference/workflows/exception-apps.md` | **Exception command centers.** Stable operational-key queues, deterministic recommendations, overrides, ownership, resolution logs, and exact KPI-delta tests. |
 | `reference/workflows/crud.md` | POST / GET / PUT against the workbook spec endpoints. Load when creating, retrieving, or updating a workbook. |
-| `reference/workflows/validate.md` | Pre-submit + post-create validation. Load before any POST or PUT. |
+| `reference/workflows/validate.md` | Pre-submit + post-create structural validation. Load before any POST or PUT; for joins, controls, writeback, agents, or numeric claims continue to `runtime-verification.md`. |
+| `reference/workflows/runtime-verification.md` | **Runtime evidence loop:** compile, render, export, cardinality, numeric oracle, published writeback, linked-row correlation, control scope, approval scope, and agent tests. |
 | `reference/workflows/from-image.md` | The user supplied a target image or Claude design artifact to reproduce. Load *before* discovery — it inventories the entire app shell and behavior, routes native Sigma vs plugin/UI-only surfaces, requires a local design manifest, and enforces first-render → diff → final-render acceptance. |
 | `reference/workflows/element-rep.md` | **Large or multi-page workbooks, parallel element work, or iterative refinement.** `scripts/wb-rep.rb` explodes the spec into one small file per element (pull/status/push/render) so edits never drag the whole spec through context — element-level semantics over the whole-spec API, plus PNG renders to inspect what you built. |
 

--- a/sigma-workbooks/generated/cline/sigma-workbooks.md
+++ b/sigma-workbooks/generated/cline/sigma-workbooks.md
@@ -160,6 +160,14 @@ Load `reference/workflows/discover.md`. Quick summary:
 
 Map the user's request to the **Reference Index** below. State the features you identified, then read the listed reference files before drafting. **If the user asks for a feature this skill doesn't cover**, fetch the OpenAPI and inspect the relevant schema.
 
+If the request includes an input table, writeback, “populate,” “seed,” planning,
+approval, allocation, or exception workflow, load
+`reference/specification/input-tables.md` before choosing an architecture.
+Creating an input-table element, loading initial rows, composing a downstream
+read path, and submitting a runtime action are four different operations. Do
+not substitute actions, unions, or joins for one another when the first
+approach leaves the table empty.
+
 ### Step 5 — Draft the spec to a local file
 
 Write the spec YAML to disk (e.g., `/tmp/workbook-spec.yaml`). YAML is preferred over JSON in this skill — easier to read, diff, and comment for human review. The API accepts either; pick YAML unless something downstream specifically needs JSON. Key rules:
@@ -271,7 +279,7 @@ The reference is feature-sliced — don't read every file up-front. The index ha
 | `reference/specification/kpis.md` | KPI, stat, big number, single value, metric card — including layout / value styling, the comparison Δ badge (`comparisonColumn` + `comparison:{display:"delta"}` — spec-authorable and readback-stable; the house default), and the trend/sparkline block (still UI-bound). |
 | `reference/specification/controls.md` | Filter, dropdown, picker, multi-select, date range, date picker, text filter, number range, slider, segmented, hierarchy, legend, and drill controls. Also entry controls and formula handles. |
 | `reference/specification/content-elements.md` | The non-data elements — `text` (Markdown + inline styling), `image`, `divider`, `embed` (external URLs), `page-break` (PDF/print pagination), `form`, `progress`, `navigation`, `plugin`. Titles, callouts, logos, rules, embedded content. |
-| `reference/specification/input-tables.md` | Operational supplement for `input-table` (spec shape lives in `tables.md`): write-connection requirement, the publish gate, reading data back via warehouse views, element endpoints for auditing, and migration patterns (Excel/planning models). |
+| `reference/specification/input-tables.md` | **Load for every input-table or “populate/seed” request.** Operational supplement for `input-table`: supported row-arrival decision tree, write connection, UI-only published permission, publish gate, linked-key correlation, warehouse views, and why actions/unions/joins are not bulk seeding mechanisms. |
 | `reference/specification/styling.md` | **Load when building a dashboard from scratch.** Design recipe library — vetted color palette, hero header strip, gradient header/KPI cards + composite sparkline, KPI card row, section headers, divider rhythm, categorical chart colors. Turns a default-arrange workbook into a designed-looking one without UI editing. |
 | `reference/specification/agents.md` | Workbook AI agent, chat with your data, agent, chatbot, AI assistant. The workbook-top-level `agents:[]` array + page-level `chat` element; read-only analyst vs. write/action agent; the four `tools[]` kinds (`action`, `mcp-connector`, `warehouse-agent`, `search-service`), `greeting`, `requiresApproval`, why action sequences are referenceable but not authorable; org-feature gate + graceful degrade. |
 
@@ -300,8 +308,13 @@ The reference is feature-sliced — don't read every file up-front. The index ha
 | `reference/workflows/discover.md` | Finding connections, tables, and column names. Load before composing a new spec. |
 | `reference/workflows/composition.md` | Open-ended design decisions — calibrating workbook complexity to the request, when to ask the user, what to ask, surfacing structural choices in the final summary, and a few safe defaults (hidden source pages, ranked-table sort direction). Load before drafting anything when the prompt leaves significant design choices unmade. |
 | `reference/workflows/actions.md` | Buttons, write-back, and **all twelve** action effects — insert/update/delete-rows, clear-control, set-control-value, open/close-overlay (modal **and** drawer), open-url, open-document (incl. passing `targetControls` into another workbook), navigate, select-tab, refresh-element — plus the append-only-log pattern and the masked-error catalog. Load when the user wants a button, a "log/save/submit" action, tab/page navigation, a deep link, or a write-back workflow. |
+| `reference/workflows/planning-apps.md` | **Scenario planning, budgeting, and forecasting apps.** Scenario × Period × Planning Line grain, governed baseline, scenario matrix, linked override grid, financial sign, filter-propagation choices, approval/audit, and runtime gates. |
+| `reference/workflows/allocation-apps.md` | **Allocation and capacity apps.** Budget/target vs. baseline at Period × Allocation Dimension grain, linked editable units/uplifts, working allocation, request queue, and exact variance gates. |
+| `reference/workflows/approval-apps.md` | **Approval and decision apps.** Stable entity-key queues, counter-values, immutable audit logs, one-row status updates, agent boundaries, and runtime tests. |
+| `reference/workflows/exception-apps.md` | **Exception command centers.** Stable operational-key queues, deterministic recommendations, overrides, ownership, resolution logs, and exact KPI-delta tests. |
 | `reference/workflows/crud.md` | POST / GET / PUT against the workbook spec endpoints. Load when creating, retrieving, or updating a workbook. |
-| `reference/workflows/validate.md` | Pre-submit + post-create validation. Load before any POST or PUT. |
+| `reference/workflows/validate.md` | Pre-submit + post-create structural validation. Load before any POST or PUT; for joins, controls, writeback, agents, or numeric claims continue to `runtime-verification.md`. |
+| `reference/workflows/runtime-verification.md` | **Runtime evidence loop:** compile, render, export, cardinality, numeric oracle, published writeback, linked-row correlation, control scope, approval scope, and agent tests. |
 | `reference/workflows/from-image.md` | The user supplied a target image or Claude design artifact to reproduce. Load *before* discovery — it inventories the entire app shell and behavior, routes native Sigma vs plugin/UI-only surfaces, requires a local design manifest, and enforces first-render → diff → final-render acceptance. |
 | `reference/workflows/element-rep.md` | **Large or multi-page workbooks, parallel element work, or iterative refinement.** `scripts/wb-rep.rb` explodes the spec into one small file per element (pull/status/push/render) so edits never drag the whole spec through context — element-level semantics over the whole-spec API, plus PNG renders to inspect what you built. |
 

--- a/sigma-workbooks/generated/codex/AGENTS.md
+++ b/sigma-workbooks/generated/codex/AGENTS.md
@@ -160,6 +160,14 @@ Load `reference/workflows/discover.md`. Quick summary:
 
 Map the user's request to the **Reference Index** below. State the features you identified, then read the listed reference files before drafting. **If the user asks for a feature this skill doesn't cover**, fetch the OpenAPI and inspect the relevant schema.
 
+If the request includes an input table, writeback, “populate,” “seed,” planning,
+approval, allocation, or exception workflow, load
+`reference/specification/input-tables.md` before choosing an architecture.
+Creating an input-table element, loading initial rows, composing a downstream
+read path, and submitting a runtime action are four different operations. Do
+not substitute actions, unions, or joins for one another when the first
+approach leaves the table empty.
+
 ### Step 5 — Draft the spec to a local file
 
 Write the spec YAML to disk (e.g., `/tmp/workbook-spec.yaml`). YAML is preferred over JSON in this skill — easier to read, diff, and comment for human review. The API accepts either; pick YAML unless something downstream specifically needs JSON. Key rules:
@@ -271,7 +279,7 @@ The reference is feature-sliced — don't read every file up-front. The index ha
 | `reference/specification/kpis.md` | KPI, stat, big number, single value, metric card — including layout / value styling, the comparison Δ badge (`comparisonColumn` + `comparison:{display:"delta"}` — spec-authorable and readback-stable; the house default), and the trend/sparkline block (still UI-bound). |
 | `reference/specification/controls.md` | Filter, dropdown, picker, multi-select, date range, date picker, text filter, number range, slider, segmented, hierarchy, legend, and drill controls. Also entry controls and formula handles. |
 | `reference/specification/content-elements.md` | The non-data elements — `text` (Markdown + inline styling), `image`, `divider`, `embed` (external URLs), `page-break` (PDF/print pagination), `form`, `progress`, `navigation`, `plugin`. Titles, callouts, logos, rules, embedded content. |
-| `reference/specification/input-tables.md` | Operational supplement for `input-table` (spec shape lives in `tables.md`): write-connection requirement, the publish gate, reading data back via warehouse views, element endpoints for auditing, and migration patterns (Excel/planning models). |
+| `reference/specification/input-tables.md` | **Load for every input-table or “populate/seed” request.** Operational supplement for `input-table`: supported row-arrival decision tree, write connection, UI-only published permission, publish gate, linked-key correlation, warehouse views, and why actions/unions/joins are not bulk seeding mechanisms. |
 | `reference/specification/styling.md` | **Load when building a dashboard from scratch.** Design recipe library — vetted color palette, hero header strip, gradient header/KPI cards + composite sparkline, KPI card row, section headers, divider rhythm, categorical chart colors. Turns a default-arrange workbook into a designed-looking one without UI editing. |
 | `reference/specification/agents.md` | Workbook AI agent, chat with your data, agent, chatbot, AI assistant. The workbook-top-level `agents:[]` array + page-level `chat` element; read-only analyst vs. write/action agent; the four `tools[]` kinds (`action`, `mcp-connector`, `warehouse-agent`, `search-service`), `greeting`, `requiresApproval`, why action sequences are referenceable but not authorable; org-feature gate + graceful degrade. |
 
@@ -300,8 +308,13 @@ The reference is feature-sliced — don't read every file up-front. The index ha
 | `reference/workflows/discover.md` | Finding connections, tables, and column names. Load before composing a new spec. |
 | `reference/workflows/composition.md` | Open-ended design decisions — calibrating workbook complexity to the request, when to ask the user, what to ask, surfacing structural choices in the final summary, and a few safe defaults (hidden source pages, ranked-table sort direction). Load before drafting anything when the prompt leaves significant design choices unmade. |
 | `reference/workflows/actions.md` | Buttons, write-back, and **all twelve** action effects — insert/update/delete-rows, clear-control, set-control-value, open/close-overlay (modal **and** drawer), open-url, open-document (incl. passing `targetControls` into another workbook), navigate, select-tab, refresh-element — plus the append-only-log pattern and the masked-error catalog. Load when the user wants a button, a "log/save/submit" action, tab/page navigation, a deep link, or a write-back workflow. |
+| `reference/workflows/planning-apps.md` | **Scenario planning, budgeting, and forecasting apps.** Scenario × Period × Planning Line grain, governed baseline, scenario matrix, linked override grid, financial sign, filter-propagation choices, approval/audit, and runtime gates. |
+| `reference/workflows/allocation-apps.md` | **Allocation and capacity apps.** Budget/target vs. baseline at Period × Allocation Dimension grain, linked editable units/uplifts, working allocation, request queue, and exact variance gates. |
+| `reference/workflows/approval-apps.md` | **Approval and decision apps.** Stable entity-key queues, counter-values, immutable audit logs, one-row status updates, agent boundaries, and runtime tests. |
+| `reference/workflows/exception-apps.md` | **Exception command centers.** Stable operational-key queues, deterministic recommendations, overrides, ownership, resolution logs, and exact KPI-delta tests. |
 | `reference/workflows/crud.md` | POST / GET / PUT against the workbook spec endpoints. Load when creating, retrieving, or updating a workbook. |
-| `reference/workflows/validate.md` | Pre-submit + post-create validation. Load before any POST or PUT. |
+| `reference/workflows/validate.md` | Pre-submit + post-create structural validation. Load before any POST or PUT; for joins, controls, writeback, agents, or numeric claims continue to `runtime-verification.md`. |
+| `reference/workflows/runtime-verification.md` | **Runtime evidence loop:** compile, render, export, cardinality, numeric oracle, published writeback, linked-row correlation, control scope, approval scope, and agent tests. |
 | `reference/workflows/from-image.md` | The user supplied a target image or Claude design artifact to reproduce. Load *before* discovery — it inventories the entire app shell and behavior, routes native Sigma vs plugin/UI-only surfaces, requires a local design manifest, and enforces first-render → diff → final-render acceptance. |
 | `reference/workflows/element-rep.md` | **Large or multi-page workbooks, parallel element work, or iterative refinement.** `scripts/wb-rep.rb` explodes the spec into one small file per element (pull/status/push/render) so edits never drag the whole spec through context — element-level semantics over the whole-spec API, plus PNG renders to inspect what you built. |
 

--- a/sigma-workbooks/generated/continue/sigma-workbooks.md
+++ b/sigma-workbooks/generated/continue/sigma-workbooks.md
@@ -160,6 +160,14 @@ Load `reference/workflows/discover.md`. Quick summary:
 
 Map the user's request to the **Reference Index** below. State the features you identified, then read the listed reference files before drafting. **If the user asks for a feature this skill doesn't cover**, fetch the OpenAPI and inspect the relevant schema.
 
+If the request includes an input table, writeback, “populate,” “seed,” planning,
+approval, allocation, or exception workflow, load
+`reference/specification/input-tables.md` before choosing an architecture.
+Creating an input-table element, loading initial rows, composing a downstream
+read path, and submitting a runtime action are four different operations. Do
+not substitute actions, unions, or joins for one another when the first
+approach leaves the table empty.
+
 ### Step 5 — Draft the spec to a local file
 
 Write the spec YAML to disk (e.g., `/tmp/workbook-spec.yaml`). YAML is preferred over JSON in this skill — easier to read, diff, and comment for human review. The API accepts either; pick YAML unless something downstream specifically needs JSON. Key rules:
@@ -271,7 +279,7 @@ The reference is feature-sliced — don't read every file up-front. The index ha
 | `reference/specification/kpis.md` | KPI, stat, big number, single value, metric card — including layout / value styling, the comparison Δ badge (`comparisonColumn` + `comparison:{display:"delta"}` — spec-authorable and readback-stable; the house default), and the trend/sparkline block (still UI-bound). |
 | `reference/specification/controls.md` | Filter, dropdown, picker, multi-select, date range, date picker, text filter, number range, slider, segmented, hierarchy, legend, and drill controls. Also entry controls and formula handles. |
 | `reference/specification/content-elements.md` | The non-data elements — `text` (Markdown + inline styling), `image`, `divider`, `embed` (external URLs), `page-break` (PDF/print pagination), `form`, `progress`, `navigation`, `plugin`. Titles, callouts, logos, rules, embedded content. |
-| `reference/specification/input-tables.md` | Operational supplement for `input-table` (spec shape lives in `tables.md`): write-connection requirement, the publish gate, reading data back via warehouse views, element endpoints for auditing, and migration patterns (Excel/planning models). |
+| `reference/specification/input-tables.md` | **Load for every input-table or “populate/seed” request.** Operational supplement for `input-table`: supported row-arrival decision tree, write connection, UI-only published permission, publish gate, linked-key correlation, warehouse views, and why actions/unions/joins are not bulk seeding mechanisms. |
 | `reference/specification/styling.md` | **Load when building a dashboard from scratch.** Design recipe library — vetted color palette, hero header strip, gradient header/KPI cards + composite sparkline, KPI card row, section headers, divider rhythm, categorical chart colors. Turns a default-arrange workbook into a designed-looking one without UI editing. |
 | `reference/specification/agents.md` | Workbook AI agent, chat with your data, agent, chatbot, AI assistant. The workbook-top-level `agents:[]` array + page-level `chat` element; read-only analyst vs. write/action agent; the four `tools[]` kinds (`action`, `mcp-connector`, `warehouse-agent`, `search-service`), `greeting`, `requiresApproval`, why action sequences are referenceable but not authorable; org-feature gate + graceful degrade. |
 
@@ -300,8 +308,13 @@ The reference is feature-sliced — don't read every file up-front. The index ha
 | `reference/workflows/discover.md` | Finding connections, tables, and column names. Load before composing a new spec. |
 | `reference/workflows/composition.md` | Open-ended design decisions — calibrating workbook complexity to the request, when to ask the user, what to ask, surfacing structural choices in the final summary, and a few safe defaults (hidden source pages, ranked-table sort direction). Load before drafting anything when the prompt leaves significant design choices unmade. |
 | `reference/workflows/actions.md` | Buttons, write-back, and **all twelve** action effects — insert/update/delete-rows, clear-control, set-control-value, open/close-overlay (modal **and** drawer), open-url, open-document (incl. passing `targetControls` into another workbook), navigate, select-tab, refresh-element — plus the append-only-log pattern and the masked-error catalog. Load when the user wants a button, a "log/save/submit" action, tab/page navigation, a deep link, or a write-back workflow. |
+| `reference/workflows/planning-apps.md` | **Scenario planning, budgeting, and forecasting apps.** Scenario × Period × Planning Line grain, governed baseline, scenario matrix, linked override grid, financial sign, filter-propagation choices, approval/audit, and runtime gates. |
+| `reference/workflows/allocation-apps.md` | **Allocation and capacity apps.** Budget/target vs. baseline at Period × Allocation Dimension grain, linked editable units/uplifts, working allocation, request queue, and exact variance gates. |
+| `reference/workflows/approval-apps.md` | **Approval and decision apps.** Stable entity-key queues, counter-values, immutable audit logs, one-row status updates, agent boundaries, and runtime tests. |
+| `reference/workflows/exception-apps.md` | **Exception command centers.** Stable operational-key queues, deterministic recommendations, overrides, ownership, resolution logs, and exact KPI-delta tests. |
 | `reference/workflows/crud.md` | POST / GET / PUT against the workbook spec endpoints. Load when creating, retrieving, or updating a workbook. |
-| `reference/workflows/validate.md` | Pre-submit + post-create validation. Load before any POST or PUT. |
+| `reference/workflows/validate.md` | Pre-submit + post-create structural validation. Load before any POST or PUT; for joins, controls, writeback, agents, or numeric claims continue to `runtime-verification.md`. |
+| `reference/workflows/runtime-verification.md` | **Runtime evidence loop:** compile, render, export, cardinality, numeric oracle, published writeback, linked-row correlation, control scope, approval scope, and agent tests. |
 | `reference/workflows/from-image.md` | The user supplied a target image or Claude design artifact to reproduce. Load *before* discovery — it inventories the entire app shell and behavior, routes native Sigma vs plugin/UI-only surfaces, requires a local design manifest, and enforces first-render → diff → final-render acceptance. |
 | `reference/workflows/element-rep.md` | **Large or multi-page workbooks, parallel element work, or iterative refinement.** `scripts/wb-rep.rb` explodes the spec into one small file per element (pull/status/push/render) so edits never drag the whole spec through context — element-level semantics over the whole-spec API, plus PNG renders to inspect what you built. |
 

--- a/sigma-workbooks/generated/cursor/rules/sigma-workbooks.mdc
+++ b/sigma-workbooks/generated/cursor/rules/sigma-workbooks.mdc
@@ -165,6 +165,14 @@ Load `reference/workflows/discover.md`. Quick summary:
 
 Map the user's request to the **Reference Index** below. State the features you identified, then read the listed reference files before drafting. **If the user asks for a feature this skill doesn't cover**, fetch the OpenAPI and inspect the relevant schema.
 
+If the request includes an input table, writeback, “populate,” “seed,” planning,
+approval, allocation, or exception workflow, load
+`reference/specification/input-tables.md` before choosing an architecture.
+Creating an input-table element, loading initial rows, composing a downstream
+read path, and submitting a runtime action are four different operations. Do
+not substitute actions, unions, or joins for one another when the first
+approach leaves the table empty.
+
 ### Step 5 — Draft the spec to a local file
 
 Write the spec YAML to disk (e.g., `/tmp/workbook-spec.yaml`). YAML is preferred over JSON in this skill — easier to read, diff, and comment for human review. The API accepts either; pick YAML unless something downstream specifically needs JSON. Key rules:
@@ -276,7 +284,7 @@ The reference is feature-sliced — don't read every file up-front. The index ha
 | `reference/specification/kpis.md` | KPI, stat, big number, single value, metric card — including layout / value styling, the comparison Δ badge (`comparisonColumn` + `comparison:{display:"delta"}` — spec-authorable and readback-stable; the house default), and the trend/sparkline block (still UI-bound). |
 | `reference/specification/controls.md` | Filter, dropdown, picker, multi-select, date range, date picker, text filter, number range, slider, segmented, hierarchy, legend, and drill controls. Also entry controls and formula handles. |
 | `reference/specification/content-elements.md` | The non-data elements — `text` (Markdown + inline styling), `image`, `divider`, `embed` (external URLs), `page-break` (PDF/print pagination), `form`, `progress`, `navigation`, `plugin`. Titles, callouts, logos, rules, embedded content. |
-| `reference/specification/input-tables.md` | Operational supplement for `input-table` (spec shape lives in `tables.md`): write-connection requirement, the publish gate, reading data back via warehouse views, element endpoints for auditing, and migration patterns (Excel/planning models). |
+| `reference/specification/input-tables.md` | **Load for every input-table or “populate/seed” request.** Operational supplement for `input-table`: supported row-arrival decision tree, write connection, UI-only published permission, publish gate, linked-key correlation, warehouse views, and why actions/unions/joins are not bulk seeding mechanisms. |
 | `reference/specification/styling.md` | **Load when building a dashboard from scratch.** Design recipe library — vetted color palette, hero header strip, gradient header/KPI cards + composite sparkline, KPI card row, section headers, divider rhythm, categorical chart colors. Turns a default-arrange workbook into a designed-looking one without UI editing. |
 | `reference/specification/agents.md` | Workbook AI agent, chat with your data, agent, chatbot, AI assistant. The workbook-top-level `agents:[]` array + page-level `chat` element; read-only analyst vs. write/action agent; the four `tools[]` kinds (`action`, `mcp-connector`, `warehouse-agent`, `search-service`), `greeting`, `requiresApproval`, why action sequences are referenceable but not authorable; org-feature gate + graceful degrade. |
 
@@ -305,8 +313,13 @@ The reference is feature-sliced — don't read every file up-front. The index ha
 | `reference/workflows/discover.md` | Finding connections, tables, and column names. Load before composing a new spec. |
 | `reference/workflows/composition.md` | Open-ended design decisions — calibrating workbook complexity to the request, when to ask the user, what to ask, surfacing structural choices in the final summary, and a few safe defaults (hidden source pages, ranked-table sort direction). Load before drafting anything when the prompt leaves significant design choices unmade. |
 | `reference/workflows/actions.md` | Buttons, write-back, and **all twelve** action effects — insert/update/delete-rows, clear-control, set-control-value, open/close-overlay (modal **and** drawer), open-url, open-document (incl. passing `targetControls` into another workbook), navigate, select-tab, refresh-element — plus the append-only-log pattern and the masked-error catalog. Load when the user wants a button, a "log/save/submit" action, tab/page navigation, a deep link, or a write-back workflow. |
+| `reference/workflows/planning-apps.md` | **Scenario planning, budgeting, and forecasting apps.** Scenario × Period × Planning Line grain, governed baseline, scenario matrix, linked override grid, financial sign, filter-propagation choices, approval/audit, and runtime gates. |
+| `reference/workflows/allocation-apps.md` | **Allocation and capacity apps.** Budget/target vs. baseline at Period × Allocation Dimension grain, linked editable units/uplifts, working allocation, request queue, and exact variance gates. |
+| `reference/workflows/approval-apps.md` | **Approval and decision apps.** Stable entity-key queues, counter-values, immutable audit logs, one-row status updates, agent boundaries, and runtime tests. |
+| `reference/workflows/exception-apps.md` | **Exception command centers.** Stable operational-key queues, deterministic recommendations, overrides, ownership, resolution logs, and exact KPI-delta tests. |
 | `reference/workflows/crud.md` | POST / GET / PUT against the workbook spec endpoints. Load when creating, retrieving, or updating a workbook. |
-| `reference/workflows/validate.md` | Pre-submit + post-create validation. Load before any POST or PUT. |
+| `reference/workflows/validate.md` | Pre-submit + post-create structural validation. Load before any POST or PUT; for joins, controls, writeback, agents, or numeric claims continue to `runtime-verification.md`. |
+| `reference/workflows/runtime-verification.md` | **Runtime evidence loop:** compile, render, export, cardinality, numeric oracle, published writeback, linked-row correlation, control scope, approval scope, and agent tests. |
 | `reference/workflows/from-image.md` | The user supplied a target image or Claude design artifact to reproduce. Load *before* discovery — it inventories the entire app shell and behavior, routes native Sigma vs plugin/UI-only surfaces, requires a local design manifest, and enforces first-render → diff → final-render acceptance. |
 | `reference/workflows/element-rep.md` | **Large or multi-page workbooks, parallel element work, or iterative refinement.** `scripts/wb-rep.rb` explodes the spec into one small file per element (pull/status/push/render) so edits never drag the whole spec through context — element-level semantics over the whole-spec API, plus PNG renders to inspect what you built. |
 

--- a/sigma-workbooks/reference/specification/input-tables.md
+++ b/sigma-workbooks/reference/specification/input-tables.md
@@ -24,13 +24,18 @@ table, and a data model can read it through a warehouse view.
    fails with the generic **`Invalid kind: "input-table"`**, which reads like
    the element kind itself is rejected. If you hit that error on an
    input-table, check `inputMode` first before suspecting anything else about
-   the shape.
-3. **Data lands in `SIGDS_`-prefixed tables** in the connection's write schema.
+   the shape. `inputMode` does not enable published-view data entry.
+3. **Published data entry is a UI-only element setting.** Use *kebab → Set
+   data entry permission → Only in published version*. The default is “Only in
+   draft.” The setting is absent from `GET /spec`, so Code Rep cannot set or
+   inspect it. Until flipped, a published cell can take selection but silently
+   swallow keystrokes.
+4. **Data lands in `SIGDS_`-prefixed tables** in the connection's write schema.
    Don't query or modify those directly — see "Reading the data" below.
-4. **Data is invisible until Publish.** A query of an input table before the
+5. **Data is invisible until Publish.** A query of an input table before the
    workbook is published returns **0 rows** — the query layer reads the
    published version. Publish, then re-query.
-5. **System columns take no `type`** (`ID`, `CREATED_AT`, `CREATED_BY`,
+6. **System columns take no `type`** (`ID`, `CREATED_AT`, `CREATED_BY`,
    `UPDATED_AT`, `UPDATED_BY`) — adding one breaks the column. They're also
    never included in an `insert-rows` action effect's `values` — Sigma
    auto-fills them at insert time (see `reference/workflows/actions.md`).
@@ -91,6 +96,42 @@ columns misbehave, suspect an older org/API first.
 mutually exclusive on a column (combining them 400s). Still UI-only: **column
 protection** and **data-entry permissions**.
 
+## Choose how rows arrive before composing the workbook
+
+Creating an input-table element and populating it are different operations.
+Code Rep defines the table's structure; it is not a general bulk row-loading
+API. Route the requirement before adding actions, unions, or joins:
+
+| Requirement | Supported pattern |
+|---|---|
+| User starts with a blank table and enters rows | Empty input table; type, paste, or upload through Sigma |
+| Existing governed rows need editable fields beside them | Linked input table with stable parent key bindings |
+| A file must pre-populate the table | CSV upload through Sigma's supported UI flow |
+| A user submits one record from controls | Empty input table + `insert-rows` action |
+| Baseline data plus sparse planning changes | Governed baseline + linked/empty override input table; calculate the working result downstream |
+| Automated initial or bulk load | Load through a supported warehouse/Sigma ingestion path, then expose it to the workbook |
+
+**Unions, joins, and lookups do not populate an input table.** They compose a
+read path. Use them after the write surface exists—for example to combine a
+governed baseline with overrides—not as retries when the input table is empty.
+
+**Actions are not a seeding mechanism.** `insert-rows` is appropriate when a
+user intentionally submits a record, such as a note, request, or scenario
+header. Do not generate hundreds of button effects to initialize planning
+grain.
+
+If the request says only “populate the input table,” establish these facts
+before building:
+
+1. desired row grain and expected row count;
+2. whether rows already exist in a governed source;
+3. whether users edit whole rows or sparse override columns;
+4. one-time file load versus ongoing interactive entry;
+5. whether UI loading or warehouse loading is acceptable.
+
+For scenario planning, allocation, approval, or exception workflows, load the
+matching app recipe in `../workflows/` before choosing the table shape.
+
 ## Reading an input table's data & structure
 
 `SIGDS_` write-back tables aren't directly queryable. To read the data, create a
@@ -114,3 +155,7 @@ GET /v2/workbooks/{workbookId}/elements/{elementId}/columns
 For data-entry migrations (Excel/planning models) the end-to-end pattern is
 input table → publish → warehouse view → data model `FROM` that view. The
 `excel-to-sigma` skill covers it in depth.
+
+For a scenario planning app, do not stop at “add an input table.” Load
+`../workflows/planning-apps.md`; it defines the scenario grain, baseline,
+writeback, control scope, and runtime tests.

--- a/sigma-workbooks/reference/specification/tables.md
+++ b/sigma-workbooks/reference/specification/tables.md
@@ -181,11 +181,22 @@ Condition operators include `=`, `!=`, `>`, `>=`, `<`, `<=`, `IsNull`, `IsNotNul
 
 The `input-table` element is an editable table — users type values directly into cells, backed by a provisioned warehouse table. Required fields: `id`, `kind`, `source`, `inputMode`.
 
-`inputMode` controls who can edit and where:
+`inputMode` is required and accepts `edit`, `explore`, or `view`. It does
+**not** decide whether users can type into the published workbook.
 
-- `edit` — workbook editors only, in draft mode
-- `explore` — users with explore permission or greater, in published view
-- `view` — all users, in published view
+Published data entry is a separate UI-only setting on each input table:
+
+```text
+element kebab → Set data entry permission
+              → Only in draft              # default
+              → Only in published version
+```
+
+Live verification found that all three `inputMode` values remained inert in
+published view while the permission stayed at its default. Flipping one table
+made only that table editable, while `GET /spec` stayed byte-identical. Code
+Rep therefore cannot set or inspect this permission. Every spec-built
+writeback app needs this manual step per input table before handoff.
 
 `source` is one of:
 
@@ -230,3 +241,8 @@ columns:
 ```
 
 `input-table` also supports `filters`, `conditionalFormats` (see above), `sort`, `summary`, and the styled title-section `name`/`noDataText`. Fetch the full schema with the `kind`-form recipe at the top of this doc.
+
+Creating this element defines its structure; it does not bulk-populate rows.
+For the supported population decision tree—and why unions, joins, and actions
+are not interchangeable seeding strategies—read `input-tables.md` before
+building a writeback workflow.

--- a/sigma-workbooks/reference/workflows/actions.md
+++ b/sigma-workbooks/reference/workflows/actions.md
@@ -123,14 +123,53 @@ control: RegionFilter
 value: { type: constant, value: { type: text, value: "West" } }
 ```
 
-The only verified `value` shape is a constant text value (e.g. a "quick filter
-preset" button). Useful paired with a `list`/`segmented` control to give users a
-one-click shortcut into a known filter state.
+The only verified `value` shape is a constant text value (e.g. a quick-filter
+preset or `""` to blank a wizard field). Useful paired with a
+`list`/`segmented` control to give users a one-click shortcut into a known
+filter state.
 
 An action-agent step is a separate host: `/verify` also accepts
 `value: { type: agent-input, inputName: <name> }` there. That proves the step
 shape only; it does not prove that the agent will invoke it or that the control
 will accept the supplied value at runtime.
+
+### Resetting a create wizard after it writes
+
+A new-record modal keeps its control values after the row is inserted. Reset
+the fields on the same button, ordered after `insert-rows` because the write
+reads those controls:
+
+```yaml
+effects:
+  - effect: insert-rows
+    table: scenarios
+    values:
+      name:  { type: control, control: newName }
+      owner: { type: control, control: newOwner }
+  - effect: set-control-value
+    control: newName
+    value: { type: constant, value: { type: text, value: "" } }
+  - effect: set-control-value
+    control: newStrategy
+    value: { type: constant, value: { type: text, value: "Baseline" } }
+  - effect: close-overlay
+```
+
+Do not use page-scoped `clear-control` for this. Overlay content lives in flat
+`document.elements`; page scope resolves to the host page and can clear
+unrelated controls such as an active-scenario selector. Use per-control,
+constant `set-control-value` effects, then close the overlay last.
+
+Click the deployed button once and prove both outcomes: the row landed and the
+fields reset. Readback proves only that the effect shapes persisted.
+
+### Actions write workflow events; they do not bulk-populate tables
+
+Use `insert-rows` for deliberate runtime submissions—a note, request, scenario
+header, or audit event. It is not a supported initial-load mechanism for a
+planning grid or imported dataset. A union or join also cannot write rows; it
+only composes a downstream read path. Route row creation through
+`../specification/input-tables.md` before authoring actions.
 
 ## Overlays: `open-overlay` / `close-overlay` (modal **and** drawer)
 
@@ -393,7 +432,7 @@ to capture what the user types, and a **button** that inserts a row.
 #    insert-rows `values` above; doing so breaks the column.
 - id: annotations
   kind: input-table
-  inputMode: edit
+  inputMode: view # required; published editing is a separate UI-only setting
   source: { kind: empty, connectionId: <WRITE_CONNECTION_ID> }
   columns:
     - id: an-note
@@ -416,7 +455,7 @@ listed cause **first** before assuming the element kind itself is unsupported.
 
 | Error | Real cause | Fix |
 |---|---|---|
-| `Invalid kind: "input-table"` | `inputMode` was omitted. | Always set `inputMode: edit` (or `explore`/`view` — see `input-tables.md`). It's technically documented as required in `tables.md`, but omitting it produces this generic message rather than a field-specific one. |
+| `Invalid kind: "input-table"` | `inputMode` was omitted. | Always set `inputMode` (`view` is a safe structural default). It does not enable published editing; that is the UI-only “Set data entry permission” setting in `input-tables.md`. |
 | `Invalid kind: "control"` (on a `text`/`text-area` control used for **entry**, not filtering) | One or more of `mode`, `case`, `includeNulls`, `showOperators` was omitted. | Set all four — see `controls.md`'s "Entry (write) text controls" section. |
 | Button silently does nothing on click | An element/container-scoped `clear-control`. | Use `scope: { type: page, page: <id> }` only (see above). |
 | `document.pages[0]: Invalid type: "page"` | An invalid entry in some element's `columns[]` — e.g. trying to author a row-action `kind: button` as an input-table column. The mismatch is reported against the **page** schema, not the offending column. | Check the `columns[]` you last touched, not the page `type`. Row-scoped action hosts aren't spec-authorable (see `delete-rows` / `current-row` above). |
@@ -429,12 +468,13 @@ listed cause **first** before assuming the element kind itself is unsupported.
 
 - `scripts/lib/actions.rb` — `Actions.button(id:, text:, effects:,
   appearance:)`, `Actions.input_table_empty(id:, connection_id:, columns:,
-  name:)`, `Actions.input_table_linked(id:, from:, connection_id:, columns:,
-  name:)`, and the three effect builders `Actions.insert_rows_effect(table:,
+  name:, input_mode:)`, `Actions.input_table_linked(id:, from:,
+  connection_id:, columns:, name:, input_mode:)`, and the three effect builders `Actions.insert_rows_effect(table:,
   values:)` / `Actions.clear_control_effect(page:)` /
   `Actions.set_control_value_effect(control:, text:)` build exactly the shapes
-  above (`inputMode: "edit"` always emitted; `clear_control_effect` only ever
-  emits page scope). Gated behind `Actions::SURFACES`; a NO-GO flip returns
+  above (`inputMode: "view"` by default with explicit `edit`/`explore`
+  overrides; `clear_control_effect` only ever emits page scope). Gated behind
+  `Actions::SURFACES`; a NO-GO flip returns
   `{opt_in: true, id:}` (element builders) or `{}` (effect builders) rather than
   a faked shape. **The nine effects in *Navigation, refresh, and row-editing
   effects* have no builder yet** — hand-author those shapes (they're verified,

--- a/sigma-workbooks/reference/workflows/allocation-apps.md
+++ b/sigma-workbooks/reference/workflows/allocation-apps.md
@@ -1,0 +1,83 @@
+# Allocation and capacity apps
+
+Use this pattern when the source contains:
+
+- Budget / Target / Quota / Capacity measures;
+- Actual / Current / Baseline measures;
+- a dimension across which values can be allocated (Department, Team, Region,
+  Territory, Channel, Role);
+- usually a period grain.
+
+Examples include workforce planning, marketing budget allocation, quota and
+territory planning, and capacity assignment.
+
+## Grain
+
+The typical editable grain is:
+
+```text
+Period × Allocation Dimension
+```
+
+Add Scenario if multiple plans coexist. Add Role, Product, or Channel only when
+users need to edit at that lower grain and uniqueness is proven.
+
+## Architecture
+
+1. **Baseline** — actual/current capacity and governed budget or target.
+2. **Linked allocation grid** — baseline context as stable keys; editable
+   units, uplift, override, and rationale.
+3. **Working allocation** — calculated result and variance.
+4. **Optional request queue** — hiring or reallocation requests.
+5. **Decision log** — approvals separated from the editable plan.
+
+Workforce example:
+
+```text
+Plan Headcount = Baseline Headcount + Added Hires
+
+Plan Cost =
+  Baseline Loaded Cost × (1 + Cost Uplift %)
+  + Added Hires × Monthly Loaded Cost per Hire
+
+Vs Budget = Plan Cost - Budget
+```
+
+Use precise labels: a row-level percentage is an uplift to that row, not a
+compounding growth driver.
+
+## Row population
+
+Do not seed this grid with an `insert-rows` button. Build the governed
+`Period × Allocation Dimension` baseline, then link editable columns to its
+stable keys. If the source cannot provide that grain, establish it through a
+supported Sigma UI or warehouse load before building the app.
+
+## Scope
+
+Keep the editable all-dimension grid complete. If a dashboard control filters
+that grid, every descendant KPI inherits the filter. Scope selected views by
+formula or provide an independent all-scope lineage for comparisons.
+
+## Agent
+
+The agent should explain:
+
+- which dimension has highest plan cost or capacity;
+- whether variance comes from baseline underfunding or added units;
+- concentration and timing;
+- tradeoffs of a proposed allocation.
+
+## Runtime gates
+
+- no-edit plan equals baseline;
+- expected grid rows equal periods × allocation members;
+- added units affect quantity by the exact amount;
+- uplift and unit additions both contribute correctly;
+- variance equals plan minus budget or target;
+- year-end KPI sums the target month across dimensions, not `Max` of one
+  dimension;
+- approval/log action persists;
+- agent separates structural baseline variance from new allocation changes.
+
+Enable published data entry on every input table in the UI before handoff.

--- a/sigma-workbooks/reference/workflows/approval-apps.md
+++ b/sigma-workbooks/reference/workflows/approval-apps.md
@@ -1,0 +1,80 @@
+# Approval apps — decision queue and audit workflow
+
+Use this pattern when the source contains:
+
+- a stable entity key (Deal ID, Request ID, Case ID, Order ID);
+- decision-state members such as Pending / Approved / Rejected;
+- an aging, SLA, policy tier, threshold, or approval band;
+- a reviewer, owner, or assignee dimension.
+
+The source proves that an approval queue exists. The write path is an
+enhancement, so ask what decisions users should be allowed to make.
+
+## Grain
+
+```text
+one editable row per entity key
+```
+
+Never key on mutable status, reviewer, or policy tier. Bind those as inherited
+context if needed, but keep the entity key stable.
+
+## Architecture
+
+1. **Governed directory** — read-only source rows with entity, submitted value,
+   policy context, current status, and age.
+2. **Linked review input table** — entity key and submitted context plus
+   editable Decision, Counter Value, Reviewer, and Decision Note.
+3. **Computed outcome** — approved/counter value and business impact.
+4. **Append-only decision log** — entity, decision, note, author, timestamp.
+5. **Optional status update** — update the selected entity only.
+
+Example counter calculation:
+
+```text
+Approved Net =
+  List Amount × (1 - Coalesce(Approved Discount, Submitted Discount))
+
+Revenue Impact = Approved Net - Submitted Net
+```
+
+## Row population
+
+The governed entity directory supplies the queue grain. Link editable decision
+fields to its stable key. Do not recreate source entities through one action
+per row, and do not expect a union or join to write them into the input table.
+
+## Action pattern
+
+One click can perform two distinct writes:
+
+```text
+insert immutable audit row
++ update selected entity status
+```
+
+The `whichRows` formula must use the stable entity key:
+
+```text
+[Deal ID] = [dealControl]
+```
+
+Test that a second entity remains unchanged.
+
+## Agent
+
+Give the agent the directory, editable review queue, and decision log. It
+should prioritize by policy breach, value at risk, and age. It must not claim a
+decision was written unless the user approved the action.
+
+## Runtime gates
+
+- queue row count and key uniqueness match the governed directory;
+- published edit accepts a counter value;
+- calculated outcome and impact tie arithmetically;
+- KPI changes by the exact impact;
+- log row includes entity, decision, comment, user, and timestamp;
+- status update affects one entity only;
+- agent names the correct highest-risk pending entity.
+
+Apply the input-table published-data-entry permission manually before handoff.

--- a/sigma-workbooks/reference/workflows/exception-apps.md
+++ b/sigma-workbooks/reference/workflows/exception-apps.md
@@ -1,0 +1,72 @@
+# Exception apps — operational triage and resolution
+
+Use this pattern when the source contains:
+
+- a stable operational key (SKU, Account ID, Job ID, Ticket ID);
+- exception/risk members or a threshold boolean;
+- urgency, aging, coverage, variance, or severity measures;
+- enough context to recommend an action.
+
+Examples include inventory replenishment, data-quality exceptions, SLA
+breaches, reconciliation breaks, and anomaly review.
+
+## Grain
+
+```text
+one editable row per operational entity
+```
+
+If one entity can have multiple simultaneous exceptions, add Exception Type or
+Observation Date to the composite key.
+
+## Architecture
+
+1. **Exception directory** — governed source context and source-derived flag.
+2. **Linked action queue** — stable key/context plus editable Decision,
+   Override, Owner, and Resolution Note.
+3. **Recommended action** — deterministic formula from source policy.
+4. **Final action** — user override or recommendation.
+5. **Resolution log** — append-only action evidence.
+
+Inventory example:
+
+```text
+Suggested Order =
+  If(Reorder Point - On Hand - On Order > 0,
+     Reorder Point - On Hand - On Order,
+     0)
+
+Final Order = Coalesce(Override Order Qty, Suggested Order)
+Order Value = Final Order × Unit Cost
+```
+
+Do not label a recommendation “AI” when it is a policy formula. The workbook
+agent can explain and prioritize it; the calculation itself remains auditable.
+
+## Row population
+
+The source directory supplies the entity grain. Link the action queue to stable
+keys and store only user-entered decisions or overrides. Actions append
+resolution events; they do not initialize the queue. Unions and joins may
+compose the read model but cannot populate the input table.
+
+## Agent
+
+The agent should:
+
+- rank unresolved exceptions by urgency and business impact;
+- notice actions already recorded and avoid recommending them again;
+- distinguish source risk from the user-entered resolution;
+- require approval for action tools.
+
+## Runtime gates
+
+- action-queue row count and key uniqueness match the exception directory;
+- recommendation ties to source fields;
+- override replaces the recommendation;
+- KPI changes by the exact override delta, even if display rounding hides it;
+- resolution log persists with author and timestamp;
+- already-resolved items are excluded or deprioritized by the agent;
+- positive/negative or urgent/healthy formatting renders correctly.
+
+Apply published-data-entry permission manually to both action queue and log.

--- a/sigma-workbooks/reference/workflows/planning-apps.md
+++ b/sigma-workbooks/reference/workflows/planning-apps.md
@@ -1,0 +1,279 @@
+# Planning apps — scenario-grain writeback pattern
+
+Use this pattern when a workbook is a model rather than only a report: actual
+periods followed by forecast periods, assumption tables, budget/scenario
+vocabulary, manual forecast cells, or review and approval.
+
+Do not turn every dashboard into a planning app. Establish the requested mode:
+
+1. **One working plan** — one editable forecast, no scenario comparison.
+2. **Scenario planning** — isolated scenario copies, comparison, and status.
+3. **Variance workflow** — actual-vs-plan annotations and approvals, without
+   editable forecast values.
+4. **Parity only** — preserve the verified analytical workbook.
+
+The architecture below is for scenario planning.
+
+## Non-negotiable grain
+
+The editable table must have one row per:
+
+```text
+Scenario × Period × Planning Line
+```
+
+For an FP&A P&L this is usually:
+
+```text
+Scenario × Month × Line Item
+```
+
+A scenario metadata table alone is not scenario planning. If scenarios share
+one plan grid, switching the selector changes only a label; every scenario
+still edits the same values.
+
+Write and later verify:
+
+```text
+expected rows = scenarios × forecast periods × planning lines
+```
+
+## Four-layer architecture
+
+### 1. Governed baseline
+
+Create a read-only table at forecast grain with stable context and the source
+model's governed baseline:
+
+```yaml
+name: Plan Base
+columns:
+  - { id: pb-period,  formula: "[Source/Month]",     name: Month }
+  - { id: pb-line,    formula: "[Source/Line Item]", name: Line Item }
+  - { id: pb-section, formula: "[Source/Section]",   name: Section }
+  - { id: pb-base,    formula: "<driver formula>",   name: Baseline }
+  - { id: pb-key,     formula: "1",                  name: Join Key }
+```
+
+Preserve the source semantics: compounding drivers compound, manual lines stay
+manual, and flat lines stay flat. Prove baseline parity before writeback.
+
+### 2. Scenario directory
+
+Use an empty input table for scenario metadata:
+
+```yaml
+id: scenarios
+kind: input-table
+inputMode: view
+name: Scenarios
+source: { kind: empty, connectionId: <write connection> }
+columns:
+  - { id: ID }
+  - { id: sc-name,   type: text, name: Scenario Name }
+  - { id: sc-status, type: text, name: Status,
+      values: [Draft, In Review, Approved], pills: color-by-option }
+  - { id: sc-owner,  type: text, name: Owner }
+  - { id: sc-notes,  type: text, name: Notes }
+```
+
+Creating one scenario is an appropriate `insert-rows` action. Creating every
+scenario-period-line row through actions is not.
+
+Scenario strategy is descriptive unless explicit formulas implement it. Never
+give scenarios different labels but identical math and imply the labels changed
+the forecast.
+
+### 3. Scenario matrix
+
+Cross-join scenario rows to baseline rows with a constant key:
+
+```yaml
+name: Plan Matrix
+source:
+  kind: join
+  name: Plan Matrix
+  primarySource: { kind: table, elementId: scenario-directory }
+  joins:
+    - name: Base
+      joinType: inner
+      left:  { kind: table, elementId: scenario-directory }
+      right: { kind: table, elementId: plan-base }
+      columns:
+        - { left: "[Join Key]", right: "[Join Key]" }
+```
+
+The join composes the required row grain; it does not populate the input table.
+Verify:
+
+```text
+matrix rows = scenarios × baseline rows
+```
+
+If empty, inspect formula prefixes and ensure both constant keys share a type.
+
+### 4. Linked plan grid
+
+Link editable fields to the scenario matrix:
+
+```yaml
+id: plan-grid
+kind: input-table
+inputMode: view
+name: Plan Grid
+source:
+  kind: linked
+  from: plan-matrix
+  connectionId: <write connection>
+columns:
+  - { id: pg-scenario, key: mx-scenario, name: Scenario }
+  - { id: pg-period,   key: mx-period,   name: Period }
+  - { id: pg-line,     key: mx-line,     name: Planning Line }
+  - { id: pg-section,  key: mx-section,  name: Section }
+  - { id: pg-baseline, key: mx-baseline, name: Baseline }
+  - { id: pg-method, type: text, name: Method,
+      values: ["Uplift %", "Adjust $", "Set amount"] }
+  - { id: pg-percent, type: number, name: Uplift % }
+  - { id: pg-dollars, type: number, name: Dollar Change }
+  - { id: pg-new,     type: number, name: New Amount }
+  - { id: pg-plan,   formula: "<method switch>", name: Plan Amount }
+  - { id: pg-delta,  formula: "[Plan Amount] - [Baseline]", name: Plan Delta }
+  - { id: pg-impact, formula: "<signed delta>", name: Profit Impact }
+  - { id: pg-note, type: text, name: Rationale }
+```
+
+Bind inherited context as `{id, key}` columns. Cross-element formula columns
+can render “multiple values” even after a successful POST/readback. Query rows
+after data lands and prove each key resolves to one parent row.
+
+Keys are immutable once the linked table exists. Key only deterministic, stable
+context:
+
+- good: scenario, period, planning line, section, governed baseline;
+- bad: status, owner, current user, `Now()`, volatile lookup, approval state.
+
+## Override semantics
+
+Use labels that match the math. A row-level:
+
+```text
+Baseline × (1 + 10%)
+```
+
+is a 10% uplift to that row, not a monthly growth rate that compounds into
+future periods.
+
+```text
+If Method = "Uplift %":
+  Baseline × (1 + Uplift %)
+Else if Method = "Adjust $":
+  Baseline + Dollar Change
+Else if Method = "Set amount":
+  New Amount
+Else:
+  Baseline
+```
+
+Blank method means governed baseline. Do not pre-populate fake methods merely
+to make the grid look active.
+
+## Financial sign
+
+P&L expense rows commonly store positive magnitudes, so raw delta is not
+favorability:
+
+```text
+Plan Delta = Plan Amount - Baseline
+
+Profit Impact =
+  If Section = "Revenue":
+    Plan Delta
+  Else:
+    -Plan Delta
+```
+
+Revenue +10 is favorable; expense +10 is unfavorable. Color Profit Impact,
+not Plan Delta. If a conditional format that references its own formula column
+silently no-ops, repeat the underlying expression in the condition and render
+both positive and negative fixtures.
+
+## Scenario selection and filter propagation
+
+Any control filter attached to the plan grid propagates to all descendants.
+Choose one design explicitly:
+
+### Option A — complete grid, formula-scoped analytics
+
+Do not target the grid with the scenario control. Sort by scenario and scope
+selected analytics with formulas:
+
+```text
+Sum(If([Scenario] = [scenarioControl], [Amount], 0))
+```
+
+All-scenario comparisons remain intact, but the editable grid shows all
+scenarios.
+
+### Option B — filtered grid, independent all-scenario read path
+
+Filter the grid to the active scenario. This improves editing but every
+descendant loses unselected rows. Formula-scoped KPIs remain correct; a chart
+intended to compare every scenario collapses to one.
+
+Put all-scenario visuals on a lineage that does not descend from the filtered
+grid, such as a supported warehouse view/read path, or replace them with an
+active-scenario comparison. Never leave a one-bar “all scenarios” chart.
+
+## Approval and audit
+
+Approval requires two writes:
+
+1. append an immutable decision row;
+2. update only the selected scenario's status.
+
+Use the stable scenario key in `whichRows`, and prove another scenario remains
+unchanged. Reset modal controls with ordered `set-control-value` effects after
+the insert; see `actions.md`.
+
+## Agent contract
+
+Give the agent the selected plan ledger, all-scenario comparison, plan grid,
+scenario directory, and decision log. Instruct it to:
+
+- distinguish actual, baseline, and selected plan;
+- compare only scenario-keyed rows;
+- use Profit Impact rather than raw Plan Delta for favorability;
+- never claim a write occurred unless the user approved the action.
+
+Validate with a question whose answer is known from an entered override.
+
+## Manual published-view gate
+
+Code Rep cannot enable published data entry. For every input table:
+
+```text
+element kebab → Set data entry permission → Only in published version
+```
+
+Publish and type in a real cell. The setting is absent from `GET /spec`.
+
+## Required verification
+
+POST/readback proves structure only. Before handoff, capture:
+
+| Gate | Evidence |
+|---|---|
+| Baseline parity | source-vs-Sigma periods and totals |
+| Matrix cardinality | scenarios × baseline rows |
+| Key correlation | one parent row per linked row |
+| Scenario isolation | edit A; B stays baseline; A persists |
+| Financial sign | revenue increase positive; expense increase negative |
+| Selected KPI scope | active scenario changes; unselected edits excluded |
+| Grid scope | matches declared Option A or B |
+| All-scenario scope | every scenario remains where comparison is promised |
+| Approval scope | selected status changes; another does not |
+| Audit | time, user, scenario, decision, and comment persist |
+| Published writeback | real edit succeeds outside draft |
+| Visual | rendered pages contain no errors or misleading totals |
+
+Load `runtime-verification.md` for the full evidence loop.

--- a/sigma-workbooks/reference/workflows/runtime-verification.md
+++ b/sigma-workbooks/reference/workflows/runtime-verification.md
@@ -1,0 +1,205 @@
+# Runtime verification — evidence beyond a successful POST
+
+Use this after any non-trivial workbook build, especially joins, unions,
+controls, input tables, actions, agents, or dynamic text.
+
+A successful verify, POST, and readback proves only that the server accepted
+the representation. It does not prove that:
+
+- formulas compile or render;
+- a join has the intended cardinality;
+- a control preserves required descendant rows;
+- linked input-table keys correlate to one parent row;
+- actions update only the intended rows;
+- users can edit the published workbook;
+- charts and KPIs tell the numeric truth.
+
+Treat verification as an evidence loop:
+
+```text
+spec verify → write → readback diff → compile → render → export
+→ cardinality and semantic assertions → published interaction → evidence
+```
+
+## 1. Structural gates
+
+```bash
+ruby scripts/wb-rep.rb verify workbook.yaml
+ruby scripts/wb-rep.rb push <rep-dir>
+ruby scripts/wb-rep.rb pull <workbook-id> <readback-dir>
+./scripts/verify-workbook.sh <workbook-id>
+```
+
+Compare submitted and readback documents:
+
+- no field silently disappeared;
+- future writes use server-generated source/formula prefixes;
+- every element has exactly one layout placement;
+- agents, overlays, controls, actions, and theme survived;
+- no input-table key changed.
+
+Do not normalize away a meaningful dropped field.
+
+## 2. Render every affected page
+
+```bash
+ruby scripts/wb-rep.rb render <rep-dir>
+ruby scripts/wb-rep.rb render <rep-dir> --page "Workspace"
+```
+
+Inspect the PNG for:
+
+- `Invalid Query`, unknown-column, or invalid-argument messages;
+- clipped titles, controls, legends, columns, and buttons;
+- empty visuals that should have rows;
+- misleading scales, totals, stacking, or waterfall semantics;
+- unexpected font fallback;
+- a KPI that changed after adding a view-only filter.
+
+Dynamic text can POST and compile while rendering an error string.
+
+## 3. Export data-bearing elements
+
+```http
+POST /v2/workbooks/{workbookId}/export
+Content-Type: application/json
+
+{
+  "elementId": "<element-id>",
+  "format": { "type": "csv" }
+}
+```
+
+Poll the returned query ID:
+
+```http
+GET /v2/query/{queryId}/download
+```
+
+Export every governed base table, transformed table whose grain matters,
+editable input table after real rows exist, selected ledger, all-scope
+comparison source, and KPI/pivot used in a numeric claim.
+
+PNG answers what rendered. CSV answers which rows and values fed it. Both are
+required.
+
+## 4. Cardinality and uniqueness
+
+Write expected row counts before testing:
+
+```text
+union rows = source A rows + source B rows
+scenario matrix = scenarios × baseline rows
+selected scenario = one scenario × baseline rows
+```
+
+Export parent and child at the same instant. If an expected 180-row descendant
+has 60 rows, inspect upstream control filters before rewriting joins or charts.
+Filters propagate through every descendant.
+
+Also assert uniqueness at the declared grain:
+
+```text
+CountDistinct(Scenario, Period, Planning Line) = row count
+```
+
+Duplicates usually indicate a join-key problem. Missing rows usually indicate
+a filter or inner-join problem.
+
+## 5. Numeric oracle
+
+Choose source facts covering every major measure, period boundaries, subtotal
+and margin formulas, positive and negative values, and at least one manual and
+one driver-derived value.
+
+Diff source and Sigma at native precision and report:
+
+```text
+checked N cells, mismatches M
+```
+
+Two rounded KPI cards displaying the same value are not parity evidence.
+
+## 6. Writeback semantics
+
+Run tests in the published view, not only draft.
+
+### Published permission
+
+Set each input table manually:
+
+```text
+element kebab → Set data entry permission → Only in published version
+```
+
+Publish and type into a real cell. This setting is absent from Code Rep.
+
+### Linked-row correlation
+
+After real rows exist, query/export the linked table. Confirm every inherited
+key resolves to exactly one parent row; structural readback cannot detect
+“multiple values” at runtime.
+
+### Scenario isolation
+
+1. Edit scenario A and record baseline, plan, and impact.
+2. Switch to B; the same grain should remain baseline.
+3. Switch back; A's edit should persist.
+
+### Approval scope
+
+Approve one entity/scenario. Confirm its status changes and an audit row
+appears, while a second entity remains unchanged.
+
+## 7. Control-scope assertions
+
+For each control, write:
+
+```text
+what should change
+what must not change
+```
+
+Then test both. If an active-scenario control also removes scenarios from an
+all-scenario comparison, it filters a shared ancestor. Use formula scoping or
+an independent all-scope lineage.
+
+## 8. Agent verification
+
+Ask a question whose answer is known from entered data. Verify the scenario or
+entity, period, baseline, override, and signed impact. The agent must not claim
+an action ran unless the user approved it.
+
+If the agent has an action tool, approve one test action and inspect the
+resulting row or status.
+
+## 9. Record evidence
+
+Keep a small artifact beside the build:
+
+```json
+{
+  "schemaVersion": 1,
+  "workbookId": "…",
+  "verifiedAt": "…",
+  "structural": { "spec": "pass", "compile": "pass" },
+  "renders": [
+    { "page": "Workspace", "path": "renders/workspace.png", "verdict": "pass" }
+  ],
+  "cardinality": [
+    { "element": "Plan Matrix", "expected": 180, "actual": 180, "verdict": "pass" }
+  ],
+  "numericOracle": { "checked": 48, "mismatches": 0 },
+  "writeback": {
+    "publishedEdit": "pass",
+    "linkedCorrelation": "pass",
+    "isolation": "pass",
+    "approvalScope": "pass"
+  },
+  "agent": { "verdict": "pass", "question": "…" },
+  "openIssues": []
+}
+```
+
+Do not mark a gate `pass` without the actual observation: file, row count,
+values, or UI result.

--- a/sigma-workbooks/scripts/lib/actions.rb
+++ b/sigma-workbooks/scripts/lib/actions.rb
@@ -13,10 +13,11 @@
 # Live-verified shape facts (verified live against a real Sigma org, building
 # a multi-KPI command-center-style workbook with buttons + an append-only-log
 # input table):
-#   - `inputMode:"edit"` on an input-table element is MANDATORY. Omit it and
+#   - `inputMode` on an input-table element is MANDATORY. Omit it and
 #     the POST masked-fails as `Invalid kind:"input-table"` — a misleading
 #     message; the real cause is the missing inputMode. Both input_table_*
-#     builders below always emit it.
+#     builders below always emit it and default to `"view"`. No inputMode value
+#     enables published data entry; that is a UI-only element permission.
 #   - Empty input table: source:{kind:"empty",connectionId:<WRITE conn>}.
 #     Linked input table: source:{kind:"linked",from:<parent element id>,
 #     connectionId:<WRITE conn>} — the parent element (`from`) may live on a
@@ -49,7 +50,7 @@ require 'json'
 module Actions
   SURFACES = {
     button: true,             # {kind:"button"} + actions:[{trigger,effects}] — verified GO live
-    input_table_empty: true,  # input-table, source.kind:"empty" — verified GO live; inputMode:"edit" mandatory (masked-error fix)
+    input_table_empty: true,  # input-table, source.kind:"empty" — verified GO live; inputMode required
     input_table_linked: true, # input-table, source.kind:"linked" (cross-connection from a read-only parent) — verified GO live
     effects: true             # insert-rows / clear-control / set-control-value shape helpers — verified GO live, one gate for all 3
   }.freeze
@@ -78,24 +79,26 @@ module Actions
   end
 
   # Returns an `input-table` element sourced empty (a fresh write-back table,
-  # e.g. an append-only log): {id, kind:"input-table", inputMode:"edit",
-  # source:{kind:"empty",connectionId:}, columns:}. `inputMode:"edit"` is
-  # ALWAYS emitted — it is mandatory (see module docstring's masked-error
-  # note). `columns` is passed through verbatim (already-shaped column
+  # e.g. an append-only log): {id, kind:"input-table", inputMode:"view",
+  # source:{kind:"empty",connectionId:}, columns:}. `inputMode` is always
+  # emitted and defaults to `"view"`; pass `"edit"` or `"explore"` through
+  # `input_mode:` when needed. It does not grant published data entry.
+  # `columns` is passed through verbatim (already-shaped column
   # entries, including bare {'id'=>'CREATED_AT'} system-column entries with
   # no `type`). `name:` (optional; a text-style Hash or plain string, caller's
   # choice — passed through verbatim) is OMITTED entirely when not given, not
   # emitted as nil. NO-GO surface -> {'opt_in'=>true,'id'=>id}.
-  def self.input_table_empty(id:, connection_id:, columns:, name: nil, surfaces: SURFACES)
+  def self.input_table_empty(id:, connection_id:, columns:, name: nil, input_mode: 'view', surfaces: SURFACES)
     raise ArgumentError, 'id required' if id.to_s.empty?
     raise ArgumentError, 'connection_id required' if connection_id.to_s.empty?
     raise ArgumentError, 'columns required' if columns.nil? || columns.empty?
+    raise ArgumentError, 'input_mode must be edit, explore, or view' unless %w[edit explore view].include?(input_mode)
     return { 'opt_in' => true, 'id' => id } unless surfaces[:input_table_empty]
 
     out = {
       'id' => id,
       'kind' => 'input-table',
-      'inputMode' => 'edit',
+      'inputMode' => input_mode,
       'source' => { 'kind' => 'empty', 'connectionId' => connection_id },
       'columns' => columns
     }
@@ -105,23 +108,25 @@ module Actions
 
   # Returns an `input-table` element sourced linked from a parent element
   # (e.g. a write-back "targets" table keyed off a read-only pivot):
-  # {id, kind:"input-table", inputMode:"edit", source:{kind:"linked",from:,
+  # {id, kind:"input-table", inputMode:"view", source:{kind:"linked",from:,
   # connectionId:}, columns:}. `from` is the PARENT element's id — verified
   # live to work even when the parent sits on a different (read-only)
   # connection than `connection_id` (the write connection this table itself
   # lives on). Same `columns`/`name:` pass-through contract as
-  # input_table_empty. NO-GO surface -> {'opt_in'=>true,'id'=>id}.
-  def self.input_table_linked(id:, from:, connection_id:, columns:, name: nil, surfaces: SURFACES)
+  # input_table_empty. `input_mode:` defaults to `"view"` and accepts
+  # `"edit"` or `"explore"`. NO-GO surface -> {'opt_in'=>true,'id'=>id}.
+  def self.input_table_linked(id:, from:, connection_id:, columns:, name: nil, input_mode: 'view', surfaces: SURFACES)
     raise ArgumentError, 'id required' if id.to_s.empty?
     raise ArgumentError, 'from required' if from.to_s.empty?
     raise ArgumentError, 'connection_id required' if connection_id.to_s.empty?
     raise ArgumentError, 'columns required' if columns.nil? || columns.empty?
+    raise ArgumentError, 'input_mode must be edit, explore, or view' unless %w[edit explore view].include?(input_mode)
     return { 'opt_in' => true, 'id' => id } unless surfaces[:input_table_linked]
 
     out = {
       'id' => id,
       'kind' => 'input-table',
-      'inputMode' => 'edit',
+      'inputMode' => input_mode,
       'source' => { 'kind' => 'linked', 'from' => from, 'connectionId' => connection_id },
       'columns' => columns
     }
@@ -160,7 +165,7 @@ module Actions
   # NO-GO surface -> {}.
   def self.set_control_value_effect(control:, text:, surfaces: SURFACES)
     raise ArgumentError, 'control required' if control.to_s.empty?
-    raise ArgumentError, 'text required' if text.to_s.empty?
+    raise ArgumentError, 'text required' if text.nil?
     return {} unless surfaces[:effects]
 
     {

--- a/sigma-workbooks/scripts/lib/test_actions.rb
+++ b/sigma-workbooks/scripts/lib/test_actions.rb
@@ -65,13 +65,27 @@ ANNOTATION_COLUMNS = [
   { 'id' => 'CREATED_AT' }, { 'id' => 'CREATED_BY' }
 ].freeze
 
-check('input_table_empty: inputMode:"edit" is present (masked-error fix) + source.kind:"empty"') do
+check('input_table_empty: inputMode defaults to "view" + source.kind:"empty"') do
   el = Actions.input_table_empty(id: 'annotations', connection_id: 'write-conn-1', columns: ANNOTATION_COLUMNS)
   el == {
-    'id' => 'annotations', 'kind' => 'input-table', 'inputMode' => 'edit',
+    'id' => 'annotations', 'kind' => 'input-table', 'inputMode' => 'view',
     'source' => { 'kind' => 'empty', 'connectionId' => 'write-conn-1' },
     'columns' => ANNOTATION_COLUMNS
   }
+end
+check('input_table_empty: input_mode override is honored') do
+  el = Actions.input_table_empty(id: 'annotations', connection_id: 'write-conn-1',
+                                 columns: ANNOTATION_COLUMNS, input_mode: 'edit')
+  el['inputMode'] == 'edit'
+end
+check('input_table_empty: invalid input_mode rejected') do
+  begin
+    Actions.input_table_empty(id: 'annotations', connection_id: 'write-conn-1',
+                              columns: ANNOTATION_COLUMNS, input_mode: 'published')
+    false
+  rescue ArgumentError
+    true
+  end
 end
 check('input_table_empty: name: omitted entirely when not given') do
   el = Actions.input_table_empty(id: 'annotations', connection_id: 'write-conn-1', columns: ANNOTATION_COLUMNS)
@@ -118,10 +132,24 @@ check('input_table_linked: source.kind:"linked" carries from + connectionId') do
   el = Actions.input_table_linked(id: 'targets', from: 'fam-pivot', connection_id: 'write-conn-1',
                                    columns: TARGET_COLUMNS)
   el == {
-    'id' => 'targets', 'kind' => 'input-table', 'inputMode' => 'edit',
+    'id' => 'targets', 'kind' => 'input-table', 'inputMode' => 'view',
     'source' => { 'kind' => 'linked', 'from' => 'fam-pivot', 'connectionId' => 'write-conn-1' },
     'columns' => TARGET_COLUMNS
   }
+end
+check('input_table_linked: input_mode override is honored') do
+  el = Actions.input_table_linked(id: 'targets', from: 'fam-pivot', connection_id: 'write-conn-1',
+                                  columns: TARGET_COLUMNS, input_mode: 'explore')
+  el['inputMode'] == 'explore'
+end
+check('input_table_linked: invalid input_mode rejected') do
+  begin
+    Actions.input_table_linked(id: 'targets', from: 'fam-pivot', connection_id: 'write-conn-1',
+                               columns: TARGET_COLUMNS, input_mode: 'published')
+    false
+  rescue ArgumentError
+    true
+  end
 end
 check('input_table_linked: id required') do
   begin; Actions.input_table_linked(id: '', from: 'f', connection_id: 'c', columns: TARGET_COLUMNS); false
@@ -183,8 +211,13 @@ check('set_control_value_effect: control required') do
   begin; Actions.set_control_value_effect(control: '', text: 'West'); false
   rescue ArgumentError; true; end
 end
+check('set_control_value_effect: empty text is accepted for wizard resets') do
+  Actions.set_control_value_effect(control: 'NewName', text: '') ==
+    { 'effect' => 'set-control-value', 'control' => 'NewName',
+      'value' => { 'type' => 'constant', 'value' => { 'type' => 'text', 'value' => '' } } }
+end
 check('set_control_value_effect: text required') do
-  begin; Actions.set_control_value_effect(control: 'RegionF', text: ''); false
+  begin; Actions.set_control_value_effect(control: 'RegionF', text: nil); false
   rescue ArgumentError; true; end
 end
 check('set_control_value_effect: NO-GO surface -> {}') do

--- a/sigma-workbooks/scripts/lib/testdata/actions_golden.json
+++ b/sigma-workbooks/scripts/lib/testdata/actions_golden.json
@@ -34,7 +34,7 @@
   "input_table_empty": {
     "id": "annotations",
     "kind": "input-table",
-    "inputMode": "edit",
+    "inputMode": "view",
     "source": {
       "kind": "empty",
       "connectionId": "write-conn-1"
@@ -62,7 +62,7 @@
   "input_table_linked": {
     "id": "targets",
     "kind": "input-table",
-    "inputMode": "edit",
+    "inputMode": "view",
     "source": {
       "kind": "linked",
       "from": "fam-pivot",


### PR DESCRIPTION
## Summary
Ports verified operational-app guidance into `sigma-skills` so agents stop guess-and-checking how to populate and operate input tables.

- Adds a mandatory row-arrival decision tree: empty/linked/CSV/UI/warehouse load vs. runtime `insert-rows`
- Documents that unions, joins, and lookups compose read paths and do not populate input tables
- Ports planning, allocation, approval, and exception app recipes plus the runtime evidence loop
- Corrects published data-entry guidance (`inputMode` is structural; published editing is UI-only)
- Aligns action builders/tests to `inputMode: view` by default and supports wizard-reset empty `set-control-value`

## Test plan
- [x] `ruby scripts/sync-targets.rb sigma-workbooks`
- [ ] `ruby sigma-workbooks/scripts/lib/test_actions.rb`
- [ ] Spot-check `SKILL.md` index routes “populate/seed” requests to `input-tables.md` and the app recipes
- [ ] Confirm docs make clear actions are for workflow writes, not bulk seeding