### PR TITLE
Document full element-level workbook filter kinds

### DIFF
--- a/sigma-workbooks/SKILL.md
+++ b/sigma-workbooks/SKILL.md
@@ -273,7 +273,7 @@ The reference is feature-sliced — don't read every file up-front. The index ha
 
 | File | When to load |
 |------|--------------|
-| `reference/specification/tables.md` | Table element, tabular data, data grid, spreadsheet-style list. Also element-level filters (top N, limit, rank), groupings (pivot, group by), the `pivot-table` and editable `input-table` element kinds, and `conditionalFormats` (threshold-based cell coloring, on pivot/input tables). |
+| `reference/specification/tables.md` | Table element, tabular data, data grid, spreadsheet-style list. Also **element-level filters** (`list`, `top-n`, `number-range`, `date-range`, `text-match`, `hierarchy`), groupings (pivot, group by), the `pivot-table` and editable `input-table` element kinds, and `conditionalFormats` (threshold-based cell coloring, on pivot/input tables). |
 | `reference/specification/charts.md` | Chart, graph, visualization, line / bar / column / stacked / grouped / combo / donut / pie / scatter / waterfall / share-of / breakdown. Cartesian axes, color, trellis, legend, trendlines, reference marks. Box chart is unsupported/pending because it is absent from the live OpenAPI. |
 | `reference/specification/maps.md` | Map visualizations — `geography-map` (GeoJSON shapes), `point-map` (lat/long bubbles), `region-map` (states / counties / countries). |
 | `reference/specification/kpis.md` | KPI, stat, big number, single value, metric card — including layout / value styling, the comparison Δ badge (`comparisonColumn` + `comparison:{display:"delta"}` — spec-authorable and readback-stable; the house default), and the trend/sparkline block (still UI-bound). |

--- a/sigma-workbooks/SKILL.md
+++ b/sigma-workbooks/SKILL.md
@@ -326,6 +326,12 @@ The single most common spec error is bare `[column_name]` references to warehous
 - References a column defined in this element by its `name` field.
 - A column cannot reference itself (circular reference error).
 
+**Data-model metrics** — use `[Metrics/<metric name>]`:
+- `Metrics` is a reserved namespace; use the metric's `name`, not its ID.
+- `[<element name>/<metric>]` is a column reference and can fail with
+  `Dependency not found` even though the metric exists.
+- Confirm the metric survives the data-model GET readback before binding it.
+
 ## Troubleshooting
 
 ### "I don't see this field in the skill"

--- a/sigma-workbooks/generated/cline/sigma-workbooks.md
+++ b/sigma-workbooks/generated/cline/sigma-workbooks.md
@@ -318,6 +318,12 @@ The single most common spec error is bare `[column_name]` references to warehous
 - References a column defined in this element by its `name` field.
 - A column cannot reference itself (circular reference error).
 
+**Data-model metrics** — use `[Metrics/<metric name>]`:
+- `Metrics` is a reserved namespace; use the metric's `name`, not its ID.
+- `[<element name>/<metric>]` is a column reference and can fail with
+  `Dependency not found` even though the metric exists.
+- Confirm the metric survives the data-model GET readback before binding it.
+
 ## Troubleshooting
 
 ### "I don't see this field in the skill"

--- a/sigma-workbooks/generated/cline/sigma-workbooks.md
+++ b/sigma-workbooks/generated/cline/sigma-workbooks.md
@@ -265,7 +265,7 @@ The reference is feature-sliced — don't read every file up-front. The index ha
 
 | File | When to load |
 |------|--------------|
-| `reference/specification/tables.md` | Table element, tabular data, data grid, spreadsheet-style list. Also element-level filters (top N, limit, rank), groupings (pivot, group by), the `pivot-table` and editable `input-table` element kinds, and `conditionalFormats` (threshold-based cell coloring, on pivot/input tables). |
+| `reference/specification/tables.md` | Table element, tabular data, data grid, spreadsheet-style list. Also **element-level filters** (`list`, `top-n`, `number-range`, `date-range`, `text-match`, `hierarchy`), groupings (pivot, group by), the `pivot-table` and editable `input-table` element kinds, and `conditionalFormats` (threshold-based cell coloring, on pivot/input tables). |
 | `reference/specification/charts.md` | Chart, graph, visualization, line / bar / column / stacked / grouped / combo / donut / pie / scatter / waterfall / share-of / breakdown. Cartesian axes, color, trellis, legend, trendlines, reference marks. Box chart is unsupported/pending because it is absent from the live OpenAPI. |
 | `reference/specification/maps.md` | Map visualizations — `geography-map` (GeoJSON shapes), `point-map` (lat/long bubbles), `region-map` (states / counties / countries). |
 | `reference/specification/kpis.md` | KPI, stat, big number, single value, metric card — including layout / value styling, the comparison Δ badge (`comparisonColumn` + `comparison:{display:"delta"}` — spec-authorable and readback-stable; the house default), and the trend/sparkline block (still UI-bound). |

--- a/sigma-workbooks/generated/codex/AGENTS.md
+++ b/sigma-workbooks/generated/codex/AGENTS.md
@@ -318,6 +318,12 @@ The single most common spec error is bare `[column_name]` references to warehous
 - References a column defined in this element by its `name` field.
 - A column cannot reference itself (circular reference error).
 
+**Data-model metrics** — use `[Metrics/<metric name>]`:
+- `Metrics` is a reserved namespace; use the metric's `name`, not its ID.
+- `[<element name>/<metric>]` is a column reference and can fail with
+  `Dependency not found` even though the metric exists.
+- Confirm the metric survives the data-model GET readback before binding it.
+
 ## Troubleshooting
 
 ### "I don't see this field in the skill"

--- a/sigma-workbooks/generated/codex/AGENTS.md
+++ b/sigma-workbooks/generated/codex/AGENTS.md
@@ -265,7 +265,7 @@ The reference is feature-sliced — don't read every file up-front. The index ha
 
 | File | When to load |
 |------|--------------|
-| `reference/specification/tables.md` | Table element, tabular data, data grid, spreadsheet-style list. Also element-level filters (top N, limit, rank), groupings (pivot, group by), the `pivot-table` and editable `input-table` element kinds, and `conditionalFormats` (threshold-based cell coloring, on pivot/input tables). |
+| `reference/specification/tables.md` | Table element, tabular data, data grid, spreadsheet-style list. Also **element-level filters** (`list`, `top-n`, `number-range`, `date-range`, `text-match`, `hierarchy`), groupings (pivot, group by), the `pivot-table` and editable `input-table` element kinds, and `conditionalFormats` (threshold-based cell coloring, on pivot/input tables). |
 | `reference/specification/charts.md` | Chart, graph, visualization, line / bar / column / stacked / grouped / combo / donut / pie / scatter / waterfall / share-of / breakdown. Cartesian axes, color, trellis, legend, trendlines, reference marks. Box chart is unsupported/pending because it is absent from the live OpenAPI. |
 | `reference/specification/maps.md` | Map visualizations — `geography-map` (GeoJSON shapes), `point-map` (lat/long bubbles), `region-map` (states / counties / countries). |
 | `reference/specification/kpis.md` | KPI, stat, big number, single value, metric card — including layout / value styling, the comparison Δ badge (`comparisonColumn` + `comparison:{display:"delta"}` — spec-authorable and readback-stable; the house default), and the trend/sparkline block (still UI-bound). |

--- a/sigma-workbooks/generated/continue/sigma-workbooks.md
+++ b/sigma-workbooks/generated/continue/sigma-workbooks.md
@@ -318,6 +318,12 @@ The single most common spec error is bare `[column_name]` references to warehous
 - References a column defined in this element by its `name` field.
 - A column cannot reference itself (circular reference error).
 
+**Data-model metrics** — use `[Metrics/<metric name>]`:
+- `Metrics` is a reserved namespace; use the metric's `name`, not its ID.
+- `[<element name>/<metric>]` is a column reference and can fail with
+  `Dependency not found` even though the metric exists.
+- Confirm the metric survives the data-model GET readback before binding it.
+
 ## Troubleshooting
 
 ### "I don't see this field in the skill"

--- a/sigma-workbooks/generated/continue/sigma-workbooks.md
+++ b/sigma-workbooks/generated/continue/sigma-workbooks.md
@@ -265,7 +265,7 @@ The reference is feature-sliced — don't read every file up-front. The index ha
 
 | File | When to load |
 |------|--------------|
-| `reference/specification/tables.md` | Table element, tabular data, data grid, spreadsheet-style list. Also element-level filters (top N, limit, rank), groupings (pivot, group by), the `pivot-table` and editable `input-table` element kinds, and `conditionalFormats` (threshold-based cell coloring, on pivot/input tables). |
+| `reference/specification/tables.md` | Table element, tabular data, data grid, spreadsheet-style list. Also **element-level filters** (`list`, `top-n`, `number-range`, `date-range`, `text-match`, `hierarchy`), groupings (pivot, group by), the `pivot-table` and editable `input-table` element kinds, and `conditionalFormats` (threshold-based cell coloring, on pivot/input tables). |
 | `reference/specification/charts.md` | Chart, graph, visualization, line / bar / column / stacked / grouped / combo / donut / pie / scatter / waterfall / share-of / breakdown. Cartesian axes, color, trellis, legend, trendlines, reference marks. Box chart is unsupported/pending because it is absent from the live OpenAPI. |
 | `reference/specification/maps.md` | Map visualizations — `geography-map` (GeoJSON shapes), `point-map` (lat/long bubbles), `region-map` (states / counties / countries). |
 | `reference/specification/kpis.md` | KPI, stat, big number, single value, metric card — including layout / value styling, the comparison Δ badge (`comparisonColumn` + `comparison:{display:"delta"}` — spec-authorable and readback-stable; the house default), and the trend/sparkline block (still UI-bound). |

--- a/sigma-workbooks/generated/cursor/rules/sigma-workbooks.mdc
+++ b/sigma-workbooks/generated/cursor/rules/sigma-workbooks.mdc
@@ -270,7 +270,7 @@ The reference is feature-sliced — don't read every file up-front. The index ha
 
 | File | When to load |
 |------|--------------|
-| `reference/specification/tables.md` | Table element, tabular data, data grid, spreadsheet-style list. Also element-level filters (top N, limit, rank), groupings (pivot, group by), the `pivot-table` and editable `input-table` element kinds, and `conditionalFormats` (threshold-based cell coloring, on pivot/input tables). |
+| `reference/specification/tables.md` | Table element, tabular data, data grid, spreadsheet-style list. Also **element-level filters** (`list`, `top-n`, `number-range`, `date-range`, `text-match`, `hierarchy`), groupings (pivot, group by), the `pivot-table` and editable `input-table` element kinds, and `conditionalFormats` (threshold-based cell coloring, on pivot/input tables). |
 | `reference/specification/charts.md` | Chart, graph, visualization, line / bar / column / stacked / grouped / combo / donut / pie / scatter / waterfall / share-of / breakdown. Cartesian axes, color, trellis, legend, trendlines, reference marks. Box chart is unsupported/pending because it is absent from the live OpenAPI. |
 | `reference/specification/maps.md` | Map visualizations — `geography-map` (GeoJSON shapes), `point-map` (lat/long bubbles), `region-map` (states / counties / countries). |
 | `reference/specification/kpis.md` | KPI, stat, big number, single value, metric card — including layout / value styling, the comparison Δ badge (`comparisonColumn` + `comparison:{display:"delta"}` — spec-authorable and readback-stable; the house default), and the trend/sparkline block (still UI-bound). |

--- a/sigma-workbooks/generated/cursor/rules/sigma-workbooks.mdc
+++ b/sigma-workbooks/generated/cursor/rules/sigma-workbooks.mdc
@@ -323,6 +323,12 @@ The single most common spec error is bare `[column_name]` references to warehous
 - References a column defined in this element by its `name` field.
 - A column cannot reference itself (circular reference error).
 
+**Data-model metrics** — use `[Metrics/<metric name>]`:
+- `Metrics` is a reserved namespace; use the metric's `name`, not its ID.
+- `[<element name>/<metric>]` is a column reference and can fail with
+  `Dependency not found` even though the metric exists.
+- Confirm the metric survives the data-model GET readback before binding it.
+
 ## Troubleshooting
 
 ### "I don't see this field in the skill"

--- a/sigma-workbooks/reference/specification/charts.md
+++ b/sigma-workbooks/reference/specification/charts.md
@@ -179,9 +179,9 @@ holeValue:
 
 Related donut-only fields (all round-trip): `innerRadius` (hole size as a ratio of the outer radius, default 0.6) and `hole.value` styling (`fontWeight`, `color`, `visibility`) for the center label.
 
-## Element-level filters (Top-N, etc.)
+## Element-level filters
 
-Charts take the same `filters` array as tables — the top-N example in `tables.md` applies to `bar-chart`, `line-chart`, and `donut-chart` without changes.
+Charts (and KPIs / maps) take the **same** element `filters` array as tables — all six `kind`s (`list`, `top-n`, `number-range`, `date-range`, `text-match`, `hierarchy`). Full field catalog and traps: `tables.md` → `filters`.
 
 Top 10 regions by `Sales` on a bar chart:
 
@@ -196,7 +196,7 @@ filters:
     includeNulls: when-no-value-is-selected
 ```
 
-`rowCount` takes a number literal — it cannot be bound to a control (see `controls.md`, "Where Control Bindings Apply").
+`rowCount` takes a number literal — it cannot be bound to a control (see `tables.md` and `controls.md`).
 
 ## Cartesian-only optional features
 

--- a/sigma-workbooks/reference/specification/controls.md
+++ b/sigma-workbooks/reference/specification/controls.md
@@ -5,6 +5,8 @@ Recipe book for the control element family and the patterns that wire them up. T
 Controls are flat `document.elements[]` entries alongside tables and charts.
 Layout assigns them to pages or containers.
 
+> **Two different `filters` arrays.** On a `kind: control`, `filters[]` is only **wiring**: `{ source: { kind: table, elementId }, columnId }` — which element+column this widget drives. On a data element (`table`, chart, …), `filters[]` is the **predicate catalog** (`kind: list | top-n | number-range | date-range | text-match | hierarchy`). Do not put control wiring objects on a table, or list/`top-n` objects on a control. Element-filter shapes: `tables.md` → `filters`.
+
 **Every `controlType` wires up the same way** (`controlId` + `filters`, below); they differ only in the widget and its (flat top-level) value fields. So treat the per-type sections below as illustrations of the *wiring*, **not a catalog of what's supported** — a `controlType` you don't see here works the same way. The set also grows over time, so get the current list from the spec rather than hardcoding it:
 
 ```bash

--- a/sigma-workbooks/reference/specification/tables.md
+++ b/sigma-workbooks/reference/specification/tables.md
@@ -60,20 +60,141 @@ groupings:
 >
 > **Exclude a NULL/unwanted bucket** with an element list filter on the dimension — this is how a Tableau view filter maps: `filters: [{ id: f, columnId: col-flag, kind: list, mode: include, values: ["Cur FYTD", "Prior FYTD"] }]`. (A grouped bar that includes the NULL bucket is the classic "giant first bar" artifact.)
 
-### `filters` (top-N, element-level row filters)
+### `filters` — element-level column filters
+
+`filters` is an **element-owned** array on `table`, `pivot-table`, `input-table`, charts, KPIs, and maps. Each entry scopes that element's rows. This is **not** the same as a `kind: control` element's `filters[]` (which is only `{ source, columnId }` wiring — see `controls.md`).
+
+OpenAPI kinds (compiled workbook spec / Create workbook spec → Table.filters):
+
+| `kind` | Typical column type | Purpose |
+|---|---|---|
+| `list` | text / number / date / boolean | Include or exclude discrete values |
+| `top-n` | text / number / date | Rank and keep top/bottom N or percentile |
+| `number-range` | number | Inclusive numeric bounds |
+| `date-range` | date | Fixed or relative date window (same `mode` family as date-range **controls**) |
+| `text-match` | text | String compare / contains / like / regexp |
+| `hierarchy` | hierarchy | Include/exclude hierarchy paths (beta in product UI) |
+
+Common fields on every entry: required `id` + `columnId` + `kind`; optional `state: enabled | disabled`. Most kinds also take `includeNulls: always | never | when-no-value-is-selected`.
+
+> **One element filter per column.** To filter the same column twice, combine with a control or a quick filter in the UI — do not stack two `filters[]` entries on one `columnId`.
+>
+> Prefer a **control** when the user should change the predicate interactively. Prefer an **element filter** when the cut is fixed (migration view filters, top-N caps, scrubbing NULL buckets).
+
+#### `list`
+
+```yaml
+filters:
+  - id: f-flag
+    columnId: col-flag
+    kind: list
+    mode: include            # include | exclude
+    values: ["Cur FYTD", "Prior FYTD"]   # string | number | boolean | ISO date; null allowed
+```
+
+#### `top-n`
+
+Two shapes (OpenAPI oneOf) — **row count** vs **percentile**:
 
 ```yaml
 filters:
   - id: top-20
     columnId: col-revenue
     kind: top-n
-    rankingFunction: rank
-    mode: top-n
-    rowCount: 20
+    rankingFunction: rank          # rank | rank-dense | row-number
+    mode: top-n                    # top-n | bottom-n
+    rowCount: 20                   # number literal only — not a control binding
+    includeNulls: when-no-value-is-selected
+  - id: top-decile
+    columnId: col-revenue
+    kind: top-n
+    rankingFunction: rank-percentile   # rank-percentile | cume-dist
+    mode: top-percentile               # top-percentile | bottom-percentile
+    percentile: 10
     includeNulls: when-no-value-is-selected
 ```
 
-> **`rowCount` takes a number literal only** — it cannot be parametrized by a control. `rowCount: "[TopN]"` is rejected. Control bindings apply to filter **values**, not to structural fields like `rowCount`, `rankingFunction`, `mode`, or `kind`. To vary the cap interactively, duplicate the element per cap.
+> **`rowCount` / `percentile` take number literals only** — `rowCount: "[TopN]"` is rejected. Control bindings apply to filter **values**, not structural fields (`rowCount`, `percentile`, `rankingFunction`, `mode`, `kind`). To vary the cap interactively, use a `controlType: top-n` control (`controls.md`) or duplicate the element per cap.
+
+#### `number-range`
+
+```yaml
+filters:
+  - id: f-qty
+    columnId: col-quantity
+    kind: number-range
+    min: 4
+    max: 10
+    includeNulls: when-no-value-is-selected
+```
+
+Bounds are inclusive. Either bound may be omitted.
+
+#### `date-range`
+
+Same `mode` vocabulary as date-range **controls** (`between` | `on` | `before` | `after` | `last` | `next` | `current` | `custom`) with the same flat fields (`startDate`/`endDate`, `date`, `value`+`unit`+`includeToday`, relative `{ op, unit, value }` objects). See `controls.md` → Date Range for the mode table and examples; on an element filter they sit on the filter object (with `kind: date-range`), not on a control:
+
+```yaml
+filters:
+  - id: f-last-90
+    columnId: col-order-date
+    kind: date-range
+    mode: last
+    value: 90
+    unit: day
+    includeToday: true
+    includeNulls: when-no-value-is-selected
+  - id: f-fy
+    columnId: col-order-date
+    kind: date-range
+    mode: between
+    startDate: "2026-01-01"
+    endDate: "2026-03-31"
+```
+
+#### `text-match`
+
+```yaml
+filters:
+  - id: f-name
+    columnId: col-product-name
+    kind: text-match
+    mode: contains    # equals | does-not-equal | contains | does-not-contain |
+                      # starts-with | does-not-start-with | ends-with | does-not-end-with |
+                      # like | not-like | matches-regexp | does-not-match-regexp
+    value: "Geek Squad"
+    case: insensitive               # sensitive | insensitive
+    includeNulls: when-no-value-is-selected
+```
+
+> OpenAPI uses `equals` / `does-not-equal` (not the Help UI labels "Equal to" / "Not equal to").
+
+#### `hierarchy`
+
+```yaml
+filters:
+  - id: f-geo
+    columnId: col-geo-hierarchy
+    kind: hierarchy
+    mode: include                   # include | exclude
+    values:
+      - ["West"]
+      - ["East", "New York"]        # each entry is a root→leaf path
+```
+
+Requires a real hierarchy-typed column. For interactive hierarchy picking across elements, prefer `controlType: hierarchy` (`controls.md`).
+
+#### Inspect live shapes
+
+```bash
+# After fetching the compiled OpenAPI to /tmp/sigma-api.json (see SKILL.md):
+jq --arg k table '
+  first(.. | objects | select(.properties?.kind?.enum==[$k]))
+  | .properties.filters
+' /tmp/sigma-api.json
+```
+
+Human reference: Create workbook spec → Table.filters on the help site (`/reference/create-workbook-spec`). Product behavior overview: Data element filters (`/docs/data-element-filters`).
 
 ### `conditionalFormats` — cell coloring, gradients, and **data bars**
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Expand `sigma-workbooks` `tables.md` `filters` from top-N-only to the full OpenAPI catalog: `list`, `top-n`, `number-range`, `date-range`, `text-match`, `hierarchy`, with create-ready YAML examples and traps (one filter per column; literal `rowCount`; control vs element `filters` confusion).
- Cross-link from `charts.md`, `controls.md`, and the SKILL.md reference index; regenerate agent variants.
- Also ports the `[Metrics/<name>]` workbook binding guidance upstream (from sigma-migration-skills #705) so the next full authoring re-vendor does not drop it.

## Why
Agents were only clearly guided on `list`/`top-n` for element filters, while the Create workbook spec Table.filters surface exposes six kinds. This closes that gap against the compiled OpenAPI.

## Test plan
- [x] Diff reviewed against `/tmp/sigma-api.json` Table.filters oneOf
- [x] `ruby scripts/sync-targets.rb sigma-workbooks` regenerated variants
- [ ] Follow-up: selective re-vendor into `sigma-migration-skills` `plugins/sigma-authoring`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8d91cbf9-78e3-4f10-9f0c-f60d5856c05d?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8d91cbf9-78e3-4f10-9f0c-f60d5856c05d&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

