### PR TITLE
fix(sigma-plugin-authoring): pin the gauge's SDK version

### DIFF
--- a/sigma-plugin-authoring/plugins/gauge/index.html
+++ b/sigma-plugin-authoring/plugins/gauge/index.html
@@ -82,7 +82,10 @@
   @sigmacomputing/plugin v1.2.0 (see reference/plugin-lifecycle.md).
 -->
 <script crossorigin src="https://unpkg.com/react@18.3.1/umd/react.production.min.js"></script>
-<script src="https://unpkg.com/@sigmacomputing/plugin"></script>
+<!-- Pinned. Unpinned @latest silently crosses the 1.1.1 -> 1.2.0 boundary
+     that introduced the React peer-global requirement noted above; it also
+     drifted 1.2.0 -> 1.3.2 mid-development on 2026-08-25. -->
+<script src="https://unpkg.com/@sigmacomputing/plugin@1.2.0/dist/umd/sigmacomputing-plugin.umd.js"></script>
 <script>
 (function () {
   'use strict';

--- a/sigma-plugin-authoring/scripts/test-gauge-plugin-static.rb
+++ b/sigma-plugin-authoring/scripts/test-gauge-plugin-static.rb
@@ -23,6 +23,7 @@ def chk(c, m)
   $f += 1 unless c
 end
 chk(HTML.include?('@sigmacomputing/plugin'), 'loads the @sigmacomputing/plugin SDK')
+chk(HTML.match?(%r{@sigmacomputing/plugin@\d+\.\d+\.\d+}), 'SDK version is PINNED (unpinned @latest crossed the 1.1.1 -> 1.2.0 React break)')
 chk(HTML.include?('configureEditorPanel'),   'configures an editor panel')
 chk(HTML =~ /['"]value['"]/ && HTML =~ /['"]target['"]/, 'declares value + target bindings')
 chk(HTML.include?('ResizeObserver'),         'attaches a ResizeObserver (redraw-on-resize)')


### PR DESCRIPTION
## What

`plugins/gauge/index.html` loads `https://unpkg.com/@sigmacomputing/plugin` unpinned. Pin it to `@1.2.0` and add a lint assertion.

## Why

That URL silently crosses a breaking boundary. Measured 2026-08-25:

| SDK version | needs `window.React`? |
|---|---|
| 1.0.9 / 1.0.10 / 1.1.1 | no |
| **1.2.0** (2026-05-19) | **yes** |
| 1.3.2 | yes |

Without `window.React` the UMD factory throws and leaves `window.SigmaPlugin` an empty object — `client` is `undefined` and the plugin silently never binds. The gauge already loads React, so it is fine today; pinning stops a future `@latest` bump from moving the requirement again. It also drifted `1.2.0 → 1.3.2` mid-development during this work.

## Scope note

This PR originally also claimed `PluginEmbed.build`'s bare-string column bindings were wrong and rewrote the emitter and docs to the object form. **That claim was disproven** by an A/B on a live workbook: bare-string bindings render correctly. The original symptom was the published view lagging a spec write, which a refresh clears. The emitter and its guidance are correct and untouched — only the version pin remains.

## Verification

```
ruby sigma-plugin-authoring/scripts/test-gauge-plugin-static.rb   # PASS
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)