### PR TITLE
docs(sigma-workbooks): finish the action field rename — 2 stale keys + the not-renamed list

### DIFF
--- a/sigma-workbooks/reference/workflows/actions.md
+++ b/sigma-workbooks/reference/workflows/actions.md
@@ -4,6 +4,27 @@ Buttons wire a user click to one or more **effects** — insert rows into an
 input table, reset a control, set a control's value, or open/close a modal.
 They live in flat `document.elements[]`; layout places them.
 
+> **Action identifier fields — which ones carry an `Id` suffix.** The
+> 2026-08-26 rename gave identifier properties the referenced resource type
+> plus an `Id` suffix. Verified by A/B creates plus `GET .../spec` readback
+> diffs against a live org. The renamed ones are documented per-effect below;
+> what follows is the part that is easy to get wrong.
+>
+> **These were deliberately NOT renamed.** The bare name is still the only
+> accepted spelling and the `*Id` form is **rejected** — so don't "regularise"
+> them for consistency:
+>
+> | still bare | not this |
+> |---|---|
+> | `set-control-value.control` | ~~`controlId`~~ |
+> | `navigate` `target: {type: page, page:}` | ~~`pageId`~~ |
+> | `refresh-element` `target: {type: element, element:}` | ~~`elementId`~~ |
+> | value source `{type: control, control:}` | ~~`controlId`~~ |
+>
+> Note `clear-control`'s scope *does* use `controlId`, while
+> `set-control-value` keeps a bare `control`. That asymmetry is real, not a
+> documentation slip.
+
 ## Button shape
 
 ```yaml
@@ -316,8 +337,8 @@ whichRows: { type: formula, formula: '[note] = "x"' }
 `whichRows` has **four** variants (re-verified 2026-08-08 against the live
 codec — an earlier pass here missed the fourth) — `{type: formula, formula}`,
 `{type: single-row, primaryKeys}`, `{type: current-row}`, and `{type:
-column-match, column, condition, value?}`: a column where-clause, e.g. `{
-type: column-match, column: status, condition: "=", value: {...} }`.
+column-match, columnId, condition, value?}`: a column where-clause, e.g. `{
+type: column-match, columnId: status, condition: "=", value: {...} }`.
 `condition` is one of `IsNull` / `IsNotNull` (no `value`), `=` / `!=` / `>` /
 `>=` / `<` / `<=` / `Contains` / `NotContains` / `StartsWith` / `EndsWith`
 (`value` required), or `Between` / `NotBetween` (`low`/`high` required instead
@@ -342,7 +363,7 @@ derived table/chart that reads from the input table; Sigma may report those as
 
 ```yaml
 effect: open-document
-document: <inodeId>            # the target workbook/report inode id
+documentId: <inodeId>          # the target workbook/report inode id
 documentType: workbook         # workbook | report  (REQUIRED — selects the route)
 openTarget: _blank             # _self | _blank | _parent  (REQUIRED)
 targetControls:                # optional: seed the target's controls

--- a/sigma-workbooks/scripts/lib/actions.rb
+++ b/sigma-workbooks/scripts/lib/actions.rb
@@ -34,9 +34,14 @@
 #   - Effects verified live: insert-rows (values is a pass-through Hash of
 #     colId => {type:"control",control:} | {type:"constant",value:{type:"text",value:}}
 #     entries — this module does not reshape `values`, callers build it),
-#     clear-control (an ELEMENT-scoped clear-control masked-failed the button
-#     live — only page scope is verified, so this builder only emits
+#     clear-control (this builder emits page scope only —
 #     scope:{type:"page",pageId:}), set-control-value (constant text value).
+#
+# NOT renamed in the 2026-08-26 action field rename — probe-confirmed that the
+# `*Id` form is REJECTED and the bare name is still required, so do not "fix"
+# these: `set-control-value.control`, `navigate` target.page,
+# `refresh-element` target.element, and the {type:"control",control:} value
+# source used inside `values`.
 #
 # All builders are gated through Actions::SURFACES (same discipline as
 # richness.rb/styling.rb): a NO-GO flip on `button`/`input_table_empty`/
@@ -155,8 +160,13 @@ module Actions
   # scope:{type:"page",pageId:}, usePublishedValue:true}. The OpenAPI field
   # is `pageId` (not `page`). A stale `page:` key is dropped on GET
   # readback, and click then fails with "No target page is selected in the
-  # action." Page scope ONLY — an element-scoped clear-control masked-failed
-  # the button live, so this builder never emits any other scope shape.
+  # action." Page scope only — but note the reason has changed: the old
+  # "an element-scoped clear-control masked-failed the button live" finding
+  # was recorded while this builder still emitted the PRE-RENAME key names.
+  # Re-probed 2026-08-26, control scope ({type:"control",controlId:}) and
+  # container scope ({type:"container",containerElementId:}) BOTH create and
+  # read back cleanly, so what masked-failed was the rejected key, not the
+  # scope type. Widening this builder to those scopes is a safe follow-up.
   # NO-GO surface -> {}.
   def self.clear_control_effect(page_id:, surfaces: SURFACES)
     raise ArgumentError, 'page_id required' if page_id.to_s.empty?


### PR DESCRIPTION
## Context

Sigma's action field rename (identifiers now carry the resource type + an `Id` suffix) is **already live** — confirmed by 40 A/B creates plus `GET .../spec` readback diffs against a real org, despite the announcement saying it hadn't shipped.

**Scope note:** this PR originally carried the full rename. #49 landed that in the builders, tests and goldens while it was open, so I rebased onto main and reduced this to only what's still missing. It's now 2 files.

## Two stale keys still in the docs

Both would be copied straight into a spec that fails:

| site | old (rejected) | new |
|---|---|---|
| `whichRows` `{type: column-match}` | `column` | `columnId` |
| `open-document` | `document` | `documentId` |

Both verified live: the old spelling is rejected, the new one creates and reads back.

## The fields that were NOT renamed

This is the part that's easy to get wrong in the other direction, and nothing in the repo said it. These still require the **bare** name — the `*Id` form 400s:

- `set-control-value.control`
- `navigate` `target: {type: page, page:}`
- `refresh-element` `target: {type: element, element:}`
- value source `{type: control, control:}`

`clear-control`'s scope uses `controlId` while `set-control-value` keeps a bare `control`. That asymmetry is real, not a doc slip — but it reads exactly like one, so the next person to tidy it up would break working code. Now documented as a table in `actions.md`.

## Stale explanation corrected

`actions.rb` said an element-scoped `clear-control` "masked-failed the button live", implying the scope type was unsupported. That note was recorded while the builder still emitted pre-rename key names. Re-probed: control scope (`controlId`) and container scope (`containerElementId`) both create and read back cleanly — what masked-failed was the rejected **key**, not the scope.

Widening `clear_control_effect` beyond page scope is therefore a safe follow-up rather than a blocked one. Left out here to keep this focused.

## Verification

All 14 `sigma-workbooks` suites pass, including live `test-verify.rb`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)