### PR TITLE
feat(workbooks): interview generate-app for fields, approvals, and agent

### DIFF
--- a/sigma-workbooks/SKILL.md
+++ b/sigma-workbooks/SKILL.md
@@ -132,8 +132,11 @@ while missing the app shell and behavior.
 If the user asked to generate / build / scaffold a Sigma **app** (planning,
 approval, allocation, exception, or an unspecified “app”) and did **not**
 supply a target image, pause here and load
-`reference/workflows/generate-apps.md` — it classifies the app type, records
-an intake manifest, and clones a best-practice **architecture** fixture.
+`reference/workflows/generate-apps.md` — it classifies the app type,
+**interviews** before it builds (which fields users may edit, whether the
+workflow needs approvals, whether to add a Sigma Agent and what it is
+for), records an intake manifest, states a build plan, and clones a
+best-practice **architecture** fixture.
 Design is a separate pass: load `styling.md` as a library and compose for
 this type (do not stamp the five-recipe dashboard *or* the navy-hero
 command-center example). A
@@ -180,7 +183,9 @@ Load `reference/workflows/discover.md`. Quick summary:
 Map the user's request to the **Reference Index** below. State the features you identified, then read the listed reference files before drafting. **If the user asks for a feature this skill doesn't cover**, fetch the OpenAPI and inspect the relevant schema.
 
 If the user asked to generate an app, run `generate-apps.md` first (Step 0)
-before choosing an input-table architecture here. Load
+before choosing an input-table architecture here. That interview already
+recorded which fields users may edit, whether the workflow needs
+approvals, and whether to include a workbook agent. Load
 `reference/specification/styling.md` as a library and compose for this
 app's job — do not stamp the five-pattern exec-dashboard stack or the
 navy-hero command-center example.
@@ -333,7 +338,7 @@ The reference is feature-sliced — don't read every file up-front. The index ha
 | `reference/workflows/discover.md` | Finding connections, tables, and column names. Load before composing a new spec. |
 | `reference/workflows/composition.md` | Open-ended design decisions — calibrating workbook complexity to the request, when to ask the user, what to ask, surfacing structural choices in the final summary, and a few safe defaults (hidden source pages, ranked-table sort direction). Load before drafting anything when the prompt leaves significant design choices unmade. |
 | `reference/workflows/actions.md` | Buttons, write-back, and **all twelve** action effects — insert/update/delete-rows, clear-control, set-control-value, open/close-overlay (modal **and** drawer), open-url, open-document (incl. passing `targetControls` into another workbook), navigate, select-tab, refresh-element — plus the append-only-log pattern and the masked-error catalog. Load when the user wants a button, a "log/save/submit" action, tab/page navigation, a deep link, or a write-back workflow. |
-| `reference/workflows/generate-apps.md` | **Generate a Sigma app.** Load first when the user asks to build a planning, approval, allocation, or exception app (and did not supply a target image). Classifies the type, asks structural questions, clones an architecture fixture, then **composes** a look from `styling.md` (library + anti-patterns). Fail the PNG pass on skill chrome, invisible entry controls, Dark-by-default on data-entry, or a 3-KPI status strip. |
+| `reference/workflows/generate-apps.md` | **Generate a Sigma app.** Load first when the user asks to build a planning, approval, allocation, or exception app (and did not supply a target image). Classifies the type, **interviews** for editable fields / approvals / a workbook agent (with a recommended purpose), clones an architecture fixture, then **composes** a look from `styling.md` (library + anti-patterns). Fail the PNG pass on skill chrome, invisible entry controls, Dark-by-default on data-entry, or a 3-KPI status strip. |
 | `reference/workflows/planning-apps.md` | **Scenario planning, budgeting, and forecasting apps.** Scenario × Period × Planning Line grain, governed baseline, scenario matrix, linked override grid, financial sign, filter-propagation choices, approval/audit, and runtime gates. |
 | `reference/workflows/allocation-apps.md` | **Allocation and capacity apps.** Budget/target vs. baseline at Period × Allocation Dimension grain, linked editable units/uplifts, working allocation, request queue, and exact variance gates. |
 | `reference/workflows/approval-apps.md` | **Approval and decision apps.** Stable entity-key queues, counter-values, immutable audit logs, one-row status updates, agent boundaries, and runtime tests. |

--- a/sigma-workbooks/generated/cline/sigma-workbooks.md
+++ b/sigma-workbooks/generated/cline/sigma-workbooks.md
@@ -123,8 +123,11 @@ while missing the app shell and behavior.
 If the user asked to generate / build / scaffold a Sigma **app** (planning,
 approval, allocation, exception, or an unspecified “app”) and did **not**
 supply a target image, pause here and load
-`reference/workflows/generate-apps.md` — it classifies the app type, records
-an intake manifest, and clones a best-practice **architecture** fixture.
+`reference/workflows/generate-apps.md` — it classifies the app type,
+**interviews** before it builds (which fields users may edit, whether the
+workflow needs approvals, whether to add a Sigma Agent and what it is
+for), records an intake manifest, states a build plan, and clones a
+best-practice **architecture** fixture.
 Design is a separate pass: load `styling.md` as a library and compose for
 this type (do not stamp the five-recipe dashboard *or* the navy-hero
 command-center example). A
@@ -171,7 +174,9 @@ Load `reference/workflows/discover.md`. Quick summary:
 Map the user's request to the **Reference Index** below. State the features you identified, then read the listed reference files before drafting. **If the user asks for a feature this skill doesn't cover**, fetch the OpenAPI and inspect the relevant schema.
 
 If the user asked to generate an app, run `generate-apps.md` first (Step 0)
-before choosing an input-table architecture here. Load
+before choosing an input-table architecture here. That interview already
+recorded which fields users may edit, whether the workflow needs
+approvals, and whether to include a workbook agent. Load
 `reference/specification/styling.md` as a library and compose for this
 app's job — do not stamp the five-pattern exec-dashboard stack or the
 navy-hero command-center example.
@@ -324,7 +329,7 @@ The reference is feature-sliced — don't read every file up-front. The index ha
 | `reference/workflows/discover.md` | Finding connections, tables, and column names. Load before composing a new spec. |
 | `reference/workflows/composition.md` | Open-ended design decisions — calibrating workbook complexity to the request, when to ask the user, what to ask, surfacing structural choices in the final summary, and a few safe defaults (hidden source pages, ranked-table sort direction). Load before drafting anything when the prompt leaves significant design choices unmade. |
 | `reference/workflows/actions.md` | Buttons, write-back, and **all twelve** action effects — insert/update/delete-rows, clear-control, set-control-value, open/close-overlay (modal **and** drawer), open-url, open-document (incl. passing `targetControls` into another workbook), navigate, select-tab, refresh-element — plus the append-only-log pattern and the masked-error catalog. Load when the user wants a button, a "log/save/submit" action, tab/page navigation, a deep link, or a write-back workflow. |
-| `reference/workflows/generate-apps.md` | **Generate a Sigma app.** Load first when the user asks to build a planning, approval, allocation, or exception app (and did not supply a target image). Classifies the type, asks structural questions, clones an architecture fixture, then **composes** a look from `styling.md` (library + anti-patterns). Fail the PNG pass on skill chrome, invisible entry controls, Dark-by-default on data-entry, or a 3-KPI status strip. |
+| `reference/workflows/generate-apps.md` | **Generate a Sigma app.** Load first when the user asks to build a planning, approval, allocation, or exception app (and did not supply a target image). Classifies the type, **interviews** for editable fields / approvals / a workbook agent (with a recommended purpose), clones an architecture fixture, then **composes** a look from `styling.md` (library + anti-patterns). Fail the PNG pass on skill chrome, invisible entry controls, Dark-by-default on data-entry, or a 3-KPI status strip. |
 | `reference/workflows/planning-apps.md` | **Scenario planning, budgeting, and forecasting apps.** Scenario × Period × Planning Line grain, governed baseline, scenario matrix, linked override grid, financial sign, filter-propagation choices, approval/audit, and runtime gates. |
 | `reference/workflows/allocation-apps.md` | **Allocation and capacity apps.** Budget/target vs. baseline at Period × Allocation Dimension grain, linked editable units/uplifts, working allocation, request queue, and exact variance gates. |
 | `reference/workflows/approval-apps.md` | **Approval and decision apps.** Stable entity-key queues, counter-values, immutable audit logs, one-row status updates, agent boundaries, and runtime tests. |

--- a/sigma-workbooks/generated/codex/AGENTS.md
+++ b/sigma-workbooks/generated/codex/AGENTS.md
@@ -123,8 +123,11 @@ while missing the app shell and behavior.
 If the user asked to generate / build / scaffold a Sigma **app** (planning,
 approval, allocation, exception, or an unspecified “app”) and did **not**
 supply a target image, pause here and load
-`reference/workflows/generate-apps.md` — it classifies the app type, records
-an intake manifest, and clones a best-practice **architecture** fixture.
+`reference/workflows/generate-apps.md` — it classifies the app type,
+**interviews** before it builds (which fields users may edit, whether the
+workflow needs approvals, whether to add a Sigma Agent and what it is
+for), records an intake manifest, states a build plan, and clones a
+best-practice **architecture** fixture.
 Design is a separate pass: load `styling.md` as a library and compose for
 this type (do not stamp the five-recipe dashboard *or* the navy-hero
 command-center example). A
@@ -171,7 +174,9 @@ Load `reference/workflows/discover.md`. Quick summary:
 Map the user's request to the **Reference Index** below. State the features you identified, then read the listed reference files before drafting. **If the user asks for a feature this skill doesn't cover**, fetch the OpenAPI and inspect the relevant schema.
 
 If the user asked to generate an app, run `generate-apps.md` first (Step 0)
-before choosing an input-table architecture here. Load
+before choosing an input-table architecture here. That interview already
+recorded which fields users may edit, whether the workflow needs
+approvals, and whether to include a workbook agent. Load
 `reference/specification/styling.md` as a library and compose for this
 app's job — do not stamp the five-pattern exec-dashboard stack or the
 navy-hero command-center example.
@@ -324,7 +329,7 @@ The reference is feature-sliced — don't read every file up-front. The index ha
 | `reference/workflows/discover.md` | Finding connections, tables, and column names. Load before composing a new spec. |
 | `reference/workflows/composition.md` | Open-ended design decisions — calibrating workbook complexity to the request, when to ask the user, what to ask, surfacing structural choices in the final summary, and a few safe defaults (hidden source pages, ranked-table sort direction). Load before drafting anything when the prompt leaves significant design choices unmade. |
 | `reference/workflows/actions.md` | Buttons, write-back, and **all twelve** action effects — insert/update/delete-rows, clear-control, set-control-value, open/close-overlay (modal **and** drawer), open-url, open-document (incl. passing `targetControls` into another workbook), navigate, select-tab, refresh-element — plus the append-only-log pattern and the masked-error catalog. Load when the user wants a button, a "log/save/submit" action, tab/page navigation, a deep link, or a write-back workflow. |
-| `reference/workflows/generate-apps.md` | **Generate a Sigma app.** Load first when the user asks to build a planning, approval, allocation, or exception app (and did not supply a target image). Classifies the type, asks structural questions, clones an architecture fixture, then **composes** a look from `styling.md` (library + anti-patterns). Fail the PNG pass on skill chrome, invisible entry controls, Dark-by-default on data-entry, or a 3-KPI status strip. |
+| `reference/workflows/generate-apps.md` | **Generate a Sigma app.** Load first when the user asks to build a planning, approval, allocation, or exception app (and did not supply a target image). Classifies the type, **interviews** for editable fields / approvals / a workbook agent (with a recommended purpose), clones an architecture fixture, then **composes** a look from `styling.md` (library + anti-patterns). Fail the PNG pass on skill chrome, invisible entry controls, Dark-by-default on data-entry, or a 3-KPI status strip. |
 | `reference/workflows/planning-apps.md` | **Scenario planning, budgeting, and forecasting apps.** Scenario × Period × Planning Line grain, governed baseline, scenario matrix, linked override grid, financial sign, filter-propagation choices, approval/audit, and runtime gates. |
 | `reference/workflows/allocation-apps.md` | **Allocation and capacity apps.** Budget/target vs. baseline at Period × Allocation Dimension grain, linked editable units/uplifts, working allocation, request queue, and exact variance gates. |
 | `reference/workflows/approval-apps.md` | **Approval and decision apps.** Stable entity-key queues, counter-values, immutable audit logs, one-row status updates, agent boundaries, and runtime tests. |

--- a/sigma-workbooks/generated/continue/sigma-workbooks.md
+++ b/sigma-workbooks/generated/continue/sigma-workbooks.md
@@ -123,8 +123,11 @@ while missing the app shell and behavior.
 If the user asked to generate / build / scaffold a Sigma **app** (planning,
 approval, allocation, exception, or an unspecified “app”) and did **not**
 supply a target image, pause here and load
-`reference/workflows/generate-apps.md` — it classifies the app type, records
-an intake manifest, and clones a best-practice **architecture** fixture.
+`reference/workflows/generate-apps.md` — it classifies the app type,
+**interviews** before it builds (which fields users may edit, whether the
+workflow needs approvals, whether to add a Sigma Agent and what it is
+for), records an intake manifest, states a build plan, and clones a
+best-practice **architecture** fixture.
 Design is a separate pass: load `styling.md` as a library and compose for
 this type (do not stamp the five-recipe dashboard *or* the navy-hero
 command-center example). A
@@ -171,7 +174,9 @@ Load `reference/workflows/discover.md`. Quick summary:
 Map the user's request to the **Reference Index** below. State the features you identified, then read the listed reference files before drafting. **If the user asks for a feature this skill doesn't cover**, fetch the OpenAPI and inspect the relevant schema.
 
 If the user asked to generate an app, run `generate-apps.md` first (Step 0)
-before choosing an input-table architecture here. Load
+before choosing an input-table architecture here. That interview already
+recorded which fields users may edit, whether the workflow needs
+approvals, and whether to include a workbook agent. Load
 `reference/specification/styling.md` as a library and compose for this
 app's job — do not stamp the five-pattern exec-dashboard stack or the
 navy-hero command-center example.
@@ -324,7 +329,7 @@ The reference is feature-sliced — don't read every file up-front. The index ha
 | `reference/workflows/discover.md` | Finding connections, tables, and column names. Load before composing a new spec. |
 | `reference/workflows/composition.md` | Open-ended design decisions — calibrating workbook complexity to the request, when to ask the user, what to ask, surfacing structural choices in the final summary, and a few safe defaults (hidden source pages, ranked-table sort direction). Load before drafting anything when the prompt leaves significant design choices unmade. |
 | `reference/workflows/actions.md` | Buttons, write-back, and **all twelve** action effects — insert/update/delete-rows, clear-control, set-control-value, open/close-overlay (modal **and** drawer), open-url, open-document (incl. passing `targetControls` into another workbook), navigate, select-tab, refresh-element — plus the append-only-log pattern and the masked-error catalog. Load when the user wants a button, a "log/save/submit" action, tab/page navigation, a deep link, or a write-back workflow. |
-| `reference/workflows/generate-apps.md` | **Generate a Sigma app.** Load first when the user asks to build a planning, approval, allocation, or exception app (and did not supply a target image). Classifies the type, asks structural questions, clones an architecture fixture, then **composes** a look from `styling.md` (library + anti-patterns). Fail the PNG pass on skill chrome, invisible entry controls, Dark-by-default on data-entry, or a 3-KPI status strip. |
+| `reference/workflows/generate-apps.md` | **Generate a Sigma app.** Load first when the user asks to build a planning, approval, allocation, or exception app (and did not supply a target image). Classifies the type, **interviews** for editable fields / approvals / a workbook agent (with a recommended purpose), clones an architecture fixture, then **composes** a look from `styling.md` (library + anti-patterns). Fail the PNG pass on skill chrome, invisible entry controls, Dark-by-default on data-entry, or a 3-KPI status strip. |
 | `reference/workflows/planning-apps.md` | **Scenario planning, budgeting, and forecasting apps.** Scenario × Period × Planning Line grain, governed baseline, scenario matrix, linked override grid, financial sign, filter-propagation choices, approval/audit, and runtime gates. |
 | `reference/workflows/allocation-apps.md` | **Allocation and capacity apps.** Budget/target vs. baseline at Period × Allocation Dimension grain, linked editable units/uplifts, working allocation, request queue, and exact variance gates. |
 | `reference/workflows/approval-apps.md` | **Approval and decision apps.** Stable entity-key queues, counter-values, immutable audit logs, one-row status updates, agent boundaries, and runtime tests. |

--- a/sigma-workbooks/generated/cursor/rules/sigma-workbooks.mdc
+++ b/sigma-workbooks/generated/cursor/rules/sigma-workbooks.mdc
@@ -128,8 +128,11 @@ while missing the app shell and behavior.
 If the user asked to generate / build / scaffold a Sigma **app** (planning,
 approval, allocation, exception, or an unspecified “app”) and did **not**
 supply a target image, pause here and load
-`reference/workflows/generate-apps.md` — it classifies the app type, records
-an intake manifest, and clones a best-practice **architecture** fixture.
+`reference/workflows/generate-apps.md` — it classifies the app type,
+**interviews** before it builds (which fields users may edit, whether the
+workflow needs approvals, whether to add a Sigma Agent and what it is
+for), records an intake manifest, states a build plan, and clones a
+best-practice **architecture** fixture.
 Design is a separate pass: load `styling.md` as a library and compose for
 this type (do not stamp the five-recipe dashboard *or* the navy-hero
 command-center example). A
@@ -176,7 +179,9 @@ Load `reference/workflows/discover.md`. Quick summary:
 Map the user's request to the **Reference Index** below. State the features you identified, then read the listed reference files before drafting. **If the user asks for a feature this skill doesn't cover**, fetch the OpenAPI and inspect the relevant schema.
 
 If the user asked to generate an app, run `generate-apps.md` first (Step 0)
-before choosing an input-table architecture here. Load
+before choosing an input-table architecture here. That interview already
+recorded which fields users may edit, whether the workflow needs
+approvals, and whether to include a workbook agent. Load
 `reference/specification/styling.md` as a library and compose for this
 app's job — do not stamp the five-pattern exec-dashboard stack or the
 navy-hero command-center example.
@@ -329,7 +334,7 @@ The reference is feature-sliced — don't read every file up-front. The index ha
 | `reference/workflows/discover.md` | Finding connections, tables, and column names. Load before composing a new spec. |
 | `reference/workflows/composition.md` | Open-ended design decisions — calibrating workbook complexity to the request, when to ask the user, what to ask, surfacing structural choices in the final summary, and a few safe defaults (hidden source pages, ranked-table sort direction). Load before drafting anything when the prompt leaves significant design choices unmade. |
 | `reference/workflows/actions.md` | Buttons, write-back, and **all twelve** action effects — insert/update/delete-rows, clear-control, set-control-value, open/close-overlay (modal **and** drawer), open-url, open-document (incl. passing `targetControls` into another workbook), navigate, select-tab, refresh-element — plus the append-only-log pattern and the masked-error catalog. Load when the user wants a button, a "log/save/submit" action, tab/page navigation, a deep link, or a write-back workflow. |
-| `reference/workflows/generate-apps.md` | **Generate a Sigma app.** Load first when the user asks to build a planning, approval, allocation, or exception app (and did not supply a target image). Classifies the type, asks structural questions, clones an architecture fixture, then **composes** a look from `styling.md` (library + anti-patterns). Fail the PNG pass on skill chrome, invisible entry controls, Dark-by-default on data-entry, or a 3-KPI status strip. |
+| `reference/workflows/generate-apps.md` | **Generate a Sigma app.** Load first when the user asks to build a planning, approval, allocation, or exception app (and did not supply a target image). Classifies the type, **interviews** for editable fields / approvals / a workbook agent (with a recommended purpose), clones an architecture fixture, then **composes** a look from `styling.md` (library + anti-patterns). Fail the PNG pass on skill chrome, invisible entry controls, Dark-by-default on data-entry, or a 3-KPI status strip. |
 | `reference/workflows/planning-apps.md` | **Scenario planning, budgeting, and forecasting apps.** Scenario × Period × Planning Line grain, governed baseline, scenario matrix, linked override grid, financial sign, filter-propagation choices, approval/audit, and runtime gates. |
 | `reference/workflows/allocation-apps.md` | **Allocation and capacity apps.** Budget/target vs. baseline at Period × Allocation Dimension grain, linked editable units/uplifts, working allocation, request queue, and exact variance gates. |
 | `reference/workflows/approval-apps.md` | **Approval and decision apps.** Stable entity-key queues, counter-values, immutable audit logs, one-row status updates, agent boundaries, and runtime tests. |

--- a/sigma-workbooks/reference/workflows/allocation-apps.md
+++ b/sigma-workbooks/reference/workflows/allocation-apps.md
@@ -32,6 +32,9 @@ users need to edit at that lower grain and uniqueness is proven.
 3. **Working allocation** — calculated result and variance.
 4. **Optional request queue** — hiring or reallocation requests.
 5. **Decision log** — approvals separated from the editable plan.
+   Generate-apps Step B asks whether this workflow needs that layer; if
+   they declined, keep the allocation grid and omit the request-log
+   button.
 
 Workforce example:
 
@@ -62,6 +65,9 @@ that grid, every descendant KPI inherits the filter. Scope selected views by
 formula or provide an independent all-scope lineage for comparisons.
 
 ## Agent
+
+Generate-apps Step B offers this agent and pre-fills the recommended
+purpose; skip this section if they declined.
 
 The agent should explain:
 

--- a/sigma-workbooks/reference/workflows/approval-apps.md
+++ b/sigma-workbooks/reference/workflows/approval-apps.md
@@ -11,6 +11,8 @@ Use this pattern when the source contains:
 
 The source proves that an approval queue exists. The write path is an
 enhancement, so ask what decisions users should be allowed to make.
+Generate-apps Step B also asks whether to keep the submit / audit-log
+action (the queue itself is still this type).
 
 ## Grain
 
@@ -64,6 +66,9 @@ The `whichRows` formula must use the stable entity key:
 Test that a second entity remains unchanged.
 
 ## Agent
+
+Generate-apps Step B offers this agent and pre-fills the recommended
+purpose; skip this section if they declined.
 
 Give the agent the directory, editable review queue, and decision log. It
 should prioritize by policy breach, value at risk, and age. It must not claim a

--- a/sigma-workbooks/reference/workflows/exception-apps.md
+++ b/sigma-workbooks/reference/workflows/exception-apps.md
@@ -28,7 +28,9 @@ Observation Date to the composite key.
    Override, Owner, and Resolution Note.
 3. **Recommended action** — deterministic formula from source policy.
 4. **Final action** — user override or recommendation.
-5. **Resolution log** — append-only action evidence.
+5. **Resolution log** — append-only action evidence. Generate-apps Step B
+   asks whether this workflow needs that log action; if they declined,
+   keep the action queue and omit the log-resolution button.
 
 Inventory example:
 
@@ -53,6 +55,9 @@ resolution events; they do not initialize the queue. Unions and joins may
 compose the read model but cannot populate the input table.
 
 ## Agent
+
+Generate-apps Step B offers this agent and pre-fills the recommended
+purpose; skip this section if they declined.
 
 The agent should:
 

--- a/sigma-workbooks/reference/workflows/fixtures/README.md
+++ b/sigma-workbooks/reference/workflows/fixtures/README.md
@@ -22,6 +22,8 @@ the starting specs.
   + KPI-card stack onto every app; compose the look in `generate-apps.md`
   Step D.4 from `styling.md`. Fail that pass on invisible entry controls
   and Dark-by-default; do not copy a one-off app's look back into fixtures.
+  Fixtures stay agent-free; compose `document.agents` / `chat` in
+  generate-apps Step D.5 when intake says to include an agent.
 - Key only deterministic, stable context — never status, owner, current user,
   `Now()`, or approval state.
 - Hidden source page for warehouse / baseline / join plumbing. The visible app

--- a/sigma-workbooks/reference/workflows/generate-apps.md
+++ b/sigma-workbooks/reference/workflows/generate-apps.md
@@ -6,10 +6,12 @@ center, or an unspecified “app” — and they did **not** supply a target ima
 
 The general spec workflow ([the rest of SKILL.md](../../SKILL.md)) still
 applies. This document covers **only the intake steps** that come *before*
-discovery and spec drafting: classify the app type, ask the structural
-questions the matching recipe requires, record a local intake manifest, and
-clone a best-practice **architecture** fixture. Look is a later compose
-pass (`styling.md` as a library — not one house recipe).
+discovery and spec drafting: classify the app type, **interview** the user
+(editable fields, approvals, Sigma Agent), record a local intake manifest,
+state a build plan, and clone a best-practice **architecture** fixture.
+Look is a later compose pass (`styling.md` as a library — not one house
+recipe). The fixtures are the house standard to imitate; do not draft the
+first spec from memory.
 
 If the user supplied a screenshot, mockup, PDF, or design artifact, stop and
 load `from-image.md` instead. Image-driven reproduction is a different path.
@@ -25,6 +27,10 @@ linked to a governed source, or a “planning app” whose scenarios share one
 editable grid.
 
 This workflow makes classification, grain, and the starting spec explicit.
+It interviews **before** it clones: which fields users may edit, whether
+the workflow needs approvals, and whether to add a workbook agent (with a
+recommended purpose). Those answers become a short build plan for this
+workbook and the person who will use it.
 
 Do **not** invent a fifth operational type. Apps are still workbooks
 (`POST /v2/workbooks/spec`). Architecture details live in the matching recipe,
@@ -58,11 +64,12 @@ If the ask is mixed (for example, “planning *and* approvals”), follow the
 `from-image.md` boundary rule: **one workbook per app surface**. Confirm the
 split, then run this intake twice.
 
-### Step B — Type-specific questions
+### Step B — Interview before building
 
 Keep these few and structural. Do not expand into an open-ended UX interview.
 Load the matching recipe after classification so the answers map onto its
-grain and gates.
+grain and gates. Show the type's recommended answer for each question;
+confirm or override — do not invent a fifth operational type.
 
 **Every operational type** — the five input-table facts from
 `../specification/input-tables.md`:
@@ -99,6 +106,76 @@ Then the type-specific set:
 - One exception per entity, or a composite key (Exception Type / Observation Date)?
 - User override, or recommendation-only?
 
+Then the cross-cutting interview. These three questions apply to **every**
+type, including approval apps (that type is still a decision queue; the
+approvals question is whether to keep the submit / audit-log action).
+
+**Who uses this app?** — one line. Pre-fill the type's recommended audience
+(`FP&A planner` / `ops or finance owner` / `reviewer` / `ops owner`).
+Override if they named a role. The workbook still lands in the
+authenticated user's home folder (SKILL.md Step 0).
+
+**Editable fields (all types)** — which columns on the linked grid may
+users type into? Show the recommended `{ id, type }` list; they may subset
+or add names. Key columns and formula columns stay non-editable.
+
+| Type | Users edit (recommended) |
+|---|---|
+| planning | Method, Uplift %, Dollar Change, New Amount, Rationale |
+| allocation | Added Hires, Cost Uplift %, Rationale |
+| approval | Decision, Approved Discount, Reviewer, Decision Note |
+| exception | Override Order Qty, Decision, Owner, Resolution Note |
+
+```bash
+ruby -r ./scripts/lib/app_intake.rb -e 'p AppIntake.editable_fields_for("planning")'
+```
+
+**Approvals (all types)** — one question. Show the recommended purpose;
+do not reclassify the app.
+
+- Does this workflow need approvals? (yes / no)
+
+If **no**, keep the linked grid or queue and omit the fixture's submit /
+log-insert button and any status-update `whichRows` path. If **yes**, keep
+the recipe's approval/audit layer (planning: submit + scenario status;
+allocation: request log; approval: audit log + one-row status update;
+exception: resolution log).
+
+| Type | Recommended approval action |
+|---|---|
+| planning | submit the selected scenario: decision-log row + update only that scenario's status |
+| allocation | log a hiring or reallocation request (off the editable plan grid) |
+| approval | record Approve / Reject / Counter: audit-log row + `whichRows` on the stable entity key |
+| exception | log a resolution for the selected operational entity |
+
+```bash
+ruby -r ./scripts/lib/app_intake.rb -e 'puts AppIntake.approval_purpose_for("planning")'
+```
+
+**Sigma Agent (all types)** — one question. Show the recommended purpose
+for this type; do not invent a fifth operational type or an open-ended
+“what should the AI do?”
+
+- Add a workbook agent? (yes / no)
+
+If **no**, set `agent.include` false and omit `document.agents` and any
+`chat` element. If **yes**, set `agent.include` true and keep the type's
+recommended purpose unless they override it. Compose the agent in
+Step D.5 — do not draft `agents[]` during the interview.
+
+| Type | Analyze (`dataSources`) | Act (`tools`) |
+|---|---|---|
+| planning | plan grid, selected-plan ledger, all-scenario comparison, scenario directory, decision log — actual vs baseline vs selected plan | read-only unless they asked the agent to submit or log; any write tool sets `requiresApproval: true` |
+| allocation | allocation grid, working allocation, variance, request log — over/under, baseline vs added units, tradeoffs | read-only unless they asked the agent to log a request; any write tool sets `requiresApproval: true` |
+| approval | entity directory, review queue, decision log — prioritize by policy breach, value at risk, and age | do not record a decision unless they asked for that tool; any write tool sets `requiresApproval: true` |
+| exception | exception directory and action queue — rank unresolved items, skip already-logged resolutions | log-resolution (or equivalent) with `requiresApproval: true` |
+
+A helper prints the same purpose the manifest pre-fills:
+
+```bash
+ruby -r ./scripts/lib/app_intake.rb -e 'puts AppIntake.agent_purpose_for("exception")'
+```
+
 **Look (one optional question, all types)** — skip if they already named a
 brand, theme, or reference workbook. Do not turn this into a UX interview.
 
@@ -110,9 +187,23 @@ org theme**. Do **not** default to Dark on a page with text/list entry
 controls, and do **not** fall back to the `styling.md` exec-dashboard
 example.
 
-Do **not** proceed to spec draft until classification, grain keys, and a
-write-enabled connection are answered — or the user explicitly says to use
-the fixture defaults.
+Do **not** proceed to spec draft until classification, grain keys, a
+write-enabled connection, which fields users may edit, whether the
+workflow needs approvals, and whether to include a workbook agent are
+answered — or the user explicitly says to use the fixture defaults.
+
+Restate the answers as a **build plan** before cloning, then wait for
+confirmation:
+
+```text
+Build plan
+- App: <type> for <audience>
+- Grain: <keys>
+- Users edit: <editableFields>
+- Approvals: yes/no — <purpose>
+- Agent: yes/no — <purpose>
+- Fixture: <fixture>
+```
 
 ### Step C — Record a local intake manifest
 
@@ -121,14 +212,16 @@ is `/tmp/app-intake.json`.
 
 ```bash
 ruby scripts/lib/app_intake.rb init /tmp/app-intake.json planning
-# fill answers, sources, grain.expectedRows from Step B
+# fill answers, audience, editableFields, sources, approvals, agent,
+# grain.expectedRows from Step B
 ruby scripts/lib/app_intake.rb validate /tmp/app-intake.json
 ```
 
 `init` refuses to overwrite. Allowed `appType` values are `planning`,
 `allocation`, `approval`, and `exception`. The helper checks that `recipe`
 and `fixture` match the type, that `grain.keys` includes the required keys
-for that type, and that the fixture file exists on disk.
+for that type, that `editableFields`, `approvals`, and `agent` are present,
+and that the fixture file exists on disk.
 
 Use `--strict` only when sources are bound (write connection, source
 connection, table path, expected row count):
@@ -157,6 +250,22 @@ connection IDs, folder IDs, or workbook IDs into this skill.
    `Invalid kind: "button"`. Keep `clear-control` as
    `scope: { type: page, pageId: <page id> }` — a stale `page:` key is
    dropped on GET and click fails with `No target page is selected`.
+
+   Apply the interview:
+
+   - **Editable fields.** On the linked grid, keep only
+     `editableFields` as `{ id, type }` columns. Key columns stay keys;
+     formula columns stay formulas. If they named extra fields, add
+     `{ id, type }` columns after discovery — do not invent source
+     column names. If a formula referenced a dropped edit column,
+     rewrite it (usually `Coalesce` to the baseline) rather than leaving
+     a dangling `[Column]` ref.
+   - **Approvals.** If `approvals.include` is false, omit the fixture's
+     log-insert button and any status-update `whichRows` path. Keep the
+     linked grid. Log-only controls (comment/request inputs used only by
+     that button) go with the button. The empty log table may stay on a
+     hidden page. If `approvals.include` is true, keep the recipe's
+     approval/audit layer and the allowed decisions from Step B.
 4. Load `../specification/styling.md` as a **library**, not a stamp. A
    design pass is required — do not ship the fixture's default grid — but
    do **not** apply the five-pattern exec-dashboard stack (navy hero +
@@ -209,7 +318,29 @@ connection IDs, folder IDs, or workbook IDs into this skill.
 
    Name the design choices in the handoff summary (`composition.md`).
    Do not add a new composition to `styling.md` from a one-off app.
-5. Continue from SKILL.md Step 5: validate (`./scripts/validate-spec.sh`),
+5. **Workbook agent.** Fixtures stay agent-free; compose after clone.
+   If `agent.include` is false, omit `document.agents` and any `chat`
+   element. If **true**:
+
+   - Load `../specification/agents.md`. Confirm the org has workbook AI
+     agents enabled. If it does not, degrade to that file's static
+     sample-prompt text — never POST a cosmetic `chat` on a gated org.
+   - Build with `Richness.agent` + `Richness.chat`
+     (`scripts/lib/richness.rb`). `instructions` is the confirmed
+     `agent.purpose` plus the audience. `dataSources` are the type's
+     recommended element ids that exist on this spec:
+
+     ```bash
+     ruby -r ./scripts/lib/app_intake.rb -e 'p AppIntake.agent_data_sources_for("exception")'
+     ```
+
+   - **Read-only is the default:** omit `tools` entirely (not
+     `tools: []`). Add a write tool only if they overrode Act to include
+     one. Any write tool **must** set `requiresApproval: true`.
+   - Place `chat` as a **supporting rail**, not the focal work surface
+     (the grid or queue keeps the wide columns from Step D.4). Several
+     `chat` elements may share one `agents[]` id.
+6. Continue from SKILL.md Step 5: validate (`./scripts/validate-spec.sh`),
    POST, `./scripts/verify-workbook.sh`, then the recipe's runtime gates in
    `runtime-verification.md`.
 
@@ -224,6 +355,10 @@ system. They encode grain, writeback, and layout membership. Shared rules
 are in `fixtures/README.md`. Copy architecture from the matching fixture;
 compose the look in Step D.4. Do not assemble an operational app from
 `example-full.yaml` (that file is an analytical dashboard).
+
+Fixtures stay **agent-free** (`document.agents` and `chat` are composed in
+Step D.5 when `agent.include` is true). They **do** include the default
+approval/log layer; Step D.3 drops it when `approvals.include` is false.
 
 | Type | Fixture | Required layers |
 |---|---|---|

--- a/sigma-workbooks/reference/workflows/planning-apps.md
+++ b/sigma-workbooks/reference/workflows/planning-apps.md
@@ -228,6 +228,10 @@ active-scenario comparison. Never leave a one-bar “all scenarios” chart.
 
 ## Approval and audit
 
+Generate-apps Step B asks whether this workflow needs approvals. If they
+declined, keep the plan grid and omit the submit / status-update path
+below.
+
 Approval requires two writes:
 
 1. append an immutable decision row;
@@ -238,6 +242,9 @@ unchanged. Reset modal controls with ordered `set-control-value` effects after
 the insert; see `actions.md`.
 
 ## Agent contract
+
+Generate-apps Step B offers this agent and pre-fills the recommended
+purpose; skip this section if they declined.
 
 Give the agent the selected plan ledger, all-scenario comparison, plan grid,
 scenario directory, and decision log. Instruct it to:

--- a/sigma-workbooks/scripts/lib/app_intake.rb
+++ b/sigma-workbooks/scripts/lib/app_intake.rb
@@ -58,6 +58,61 @@ module AppIntake
     'exception' => %w[override]
   }.freeze
 
+  # Recommended `{ id, type }` columns on the linked grid. Keys and
+  # formulas stay non-editable. See generate-apps.md Step B.
+  EDITABLE_FIELDS = {
+    'planning' => ['Method', 'Uplift %', 'Dollar Change', 'New Amount', 'Rationale'],
+    'allocation' => ['Added Hires', 'Cost Uplift %', 'Rationale'],
+    'approval' => ['Decision', 'Approved Discount', 'Reviewer', 'Decision Note'],
+    'exception' => ['Override Order Qty', 'Decision', 'Owner', 'Resolution Note']
+  }.freeze
+
+  # Recommended approval/submit/log layer per type. Fixtures include this
+  # layer; generate-apps Step B asks whether to keep it.
+  APPROVAL_PURPOSES = {
+    'planning' => 'submit the selected scenario: append an immutable decision-log row and update only that scenario status',
+    'allocation' => 'log a hiring or reallocation request to the request log (approvals stay off the editable plan grid)',
+    'approval' => 'record Approve / Reject / Counter: append an audit-log row and update only the selected entity via whichRows on the stable key',
+    'exception' => 'log a resolution: append an immutable resolution-log row for the selected operational entity'
+  }.freeze
+
+  AUDIENCES = {
+    'planning' => 'FP&A planner',
+    'allocation' => 'ops or finance owner',
+    'approval' => 'reviewer',
+    'exception' => 'ops owner'
+  }.freeze
+
+  # Fixture element ids the type's agent may query (dataSources).
+  AGENT_DATA_SOURCES = {
+    'planning' => %w[plan-grid plan-matrix scenarios decision-log],
+    'allocation' => %w[alloc-grid request-log],
+    'approval' => %w[deal-directory review-queue decision-log],
+    'exception' => %w[exception-directory action-queue resolution-log]
+  }.freeze
+
+  # Recommended workbook-agent purpose per type. Analyze = dataSources;
+  # Act = tools[] (omit for read-only). Write tools always require
+  # requiresApproval: true — see reference/specification/agents.md.
+  AGENT_PURPOSES = {
+    'planning' => {
+      'analyze' => 'plan grid, selected-plan ledger, all-scenario comparison, scenario directory, and decision log — distinguish actual vs baseline vs selected plan; compare only scenario-keyed rows',
+      'act' => 'read-only unless they asked the agent to submit or log; any write tool sets requiresApproval: true and must not claim a write without that confirmation'
+    },
+    'allocation' => {
+      'analyze' => 'allocation grid, working allocation, variance, and request log — which dimension is over/under, whether variance is baseline underfunding vs added units, concentration and tradeoffs',
+      'act' => 'read-only unless they asked the agent to log a request; any write tool sets requiresApproval: true'
+    },
+    'approval' => {
+      'analyze' => 'entity directory, review queue, and decision log — prioritize by policy breach, value at risk, and age; name the highest-risk pending entity',
+      'act' => 'do not record a decision unless they asked for that tool; any write tool sets requiresApproval: true and must not claim a decision was written without confirmation'
+    },
+    'exception' => {
+      'analyze' => 'exception directory and action queue — rank unresolved items by urgency and impact, skip already-logged resolutions, distinguish source risk from the user-entered override',
+      'act' => 'log-resolution (or equivalent) action tool with requiresApproval: true'
+    }
+  }.freeze
+
   module_function
 
   def recipe_for(app_type)
@@ -66,6 +121,27 @@ module AppIntake
 
   def fixture_for(app_type)
     FIXTURES[app_type]
+  end
+
+  def agent_purpose_for(app_type)
+    purpose = AGENT_PURPOSES.fetch(app_type)
+    "Analyze: #{purpose['analyze']}. Act: #{purpose['act']}."
+  end
+
+  def editable_fields_for(app_type)
+    EDITABLE_FIELDS.fetch(app_type).dup
+  end
+
+  def approval_purpose_for(app_type)
+    APPROVAL_PURPOSES.fetch(app_type)
+  end
+
+  def audience_for(app_type)
+    AUDIENCES.fetch(app_type)
+  end
+
+  def agent_data_sources_for(app_type)
+    AGENT_DATA_SOURCES.fetch(app_type).dup
   end
 
   def route_for(app_type)
@@ -125,10 +201,20 @@ module AppIntake
       'recipe' => recipe_for(app_type),
       'fixture' => fixture_for(app_type),
       'answers' => answers,
+      'audience' => audience_for(app_type),
+      'editableFields' => editable_fields_for(app_type),
       'sources' => {
         'connectionId' => nil,
         'tablePath' => nil,
         'writeConnectionId' => nil
+      },
+      'approvals' => {
+        'include' => true,
+        'purpose' => approval_purpose_for(app_type)
+      },
+      'agent' => {
+        'include' => false,
+        'purpose' => agent_purpose_for(app_type)
       },
       'grain' => {
         'keys' => GRAIN_KEYS.fetch(app_type).dup,
@@ -190,6 +276,42 @@ module AppIntake
       end
     else
       out << 'sources must be an object'
+    end
+
+    audience = manifest['audience']
+    out << 'audience must be a non-empty string' unless
+      audience.is_a?(String) && !audience.strip.empty?
+
+    fields = manifest['editableFields']
+    out << 'editableFields must be a non-empty array of field names' unless
+      fields.is_a?(Array) && !fields.empty? && fields.all? { |name| name.is_a?(String) && !name.strip.empty? }
+
+    approvals = manifest['approvals']
+    if approvals.is_a?(Hash)
+      unless [true, false].include?(approvals['include'])
+        out << 'approvals.include must be true or false'
+      end
+      if approvals['include'] == true
+        purpose = approvals['purpose']
+        out << 'approvals.purpose must be a non-empty string when include is true' if
+          purpose.nil? || (purpose.is_a?(String) && purpose.strip.empty?)
+      end
+    else
+      out << 'approvals must be an object'
+    end
+
+    agent = manifest['agent']
+    if agent.is_a?(Hash)
+      unless [true, false].include?(agent['include'])
+        out << 'agent.include must be true or false'
+      end
+      if agent['include'] == true
+        purpose = agent['purpose']
+        out << 'agent.purpose must be a non-empty string when include is true' if
+          purpose.nil? || (purpose.is_a?(String) && purpose.strip.empty?)
+      end
+    else
+      out << 'agent must be an object'
     end
 
     grain = manifest['grain']

--- a/sigma-workbooks/scripts/lib/test_app_intake.rb
+++ b/sigma-workbooks/scripts/lib/test_app_intake.rb
@@ -34,6 +34,25 @@ AppIntake::APP_TYPES.each do |app_type|
     raise 'missing write connection error' unless errors.any? { |error| error.include?('writeConnectionId') }
     raise 'missing expectedRows error' unless errors.any? { |error| error.include?('expectedRows') }
   end
+
+  check("#{app_type} template includes recommended editable fields", failures) do
+    fields = AppIntake.template_for(app_type).fetch('editableFields')
+    expected = AppIntake.editable_fields_for(app_type)
+    raise "expected #{expected.inspect}, got #{fields.inspect}" unless fields == expected
+  end
+
+  check("#{app_type} template pre-fills agent and approvals", failures) do
+    manifest = AppIntake.template_for(app_type)
+    agent = manifest.fetch('agent')
+    raise 'agent.include must default false' unless agent['include'] == false
+    raise 'agent.purpose missing' if agent['purpose'].to_s.strip.empty?
+    raise 'agent purpose mismatch' unless agent['purpose'] == AppIntake.agent_purpose_for(app_type)
+    approvals = manifest.fetch('approvals')
+    raise 'approvals.include must default true' unless approvals['include'] == true
+    raise 'approvals.purpose missing' if approvals['purpose'].to_s.strip.empty?
+    raise 'approvals purpose mismatch' unless approvals['purpose'] == AppIntake.approval_purpose_for(app_type)
+    raise 'audience missing' if manifest['audience'].to_s.strip.empty?
+  end
 end
 
 check('unknown appType is rejected', failures) do
@@ -67,6 +86,36 @@ check('completed manifest passes strict validation', failures) do
   manifest['grain']['expectedRows'] = 12
   errors = AppIntake.errors(manifest, strict: true)
   raise errors.join('; ') unless errors.empty?
+end
+
+check('agent.include true with blank purpose is rejected', failures) do
+  manifest = AppIntake.template_for('exception')
+  manifest['agent'] = { 'include' => true, 'purpose' => '  ' }
+  errors = AppIntake.errors(manifest)
+  raise 'blank agent purpose was accepted' unless errors.any? { |error| error.include?('agent.purpose') }
+end
+
+check('approvals.include true with blank purpose is rejected', failures) do
+  manifest = AppIntake.template_for('planning')
+  manifest['approvals'] = { 'include' => true, 'purpose' => '' }
+  errors = AppIntake.errors(manifest)
+  raise 'blank approvals purpose was accepted' unless errors.any? { |error| error.include?('approvals.purpose') }
+end
+
+check('empty editableFields is rejected', failures) do
+  manifest = AppIntake.template_for('allocation')
+  manifest['editableFields'] = []
+  errors = AppIntake.errors(manifest)
+  raise 'empty editableFields was accepted' unless errors.any? { |error| error.include?('editableFields') }
+end
+
+check('helpers return a purpose and data sources for every type', failures) do
+  AppIntake::APP_TYPES.each do |app_type|
+    raise "#{app_type} agent purpose blank" if AppIntake.agent_purpose_for(app_type).strip.empty?
+    raise "#{app_type} approval purpose blank" if AppIntake.approval_purpose_for(app_type).strip.empty?
+    raise "#{app_type} missing data sources" if AppIntake.agent_data_sources_for(app_type).empty?
+    raise "#{app_type} missing editable fields" if AppIntake.editable_fields_for(app_type).empty?
+  end
 end
 
 check('init refuses to overwrite an existing manifest', failures) do

--- a/sigma-workbooks/scripts/test-app-fixtures.rb
+++ b/sigma-workbooks/scripts/test-app-fixtures.rb
@@ -153,6 +153,30 @@ AppIntake::APP_TYPES.each do |app_type|
       doc.dig('document', 'settings', 'theme')
   end
 
+  check("#{app_type} fixture stays agent-free", failures) do
+    raise 'fixtures must not ship document.agents — compose in generate-apps Step D.5' if
+      doc.dig('document', 'agents')
+    raise 'fixtures must not ship a chat element' if
+      elements(doc).any? { |el| el['kind'] == 'chat' }
+  end
+
+  check("#{app_type} recommended agent data sources exist on the fixture", failures) do
+    ids = elements(doc).map { |el| el['id'] }
+    AppIntake.agent_data_sources_for(app_type).each do |element_id|
+      raise "agent data source #{element_id} missing from fixture" unless ids.include?(element_id)
+    end
+  end
+
+  check("#{app_type} recommended editable fields are type columns on the linked grid", failures) do
+    linked = input_tables(doc).find { |table| table.dig('source', 'kind') == 'linked' }
+    raise 'missing linked input-table' unless linked
+
+    names = Array(linked['columns']).select { |col| col['type'] }.map { |col| col['name'] }
+    AppIntake.editable_fields_for(app_type).each do |name|
+      raise "#{name.inspect} is not a type column on #{linked['id']}" unless names.include?(name)
+    end
+  end
+
   check("#{app_type} layout places every element", failures) do
     xml = layout(doc)
     elements(doc).each do |el|
@@ -226,6 +250,20 @@ check('generate-apps PNG fail list encodes input and Dark constraints', failures
   text = File.read(path)
   %w[white-on-white Dark-on-dark 3-KPI strip data-entry app].each do |needle|
     raise "missing constraint #{needle.inspect}" unless text.include?(needle)
+  end
+end
+
+check('generate-apps interviews for fields, approvals, and agent', failures) do
+  path = File.join(SKILL_ROOT, 'reference/workflows/generate-apps.md')
+  text = File.read(path)
+  %w[
+    Interview before building
+    Editable fields (all types)
+    Does this workflow need approvals?
+    Add a workbook agent?
+    supporting rail
+  ].each do |needle|
+    raise "missing interview #{needle.inspect}" unless text.include?(needle)
   end
 end
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Follow-up to #49. Generate-app now **interviews before it builds**, and the planning fixture is a sanitized **Planning Studio shell** instead of a one-page grid.

## Interview (Step B)

After classification and grain, the skill asks three cross-cutting questions and **pre-fills a recommended answer per type**:

1. **Which fields may users edit** on the linked grid (`editableFields`). Keys and formulas stay non-editable.
2. **Does this workflow need approvals?** Submit / audit-log / request-log / resolution-log, depending on type. If no, keep the grid and omit the fixture’s log-insert button.
3. **Add a Sigma Agent?** If yes, use the type’s recommended purpose (analyze which tables; act only with `requiresApproval: true`). Chat is a supporting rail, not the focal queue. Fixtures stay agent-free.

It also asks who the app is for and restates a **build plan** before cloning.

## Planning fixture

`fixtures/planning-app.yaml` is now a parameterized studio (35 elements), derived from the live FP&A Planning Studio without the paint:

- Pages: Workspace, Scenarios, Build the Plan, Review & Approve, hidden Data
- New Scenario overlay (`insert-rows` into the scenarios directory)
- Actuals + plan base → join matrix → linked Plan Grid → union ledger
- Grid edits: Method, Pct Change, Dollar Change, New Amount, Rationale
- Review: Submit / Approve / Request changes = log insert + `update-rows` `whichRows: [Scenario Name] = [scenario]`
- Workspace: three **plan measures** (revenue, EBITDA, profit impact), trend, impact-by-section — not a status-count strip
- Review agent rail placeholder; `chat` is still composed in Step D.5

Left out of the fixture: indigo headers, logos, Guide page, FY26 copy, live IDs, theme, `document.agents`. Allocation / approval / exception fixtures are unchanged.

## Dogfood follow-up (live generate-app)

Live POST/PNG of planning, allocation, and approval turned up traps now encoded in the fixtures and docs:

- Entry `text` / `text-area` controls need `mode`, `case`, `includeNulls`, `showOperators` or POST is `Invalid kind: "control"`.
- PNG fail list: **empty work surface** (unseeded input table) and **Unknown column / Invalid Query** (`$` in a column name, union GET-renamed, invented warehouse columns).
- Planning: union `name` drops on GET (`Ledger Union` → `Union of 2 Sources`); spec cannot seed an empty input table; do not splice `Coalesce([scenario], …)` into an existing `If(...)`.
- Allocation: derive Period × Dimension in-workbook when the warehouse is people-grain; do not invent `[Source/Period]`.
- Approval / exception: cap the queue *before* linking; `top-n` on the parent does not flow to the linked input table.

## Tests

Creds-free:

- `scripts/lib/test_app_intake.rb` — recommended fields / approvals / agent purpose
- `scripts/test-app-fixtures.rb` — studio pages, overlay, ledger, `whichRows`, no chat / no live IDs / no branded hex, entry-control fields, PNG-fail needles

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e23f9c00-e163-4cbb-a16f-a430343922b4?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e23f9c00-e163-4cbb-a16f-a430343922b4&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

