### PR TITLE
feat: install sigma-skills as a Claude Code marketplace plugin

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,26 @@
+{
+  "$schema": "https://json.schemastore.org/claude-code-plugin-marketplace-manifest.json",
+  "name": "sigma-skills",
+  "description": "Sigma Computing authoring skills: API auth, data models, workbooks, reports, custom plugins, and custom-SQL promotion. Skills stay at the repo root so Cursor / Codex / symlink installs keep working; Claude Code installs the same tree as a marketplace plugin.",
+  "version": "1.0.0",
+  "owner": {
+    "name": "TJ Wells",
+    "url": "https://github.com/twells89"
+  },
+  "plugins": [
+    {
+      "name": "sigma-skills",
+      "source": "./",
+      "description": "Author Sigma data models, workbooks, reports, and custom plugins via the REST API. Includes sigma-api (auth), sigma-data-models, sigma-workbooks, sigma-reports, sigma-plugin-authoring, and custom-sql-to-data-model.",
+      "category": "productivity",
+      "keywords": [
+        "sigma",
+        "workbooks",
+        "data-models",
+        "reports",
+        "api",
+        "authoring"
+      ]
+    }
+  ]
+}

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,0 +1,24 @@
+{
+  "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
+  "name": "sigma-skills",
+  "displayName": "Sigma Skills",
+  "version": "1.0.0",
+  "description": "Author Sigma data models, workbooks, reports, and custom plugins via the REST API. Bundles sigma-api, sigma-data-models, sigma-workbooks, sigma-reports, sigma-plugin-authoring, and custom-sql-to-data-model.",
+  "author": {
+    "name": "TJ Wells",
+    "url": "https://github.com/twells89"
+  },
+  "homepage": "https://github.com/twells89/sigma-skills",
+  "repository": "https://github.com/twells89/sigma-skills",
+  "keywords": [
+    "sigma",
+    "api",
+    "authentication",
+    "workbooks",
+    "data-models",
+    "reports",
+    "authoring",
+    "spec"
+  ],
+  "skills": "./skills/"
+}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -26,6 +26,8 @@ jobs:
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: '3.3'
+      - name: Validate Claude plugin marketplace
+        run: ruby scripts/test-plugin-manifest.rb
       - name: Run every test-*.rb / test_*.rb (glob, aggregate failures)
         run: |
           set -uo pipefail

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ The skills split along the surfaces of the Sigma REST API: data models, responsi
 
 | Agent | Format | How it loads |
 |---|---|---|
-| Claude Code | `SKILL.md` (canonical) | Symlink the skill into `~/.claude/skills/` |
+| Claude Code | `SKILL.md` (canonical) | `/plugin install sigma-skills@sigma-skills`, or symlink into `~/.claude/skills/` |
 | Cortex Code (Snowflake) | `SKILL.md` (same as Claude Code) | Symlink into `~/.snowflake/cortex/skills/` or rely on its `~/.claude/skills/` fallback |
 | Codex (OpenAI CLI) | `AGENTS.md` | Drop `generated/codex/AGENTS.md` into project root or `~/.codex/AGENTS.md` |
 | Cursor | `.cursor/rules/<name>.mdc` | Drop `generated/cursor/rules/<skill>.mdc` into `<project>/.cursor/rules/` |
@@ -99,14 +99,34 @@ for the full flow.
 
 ## Installation
 
-### Claude Code & Cortex Code (use SKILL.md directly)
+### Claude Code (plugin marketplace)
+
+This repo is a Claude Code marketplace. Skill directories stay at the repo
+root (so Cursor / Codex / symlink installs do not change); `skills/` is a
+set of relative links Claude Code uses when it copies the plugin.
+
+```text
+/plugin marketplace add twells89/sigma-skills
+/plugin install sigma-skills@sigma-skills
+```
+
+After install, invoke a skill as `/sigma-skills:<skill-name>` (for example
+`/sigma-skills:sigma-workbooks`). Run scripts from that skill directory —
+paths in each `SKILL.md` are relative.
+
+Refresh later with `/plugin marketplace update sigma-skills`.
+
+### Claude Code & Cortex Code (symlink SKILL.md)
+
+Use this when you want a clone on disk instead of (or in addition to) the
+plugin. Do not glob every top-level directory — `scripts/` and `skills/`
+are not skills.
 
 ```bash
 git clone https://github.com/twells89/sigma-skills.git ~/sigma-skills
 mkdir -p ~/.claude/skills
-for d in ~/sigma-skills/*/; do
-  name=$(basename "$d")
-  ln -sf "$d" ~/.claude/skills/"$name"
+for name in sigma-api sigma-data-models sigma-workbooks sigma-reports sigma-plugin-authoring custom-sql-to-data-model; do
+  ln -sf ~/sigma-skills/"$name" ~/.claude/skills/"$name"
 done
 ```
 
@@ -152,6 +172,12 @@ agents:end -->
 ## Updating
 
 These skills are maintained against current Sigma API behavior. When the API evolves and a skill returns a "schema mismatch" error (`unknown field`, `unexpected property`, `invalid argument` on shape), pull the latest:
+
+```text
+/plugin marketplace update sigma-skills
+```
+
+Or, if you cloned the repo:
 
 ```bash
 cd ~/sigma-skills && git pull

--- a/scripts/test-plugin-manifest.rb
+++ b/scripts/test-plugin-manifest.rb
@@ -1,0 +1,77 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+# Creds-free check that this repo is a valid Claude Code marketplace plugin
+# without moving the skill directories Cursor / Codex / symlink installs use.
+
+require 'json'
+require 'pathname'
+
+ROOT = File.expand_path('..', __dir__)
+SKILLS = %w[
+  sigma-api
+  sigma-data-models
+  sigma-workbooks
+  sigma-reports
+  sigma-plugin-authoring
+  custom-sql-to-data-model
+].freeze
+
+failures = []
+
+def check(name, failures)
+  yield
+  puts "PASS: #{name}"
+rescue StandardError => e
+  puts "FAIL: #{name} — #{e.message}"
+  failures << name
+end
+
+check('marketplace.json parses and names this catalog', failures) do
+  path = File.join(ROOT, '.claude-plugin', 'marketplace.json')
+  raise 'missing .claude-plugin/marketplace.json' unless File.file?(path)
+
+  catalog = JSON.parse(File.read(path))
+  raise "expected marketplace name sigma-skills, got #{catalog['name'].inspect}" unless
+    catalog['name'] == 'sigma-skills'
+  raise 'marketplace owner.name is required' if catalog.dig('owner', 'name').to_s.strip.empty?
+  raise 'marketplace must list at least one plugin' if Array(catalog['plugins']).empty?
+
+  plugin = catalog['plugins'].find { |entry| entry['name'] == 'sigma-skills' }
+  raise 'marketplace is missing the sigma-skills plugin entry' unless plugin
+  raise "plugin source must be ./ so the skill tree is copied (got #{plugin['source'].inspect})" unless
+    plugin['source'] == './'
+end
+
+check('plugin.json lives next to the marketplace catalog', failures) do
+  path = File.join(ROOT, '.claude-plugin', 'plugin.json')
+  raise 'missing .claude-plugin/plugin.json' unless File.file?(path)
+
+  manifest = JSON.parse(File.read(path))
+  raise "expected plugin name sigma-skills, got #{manifest['name'].inspect}" unless
+    manifest['name'] == 'sigma-skills'
+  raise "expected skills ./skills/, got #{manifest['skills'].inspect}" unless
+    manifest['skills'] == './skills/'
+end
+
+check('skills/ maps every authoring skill onto its repo-root directory', failures) do
+  SKILLS.each do |name|
+    canonical = File.join(ROOT, name, 'SKILL.md')
+    raise "canonical skill missing: #{name}/SKILL.md" unless File.file?(canonical)
+
+    link = File.join(ROOT, 'skills', name)
+    raise "skills/#{name} is not a symlink — plugin install would duplicate or miss #{name}" unless
+      File.symlink?(link)
+
+    target = File.expand_path(File.readlink(link), File.join(ROOT, 'skills'))
+    expected = File.join(ROOT, name)
+    raise "skills/#{name} points at #{target}, expected #{expected}" unless target == expected
+    raise "skills/#{name} does not resolve to SKILL.md" unless File.file?(File.join(link, 'SKILL.md'))
+  end
+
+  extra = Dir.children(File.join(ROOT, 'skills')) - SKILLS
+  raise "unexpected entries under skills/: #{extra.join(', ')}" unless extra.empty?
+end
+
+abort "#{failures.length} failure(s)" unless failures.empty?
+puts 'All plugin-manifest tests passed.'

--- a/skills/custom-sql-to-data-model
+++ b/skills/custom-sql-to-data-model
@@ -1,0 +1,1 @@
+../custom-sql-to-data-model

--- a/skills/sigma-api
+++ b/skills/sigma-api
@@ -1,0 +1,1 @@
+../sigma-api

--- a/skills/sigma-data-models
+++ b/skills/sigma-data-models
@@ -1,0 +1,1 @@
+../sigma-data-models

--- a/skills/sigma-plugin-authoring
+++ b/skills/sigma-plugin-authoring
@@ -1,0 +1,1 @@
+../sigma-plugin-authoring

--- a/skills/sigma-reports
+++ b/skills/sigma-reports
@@ -1,0 +1,1 @@
+../sigma-reports

--- a/skills/sigma-workbooks
+++ b/skills/sigma-workbooks
@@ -1,0 +1,1 @@
+../sigma-workbooks


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Claude Code can now install this repo as a marketplace plugin. Skill directories stay at the repo root, so Cursor / Codex / the existing `~/.claude/skills/` symlink path do not change.

## Install

```text
/plugin marketplace add twells89/sigma-skills
/plugin install sigma-skills@sigma-skills
```

Skills are namespaced as `/sigma-skills:<skill-name>` (for example `/sigma-skills:sigma-workbooks`).

## How it is packaged

Claude copies the plugin `source` directory into its cache, so the cache has to contain real `SKILL.md` + `scripts/` trees — not links that point outside the plugin.

- `.claude-plugin/marketplace.json` — catalog `sigma-skills`, one plugin, `source: "./"`
- `.claude-plugin/plugin.json` — `skills: "./skills/"`
- `skills/<name>` — relative symlinks to the canonical `./<name>/` skill dirs

The symlink loop in the README is now an explicit skill list so it no longer also links `scripts/`.

## Tests

`ruby scripts/test-plugin-manifest.rb` (wired into CI) checks the catalog, the manifest, and that every `skills/` link resolves to a `SKILL.md`.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e23f9c00-e163-4cbb-a16f-a430343922b4?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e23f9c00-e163-4cbb-a16f-a430343922b4&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

