### PR TITLE
docs(sigma-workbooks): repeated-container card background + conditional formats, and what dynamic text actually does in a card

### DIFF
--- a/sigma-workbooks/reference/specification/content-elements.md
+++ b/sigma-workbooks/reference/specification/content-elements.md
@@ -24,6 +24,20 @@ body: |
 
 (YAML's `|` block scalar keeps the body readable.)
 
+> **Two traps, both live-verified 2026-08-28:**
+>
+> 1. **Never leave `body` blank or whitespace-only.** `body: " "` passes `/verify`
+>    and `POST`, then renders Sigma's error boundary — *"We've encountered an
+>    error! Sentry Id: …"* — in place of the element. Seen on a `text` child of a
+>    repeated container; give every card child real text.
+> 2. **Prose containing `{{ }}` is evaluated, not displayed.** A body that merely
+>    *documents* a reference is parsed as dynamic text. It fails two different
+>    ways depending on whether the inner text parses: an element-qualified ref
+>    hard-fails `/verify` with `Dependency not found`, while something like
+>    `{{formula}}` passes verify *and* `POST` and then renders
+>    `Invalid Query: Unknown column "[formula]"` inline. Write such examples
+>    without the braces, or with the braces spelled out in prose.
+
 ### `body`: Markdown + inline styling
 
 `body` is Markdown plus a small set of inline HTML for styling. Standard Markdown: paragraphs, `**bold**`, `*italic*`, headings (`#`, `##`, `###`), bullet / ordered lists, `[links](https://example.com)`, and `{{formula}}` / `{{ast | fmt}}` segments (same syntax as element titles, e.g. `{{Count() | ,.0f}}`).

--- a/sigma-workbooks/reference/specification/controls.md
+++ b/sigma-workbooks/reference/specification/controls.md
@@ -50,7 +50,7 @@ name: Store region
 controlType: list
 mode: include            # include | exclude   (TOP-LEVEL, not nested)
 selectionMode: multiple  # single | multiple   (TOP-LEVEL)
-values: []               # default selection, [] = all   (TOP-LEVEL)
+values: []               # default selection, [] = all   (TOP-LEVEL — multiple only)
                          # authored defaults drop on GET when the bound
                          # column has no matching members yet (empty
                          # input table / unseeded directory). PNG then
@@ -69,6 +69,15 @@ filters:                 # the TARGETS it filters — one entry per element+colu
 ```
 
 > **Verified working shape** (pulled from a live, successfully-POSTed workbook 2026-06-15). A list control carries `source` / `mode` / `selectionMode` / `values` as **flat top-level siblings** — NOT inside a nested "value object." The single most common mistake is omitting `source`/`mode`/`selectionMode`/`values` (or nesting them); Sigma then rejects the element with the opaque catch-all `Invalid kind: "control"`, which means **the inner fields are wrong, NOT that controls are unsupported** (see `reference/workflows/validate.md`). `segmented` is the other flat-scalar list-style widget — same wiring. `hierarchy` is a list-style widget too, but unlike `segmented` it doesn't support `source`-based wiring — see `## Hierarchy` below for its `filters`-only shape.
+
+> **`selectionMode: single` takes a scalar `value`, not `values`** (live-verified
+> 2026-08-28). Passing `values: ["North"]` on a single-select list is silently
+> normalised — readback shows `value: null` and the widget renders with nothing
+> selected, so any formula reading the control (a `conditionalFormats` rule, a
+> dynamic-text `{{[MyControl]}}`) evaluates against an empty value and looks like
+> a data bug rather than a control bug. Use `value: "North"` for single-select and
+> reserve `values: [...]` for `selectionMode: multiple`. Same trap as `segmented`
+> below.
 
 > **A control cannot bind to a map element** (`point-map` / `region-map` / `geography-map`). Pointing a list control's `source` (value list) or a `filters[]` target at a map element fails the POST with `Dependency not found: '<mapElementId>'` (live-verified 2026-06-26). Back the control with a real `table` element (e.g. a small dimension/directory table on the same column) for both the value list and the filter target. To also scope the map, filter it indirectly (e.g. drive the map's source element off the same filtered table, or apply the predicate in the data model) rather than targeting the map element directly.
 

--- a/sigma-workbooks/reference/specification/layout.md
+++ b/sigma-workbooks/reference/specification/layout.md
@@ -68,10 +68,13 @@ Use `<Container>` for any tag with nested children — a `<Element>` only render
 A `kind: "container"` entry in `document.elements[]` is a grouping placeholder
 — a labeled section, branded background, or KPI row. It renders only through a
 matching `<Container>`. Containers expose `style` (background color, border,
-corner radius, padding), top-level `backgroundImage`, and child spacing:
+corner radius, padding), top-level `backgroundImage`, child spacing —
 `elementGap` (`shown` / `hidden`) plus `spacing`
-(`small` / `medium` / `large`). Pull the current schema before using additional
-fields.
+(`small` / `medium` / `large`) — and `conditionalFormats` (background colour by
+formula; shape and gotchas under
+[`conditionalFormats`](#conditionalformats--card-background-colour-by-formula) in
+the repeated-container section, which shares it). Pull the current schema before
+using additional fields.
 
 ```bash
 jq --arg k container 'first(.. | objects | select((.allOf? and any(.allOf[]?; .properties?.kind?.enum==[$k])) or .properties?.kind?.enum==[$k]))' /tmp/sigma-api.json
@@ -100,9 +103,9 @@ jq --arg k container 'first(.. | objects | select((.allOf? and any(.allOf[]?; .p
 
 A **repeated container** is a first-class element kind: one card (or list row)
 rendered once per row of a source. The element and its `<Container>` layout are
-spec-authorable; use an unbound/plain child when probing the rest of the
-contract. Dynamic row binding currently has the API regression documented
-below and must stay gated.
+spec-authorable, as are per-card styling and conditional formatting. The one
+thing still broken is the **per-row field reference** — see *Binding children to
+the row* below; everything else in dynamic text works.
 
 ```yaml
 - id: rc
@@ -113,10 +116,65 @@ below and must stay gated.
   cardStyle:
     backgroundColor: "#EEF2F7"
     borderRadius: round      # square | round | pill
+    backgroundImage:                       # URL-only — uploads rejected here
+      source: { kind: url, url: "https://cdn.example.com/card.png" }
+      style: { fit: contain, tiling: none }
+  conditionalFormats:
+    - id: cf1
+      formula: "1 = 1"                     # must be a real comparison, see below
+      config: { backgroundColor: "#00C853" }
   noDataText: No rows yet
 ```
 
-Required: `id`, `kind`, `source`. `source` takes the usual union — `table` (another element, via `elementId`), `warehouse-table`, `data-model`, `sql`, `join`, `union`, `csv-table`, `metric-view`, `semantic-view`, `transpose`. Optional: `arrangement`, `cardSize`, `cardGap` / `cardSpacing`, `elementGap` / `elementSpacing`, `scroll` (`vertical` | `horizontal` | `none`), `filters`, `sort`, `noDataText`, `style`, `cardStyle`.
+Required: `id`, `kind`, `source`. `source` takes the usual union — `table` (another element, via `elementId`), `warehouse-table`, `data-model`, `sql`, `join`, `union`, `csv-table`, `metric-view`, `semantic-view`, `transpose`. Optional: `arrangement`, `cardSize`, `cardGap` / `cardSpacing`, `elementGap` / `elementSpacing`, `scroll` (`vertical` | `horizontal` | `none`), `filters`, `sort`, `noDataText`, `style`, `cardStyle` (including `cardStyle.backgroundImage`), `conditionalFormats`, `actions`.
+
+### `cardStyle.backgroundImage` — per-card background image
+
+Live as of 2026-08-28. The card background is **URL-only**: `source` must
+be `{kind: url, url}`. An `{kind: upload, key}` handle — valid on a plain
+container's `backgroundImage` — is rejected here (`cardStyle.backgroundImage.source.kind:
+Invalid "url": string`), which keeps the write path synchronous. `style` takes the
+usual `fit` / `horizontalAlign` / `verticalAlign` / `tiling`.
+
+The URL accepts `{{formula}}` dynamic text, but **references are not validated on
+this path**: a nonexistent column, a nonexistent element, and even unparseable
+garbage all pass `/verify` *and* `POST`, then round-trip verbatim. The same
+reference in a text `body` hard-errors. Render the page to check a dynamic card
+background — readback cannot tell you whether it resolved.
+
+Two live quirks when it does resolve: a per-row column reference interpolates to
+the literal string `null` (see the row-binding note below), and value formatting
+differs by surface — `{{Today()}}` renders `2026-08-28` in a text `body` but raw
+epoch `1787875200000` in a background URL.
+
+### `conditionalFormats` — card background colour by formula
+
+Also live as of 2026-08-28. Same shape on `kind: container` and
+`kind: repeated-container`, and
+**different from the table/pivot `conditionalFormats`** in `tables.md`:
+
+```yaml
+conditionalFormats:
+  - id: cf1
+    formula: '[MyControl] = "North"'   # boolean formula
+    config:
+      backgroundColor: "#2962FF"       # `config` is REQUIRED, not `style`
+```
+
+Rules are evaluated in order; the first match wins, overriding
+`style.backgroundColor` / `cardStyle.backgroundColor`.
+
+- **`config` is required** and its only field is `backgroundColor`. Writing
+  `style: {backgroundColor: ...}` instead is silently dropped.
+- **The formula must be a real comparison.** `1 = 1` fires; **`True()` is accepted
+  by `/verify` and `POST`, round-trips cleanly, and never fires** — verified
+  side-by-side on a plain container, so it is not repeater-specific.
+- **Control/parameter references work** (`[MyControl] = "North"`), which is the
+  practical way to get per-card colour that responds to user input today.
+  Per-row *column* references silently evaluate false.
+- Repeater support is gated on the `repeater_cond_formatting` org flag; when it is
+  off, a write is rejected and a read omits the field even if the store has rules.
+  Container support is unconditional.
 
 ### Binding children to the row — the derived name
 
@@ -132,20 +190,56 @@ So a source element named `Star Events` yields
 `{{[Star Events repeated container/Repo Name]}}`. Columns are referenced by
 their `name`, not their `id`.
 
-> **Known API regression (live 2026-08-08):** that exact, correctly derived
-> target is present in existing GET readbacks, proving it is a real
-> representation. However, both `/v2/workbooks/spec/verify` and
-> `POST /v2/workbooks/spec` currently reject a replay with
-> `Dependency not found: 'Star Events repeated container/Repo Name'`. Do not
-> mark bound repeated-container authoring green until both paths accept it.
-> `scripts/probe-release-contract.rb` keeps a plain child in its main
-> create/readback and runs this binding as a separate strict expected-regression
-> check.
+> **Known API regression — still open, re-probed live 2026-08-28.** That exact,
+> correctly derived target is present in existing GET readbacks, proving it is a
+> real representation, but both `/v2/workbooks/spec/verify` and
+> `POST /v2/workbooks/spec` reject a replay with
+> `Dependency not found: 'star events repeated container/repo name'`. A fix is in
+> flight upstream but **has not shipped** as of 2026-08-28 — re-probe both paths
+> before marking bound repeated-container authoring green.
+>
+> The trap is that the *wrong* forms are the ones that pass. Per-syntax, for a
+> `text` child of a repeater over a source element named `Regions`:
+>
+> | Reference | Result |
+> | --- | --- |
+> | `{{[Region]}}` (bare) | accepted, renders **`Multiple values`** |
+> | `{{[src-tbl/Region]}}` (source element **id**) | accepted, renders **`Multiple values`** |
+> | `{{[Regions/Region]}}` (source element **name**) | accepted, renders **`Multiple values`** |
+> | `{{[Regions repeated container/Region]}}` (derived, correct) | **rejected** — `Dependency not found` |
+> | `{{[rc/Region]}}` (repeater element id) | **rejected** — `Dependency not found` |
+> | `{{[Regions].[Region]}}` (dotted) | **rejected** — `Expected exactly one parsed formula … got 0` |
+>
+> So the three accepted forms write clean, read back clean, and then render
+> `Multiple values` identically in every card. **Only a rendered PNG catches
+> this** — `scripts/wb-rep.rb render <dir>` (see
+> `reference/workflows/element-rep.md`), or the export API. In a card background
+> URL the same reference interpolates to the literal string `null` instead.
 >
 > The virtual target is synthesized and therefore is not declared in
 > `document.elements[]`; local dangling-reference checks must not reject it.
 > Using the repeated-container element id, such as `[rc/<column>]`, is still
 > incorrect.
+>
+> `scripts/probe-release-contract.rb` keeps a plain child in its main
+> create/readback and runs this binding as a separate strict expected-regression
+> check.
+
+### Dynamic text that *does* work in a card
+
+Row references are the only broken form. Verified by render, 2026-08-28, in a
+single `text` element that is a child of the repeater:
+
+| Reference | Renders |
+| --- | --- |
+| `{{Today()}}` — scope-free function | `2026-08-28` |
+| `{{[MyControl]}}` — control / parameter ref (works cross-page) | the control's value |
+| `{{Sum([Regions/Amount])}}` — aggregate over the repeater's own source | the total |
+| `{{[Regions/Region]}}` — the current row's field | `Multiple values` ✗ |
+
+Build cards from control references and aggregates today; per-row values wait on
+the upstream fix above. This is also why control-driven `conditionalFormats` is
+the working way to vary card colour.
 
 ### Layout XML
 

--- a/sigma-workbooks/reference/workflows/validate.md
+++ b/sigma-workbooks/reference/workflows/validate.md
@@ -31,6 +31,18 @@ and may retain nested `pages[].elements`.
 The verify endpoint catches representation and dependency errors without
 persistence.
 
+> **`/verify` wants the CREATE shape, even when you are validating an update.**
+> It requires the outer `name` + `folderId` alongside `document`. Handing it a
+> PUT-shaped body (`{document: {...}}` alone) fails with
+> `Expecting string at 0.name but instead got: undefined, Expecting UUID at
+> 0.folderId but instead got: undefined` — which reads like a spec error but is
+> only the envelope. To pre-validate a PUT payload, prepend a throwaway shim:
+>
+> ```bash
+> { echo "name: verify-shim"; echo "folderId: $FOLDER_ID"; cat put-body.yaml; } \
+>   > /tmp/verify-body.yaml
+> ```
+
 ## 3. Offline validation
 
 ```bash


### PR DESCRIPTION
## Why

`layout.md` told you repeated containers had to stay gated on dynamic row binding and listed their optional fields as ending at `cardStyle`. Two spec fields have since gone live and weren't documented at all, and the row-binding note — while still directionally right — omitted the part that actually bites.

Everything here was probed live against a real org on 2026-08-28 and **confirmed by a rendered PNG**, not by a readback. That distinction did the work: several of these behaviours produce a clean POST, a clean GET, and wrong pixels.

## What changed

**`layout.md` — two undocumented fields**

- `cardStyle.backgroundImage` — URL-only. An `{kind: upload, key}` handle, which a plain container's `backgroundImage` accepts, is rejected here. The URL takes `{{formula}}` dynamic text but **validates no references whatsoever**: a nonexistent column, a nonexistent element, and literal unparseable garbage all pass `/verify` *and* `POST`, then round-trip verbatim. The same reference in a text `body` hard-errors, so the two paths disagree.
- `conditionalFormats` — background colour by formula. Shared with `kind: container` and **a different shape from the table/pivot `conditionalFormats`** already in `tables.md`. `config` is required (not `style`), and **`True()` is accepted, round-trips, and silently never fires** while `1 = 1` works. Confirmed side-by-side on a plain container, so it isn't repeater-specific.

**`layout.md` — the row-binding note, corrected**

It said the correctly-derived reference is rejected. Still true. What was missing is that the *wrong* forms are the ones that pass: bare, source-element-id, and source-element-name references are all accepted, read back clean, and render `Multiple values` identically in every card. Added the per-syntax table, plus a new section for the positive case — `Today()`, control/parameter refs, and aggregates over the repeater's own source **all resolve inside a card**. Only the per-row field reference is broken, and control-driven `conditionalFormats` is the working way to vary card colour today.

**Three traps that each cost a render to find**

- `controls.md` — a `selectionMode: single` list takes a **scalar `value`**. `values: ["North"]` is silently normalised to `value: null`, the widget renders unselected, and anything reading the control evaluates empty — which presents as a data bug, not a control bug. Same trap already documented for `segmented` two sections down.
- `content-elements.md` — `body: " "` renders Sigma's error boundary in place of the element; and prose containing `{{ }}` is *evaluated*, not displayed, failing two different ways depending on whether the inner text parses.
- `validate.md` — `/verify` requires the CREATE envelope (`name` + `folderId`) even when validating an update, so a PUT-shaped body fails with an error that reads like a spec problem but is only the wrapper.

## Testing

Repo CI run locally on this branch: **17 ruby test files pass** (including `test-reference-integrity.rb` and `test-openapi-contract.rb`), plugin manifest valid, `sigma-workbooks/scripts/test-verify.rb` skipped as CI does.

Docs-only, so no `plugin.json` bump — matching #56, the most recent content PR.

## Note for review

No internal PR numbers or ticket IDs: this repo is public, has zero such references today, and the upstream repo is private so those links would 404 for any external reader. Upstream state is described behaviourally instead ("a fix is in flight but has not shipped as of 2026-08-28 — re-probe before relying on it").

🤖 Generated with [Claude Code](https://claude.com/claude-code)